### PR TITLE
#164 resolves small typo in README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Make sure you have installed all these prerequisites:
 1. Clone the repository: `git clone https://github.com/Trustroots/trustroots.git trustroots`
 2. Install dependencies by running this inside **trustroots** folder: `npm install`. Note that if you run npm with sudo, it might skip installing frontend assets. You can run it manually: `bower install`.
 3. Make sure MongoDb is running on the default port (27017)
-4. Copy config _template to develpment: `cp ./config/_secret/_template.js ./config/_secret/development.js` — add any configurations you want to keep out of version control here. Many features rely on sending emails, so add settings to the `mailer` section. See [nodemailer smtp usage](https://github.com/andris9/nodemailer-smtp-transport#usage) and note that it has pre filled settings for [some services](https://github.com/andris9/nodemailer-smtp-transport#using-well-known-services).
+4. Copy config _template to develpment: `cp ./config/secret/_template.js ./config/secret/development.js` — add any configurations you want to keep out of version control here. Many features rely on sending emails, so add settings to the `mailer` section. See [nodemailer smtp usage](https://github.com/andris9/nodemailer-smtp-transport#usage) and note that it has pre filled settings for [some services](https://github.com/andris9/nodemailer-smtp-transport#using-well-known-services).
 5. Finally run grunt default task: `grunt`
 
 Application should run on the 3000 port in development mode. Open [http://localhost:3000](http://localhost:3000) in your browser.


### PR DESCRIPTION
Basically it said `./config/_secret/` but should have been `./config/secret/` 

:tada: 