### PR TITLE
Merge configs

### DIFF
--- a/app/controllers/messages.server.controller.js
+++ b/app/controllers/messages.server.controller.js
@@ -6,6 +6,7 @@
 var mongoose = require('mongoose'),
     async = require('async'),
     _ = require('lodash'),
+    config = require('../../config/config'),
     errorHandler = require('./errors'),
     sanitizeHtml = require('sanitize-html'),
     userHandler = require('./users'),
@@ -103,7 +104,7 @@ exports.send = function(req, res) {
     } else {
 
       // If the sender has an empty description (<140) return an error
-      if (sender.description.length < 140) {
+      if (sender.description.length < config.profileMinimumLength) {
         return res.status(400).send({
           message: 'Please fill out your profile before you send messages.'
         });

--- a/app/controllers/messages.server.controller.js
+++ b/app/controllers/messages.server.controller.js
@@ -92,89 +92,110 @@ exports.send = function(req, res) {
   // take out socket instance from the app container, we'll need it later
   //var socketio = req.app.get('socketio');
 
-  var message = new Message(req.body);
-  message.userFrom = req.user;
-  message.read = false;
-  message.notified = false;
-
-  // Sanitize message contents
-  message.content = sanitizeHtml(message.content, exports.messageSanitizeOptions);
-
-  message.save(function(err) {
+  // If the sending user has an empty profile, reject the message
+  User.findById(req.user, 'description').exec(function(err, sender) {
+    // If we were unable to find the sender, return the error and stop here
     if (err) {
       return res.status(400).send({
         message: errorHandler.getErrorMessage(err)
       });
+    // Otherwise, we found the sender
     } else {
 
-      // Create/upgrade Thread handle between these two users
-      var thread = new Thread();
-      thread.updated = Date.now();
-      thread.userFrom = message.userFrom;
-      thread.userTo = message.userTo;
-      thread.message = message;
-      thread.read = false;
+      // If the sender has an empty description (<140) return an error
+      if (sender.description.length < 140) {
+        return res.status(400).send({
+          message: 'Please fill out your profile before you send messages.'
+        });
+      }
 
-      // Convert the Model instance to a simple object using Model's 'toObject' function
-      // to prevent weirdness like infinite looping...
-      var upsertData = thread.toObject();
+      var message = new Message(req.body);
+      message.userFrom = req.user;
+      message.read = false;
+      message.notified = false;
 
-      // Delete the _id property, otherwise Mongo will return a "Mod on _id not allowed" error
-      delete upsertData._id;
+      // Sanitize message contents
+      message.content = sanitizeHtml(message.content, exports.messageSanitizeOptions);
 
-      // Do the upsert, which works like this: If no Thread document exists with
-      // _id = thread.id, then create a new doc using upsertData.
-      // Otherwise, update the existing doc with upsertData
-      // @link http://stackoverflow.com/a/7855281
-      Thread.update({
-        // User id's can be either way around in old thread handle, so we gotta test for both situations
-        $or: [
-          {
-            userTo: upsertData.userTo,
-            userFrom: upsertData.userFrom
-          },
-          {
-            userTo: upsertData.userFrom,
-            userFrom: upsertData.userTo
-          }
-        ]
-      },
-      upsertData,
-      { upsert: true },
-      function(err) {
+      message.save(function(err) {
         if (err) {
           return res.status(400).send({
             message: errorHandler.getErrorMessage(err)
           });
-        } /*else {
-          // Emit an event for all connected clients about new thread
-          socketio.sockets.emit('message.thread', thread);
-        }*/
+        } else {
+
+          // Create/upgrade Thread handle between these two users
+          var thread = new Thread();
+          thread.updated = Date.now();
+          thread.userFrom = message.userFrom;
+          thread.userTo = message.userTo;
+          thread.message = message;
+          thread.read = false;
+
+          // Convert the Model instance to a simple object using Model's 'toObject' function
+          // to prevent weirdness like infinite looping...
+          var upsertData = thread.toObject();
+
+          // Delete the _id property, otherwise Mongo will return a "Mod on _id not allowed" error
+          delete upsertData._id;
+
+          // Do the upsert, which works like this: If no Thread document exists with
+          // _id = thread.id, then create a new doc using upsertData.
+          // Otherwise, update the existing doc with upsertData
+          // @link http://stackoverflow.com/a/7855281
+          Thread.update({
+            // User id's can be either way around in old thread handle, so we gotta test for both situations
+            $or: [
+              {
+                userTo: upsertData.userTo,
+                userFrom: upsertData.userFrom
+              },
+              {
+                userTo: upsertData.userFrom,
+                userFrom: upsertData.userTo
+              }
+            ]
+          },
+          upsertData,
+          { upsert: true },
+          function(err) {
+            if (err) {
+              return res.status(400).send({
+                message: errorHandler.getErrorMessage(err)
+              });
+            } /*else {
+              // Emit an event for all connected clients about new thread
+              socketio.sockets.emit('message.thread', thread);
+            }*/
+          });
+
+          // We'll need some info about related users, populate some fields
+          message
+            .populate('userFrom', userHandler.userMiniProfileFields)
+            .populate({
+              path: 'userTo',
+              select: userHandler.userMiniProfileFields
+            }, function(err, message) {
+              if (err) {
+                return res.status(400).send({
+                  message: errorHandler.getErrorMessage(err)
+                });
+              } else {
+
+                // Emit an event for all connected clients about new message
+                //socketio.sockets.emit( 'message.sent', message );
+
+                // Finally res
+                res.json(message);
+              }
+            });
+
+        }
       });
 
-      // We'll need some info about related users, populate some fields
-      message
-        .populate('userFrom', userHandler.userMiniProfileFields)
-        .populate({
-          path: 'userTo',
-          select: userHandler.userMiniProfileFields
-        }, function(err, message) {
-          if (err) {
-            return res.status(400).send({
-              message: errorHandler.getErrorMessage(err)
-            });
-          } else {
-
-            // Emit an event for all connected clients about new message
-            //socketio.sockets.emit( 'message.sent', message );
-
-            // Finally res
-            res.json(message);
-          }
-        });
-
-    }
+    } // if User.findById else
   });
+
 };
 
 

--- a/config/config.js
+++ b/config/config.js
@@ -9,7 +9,7 @@ var _ = require('lodash'),
 /**
  * Load app configurations
  */
-module.exports = _.extend(
+module.exports = _.merge(
   require('./env/all'),
   require('./env/' + process.env.NODE_ENV),
   require('./secret/' + process.env.NODE_ENV) || {}

--- a/config/env/all.js
+++ b/config/env/all.js
@@ -21,5 +21,6 @@ module.exports = {
 	https: process.env.HTTPS || false,
 	templateEngine: 'swig',
 	sessionSecret: process.env.SESSION_SECRET || 'MEAN',
-	sessionCollection: 'sessions'
+	sessionCollection: 'sessions',
+	profileMinimumLength: 140 // Require User.profile.description to be >140 chars to send messages
 };


### PR DESCRIPTION
This change recursively overwrites configs. However, this may have unintended consequences if the current code relies on the fact that subsequent configs overwrite the entire objects of previous ones. For example, with the `mailer`. If the `all.js` config has `mailer: { service: 'gmail', auth: {user: 'user', pass: 'pass'}}` and then a later config has `mailer: { host: 'localhost' }` then the resulting config will now be `mailer: { service: 'gmail', auth: {user: 'user', pass: 'pass'}, host: 'localhost'}` while previously the whole `mailer` object would have been overwritten.

In the long term I think this change makes a lot of sense, and is much more intuitive for new developers. However, it does add some complication.

The pull request also includes the `block-empty-profiles` branch (which should be merged first), or this branch will need to be rebased (is that the right term?) from master.