### PR TITLE
Add coffeescript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ node_modules/
 .bower-*/
 .grunt
 .vagrant
+*.coffee.js
 
 # App
 public/lib

--- a/config/init.js
+++ b/config/init.js
@@ -34,7 +34,11 @@ module.exports = function() {
   /**
    * Add our server node extensions
    */
+  require.extensions['.coffee.js'] = require.extensions['.js'];
   require.extensions['.server.controller.js'] = require.extensions['.js'];
+  require.extensions['.server.controller.coffee.js'] = require.extensions['.js'];
   require.extensions['.server.model.js'] = require.extensions['.js'];
+  require.extensions['.server.model..coffee.js'] = require.extensions['.js'];
   require.extensions['.server.routes.js'] = require.extensions['.js'];
+  require.extensions['.server.routes.coffee.js'] = require.extensions['.js'];
 };

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -4,7 +4,8 @@ module.exports = function(grunt) {
   // Unified Watch Object
   var watchFiles = {
     serverViews: ['app/views/**/*.*'],
-    serverJS: ['gruntfile.js', 'server.js', 'config/**/*.js', 'app/**/*.js'],
+    serverJS: ['gruntfile.js', 'server.js', 'config/**/*.js', 'app/**/*[!.coffee].js'],
+    serverCoffee: ['app/**/*.coffee'],
     clientViews: ['public/modules/**/views/**/*.html'],
     clientJS: ['public/js/*.js', 'public/modules/**/*.js'],
     clientCSS: ['public/dist/application.css'],
@@ -28,6 +29,10 @@ module.exports = function(grunt) {
         options: {
           livereload: true
         }
+      },
+      serverCoffee: {
+        files: watchFiles.serverCoffee,
+        tasks: ['coffee:compile']
       },
       clientViews: {
         files: watchFiles.clientViews,
@@ -63,6 +68,15 @@ module.exports = function(grunt) {
         options: {
           jshintrc: true
         }
+      }
+    },
+    coffee: {
+      compile: {
+        files: grunt.file.expandMapping('app/**/*.coffee', '', {
+          rename: function(destBase, destPath, options) {
+            return destBase + destPath.replace(/\.coffee$/, '.coffee.js');
+          }
+        })
       }
     },
     less: {
@@ -122,7 +136,7 @@ module.exports = function(grunt) {
         options: {
           nodeArgs: ['--debug'],
           ext: 'js,html',
-          watch: watchFiles.serverViews.concat(watchFiles.serverJS)
+          watch: watchFiles.serverViews.concat(watchFiles.serverJS, watchFiles.serverCoffee)
         }
       }
     },
@@ -193,7 +207,7 @@ module.exports = function(grunt) {
   });
 
   // Default development task(s).
-  grunt.registerTask('default', ['loadConfig', 'less:development', 'concat:css', 'debug']);
+  grunt.registerTask('default', ['loadConfig', 'coffee', 'less:development', 'concat:css', 'debug']);
 
   // Default production task(s).
   grunt.registerTask('production', ['env:production', 'loadConfig', 'less:production', 'concat:css', 'ngAnnotate', 'uglify', 'concurrent:default']);

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -79,6 +79,9 @@ module.exports = function(grunt) {
         })
       }
     },
+    coffeelint: {
+      app: ['app/**/*.coffee']
+    },
     less: {
       development: {
         options: {
@@ -216,7 +219,7 @@ module.exports = function(grunt) {
   grunt.registerTask('debug', ['lint', 'concurrent:debug']);
 
   // Lint task(s).
-  grunt.registerTask('lint', ['jshint']);//, 'csslint'
+  grunt.registerTask('lint', ['jshint', 'coffeelint']);//, 'csslint'
 
   // Build task(s).
   grunt.registerTask('build', ['lint', 'loadConfig', 'less:production', 'concat:css', 'ngAnnotate', 'uglify']);

--- a/package.json
+++ b/package.json
@@ -56,7 +56,9 @@
     "swig": "~1.4.2"
   },
   "devDependencies": {
+    "coffeelint": "^1.9.3",
     "faker": "~2.1.1",
+    "grunt-coffeelint": "0.0.13",
     "grunt-concurrent": "~1.0.0",
     "grunt-contrib-coffee": "^0.13.0",
     "grunt-contrib-concat": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   "devDependencies": {
     "faker": "~2.1.1",
     "grunt-concurrent": "~1.0.0",
+    "grunt-contrib-coffee": "^0.13.0",
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-csslint": "^0.4.0",
     "grunt-contrib-cssmin": "~0.12.2",


### PR DESCRIPTION
This adds coffeescript from `app/**/*.coffee` files. They are compiled into `.coffee.js` files (which are ignored by git) and linted. However, they should probably be cleaned up by grunt. They should also probably be compiled into a single location and combined, but that will mess with the way some things are included.

Not sure if this should be merged yet or not...