### PR TITLE
Fixed bug #214  canceling edit profile

### DIFF
--- a/public/modules/users/controllers/profile.edit.client.controller.js
+++ b/public/modules/users/controllers/profile.edit.client.controller.js
@@ -11,7 +11,8 @@ angular.module('users').controller('EditProfileController', ['$scope', '$modal',
     // If user is not signed in then redirect to login
     if (!Authentication.user) $state.go('signin');
 
-    $scope.user = Authentication.user;
+    //copy tue user to make a temporary buffer for changes (fix #214)
+    $scope.user = new Users(Authentication.user);
     $scope.profile = false;
 
     /*


### PR DESCRIPTION
I guess having a copy of the user profile for editing makes sense, because it is not "real" until it is committed.
Just let me know if i'm being naive or stupid here ;)