### PR TITLE
fix profile header overlapping navigation dropdown

### DIFF
--- a/modules/users/client/less/profile.less
+++ b/modules/users/client/less/profile.less
@@ -6,6 +6,7 @@
   border-radius: 0;
   &.navbar-fixed-top {
     top: @navbar-height;
+    z-index: 1029;
   }
   .container {
     width: 100%;


### PR DESCRIPTION
@simison not sure if this is the correct way to do this or if there’s a z-index variable. :\

However the point is that on mobile, when opening the navigation menu it gets overlapped by the yellow `Send message | Add contact` line. Both are `z-index: 1030` cause of the `.navbar-fixed-top` class so here a manual fix.

(Btw, why are »design« and »UI/UX« separate labels? Bit complicated imo. ;)