### PR TITLE
Add POST /api/auth/resend-confirmation endpoint

### DIFF
--- a/modules/users/client/controllers/profile-edit-account.client.controller.js
+++ b/modules/users/client/controllers/profile-edit-account.client.controller.js
@@ -40,7 +40,7 @@
                           'If you don\'t see this email in your inbox within 15 minutes, look for it in your junk mail folder. If you find it there, please mark it as "Not Junk".';
         vm.user = Authentication.user = response;
       }, function(response) {
-        vm.emailError = response.data.message || 'Something went wrong.';
+        vm.emailError = (response.data && response.data.message) || 'Something went wrong.';
       });
     }
 

--- a/modules/users/client/controllers/profile-edit-account.client.controller.js
+++ b/modules/users/client/controllers/profile-edit-account.client.controller.js
@@ -50,8 +50,19 @@
     function resendUserEmailConfirm($event) {
       if ($event) $event.preventDefault();
       if (vm.user.emailTemporary) {
-        vm.user.email = vm.user.emailTemporary;
-        updateUserEmail();
+        $http.post('/api/auth/resend-confirmation')
+          .success(function() {
+            messageCenterService.add('success', 'Confirmation email resent.');
+          })
+          .error(function(response) {
+            var errorMessage;
+            if (response) {
+              errorMessage = 'Error: ' + (response.data.message || 'Something went wrong.');
+            } else {
+              errorMessage = 'Something went wrong.';
+            }
+            messageCenterService.add('danger', errorMessage);
+          });
       }
     }
 

--- a/modules/users/client/controllers/profile-edit-account.client.controller.js
+++ b/modules/users/client/controllers/profile-edit-account.client.controller.js
@@ -57,7 +57,7 @@
           .error(function(response) {
             var errorMessage;
             if (response) {
-              errorMessage = 'Error: ' + (response.data.message || 'Something went wrong.');
+              errorMessage = 'Error: ' + (response.message || 'Something went wrong.');
             } else {
               errorMessage = 'Something went wrong.';
             }

--- a/modules/users/client/controllers/profile-edit-account.client.controller.js
+++ b/modules/users/client/controllers/profile-edit-account.client.controller.js
@@ -51,13 +51,13 @@
       if ($event) $event.preventDefault();
       if (vm.user.emailTemporary) {
         $http.post('/api/auth/resend-confirmation')
-          .success(function() {
+          .then(function() {
             messageCenterService.add('success', 'Confirmation email resent.');
           })
-          .error(function(response) {
+          .catch(function(response) {
             var errorMessage;
             if (response) {
-              errorMessage = 'Error: ' + (response.message || 'Something went wrong.');
+              errorMessage = 'Error: ' + ((response.data && response.data.message) || 'Something went wrong.');
             } else {
               errorMessage = 'Something went wrong.';
             }

--- a/modules/users/server/routes/auth.server.routes.js
+++ b/modules/users/server/routes/auth.server.routes.js
@@ -15,6 +15,10 @@ module.exports = function(app) {
     .get(users.validateEmailToken)
     .post(users.confirmEmail);
 
+  // Resend email confirmation
+  app.route('/api/auth/resend-confirmation')
+    .post(users.resendConfirmation);
+
   // Setting up the users password api
   app.route('/api/auth/forgot').post(users.forgot);
   app.route('/api/auth/reset/:token')

--- a/modules/users/tests/client/profile-edit-account.client.controller.tests.js
+++ b/modules/users/tests/client/profile-edit-account.client.controller.tests.js
@@ -71,6 +71,18 @@
           );
         });
 
+        it('can show an custom error message during failure', function() {
+          $httpBackend.expect('POST', '/api/auth/resend-confirmation').respond(400, {
+            message: 'my customer error'
+          });
+          ProfileEditAccountController.resendUserEmailConfirm();
+          $httpBackend.flush();
+          expect(messageCenterService.add).toHaveBeenCalledWith(
+            'danger',
+            'Error: my customer error'
+          );
+        });
+
       });
 
     });

--- a/modules/users/tests/client/profile-edit-account.client.controller.tests.js
+++ b/modules/users/tests/client/profile-edit-account.client.controller.tests.js
@@ -1,0 +1,80 @@
+(function() {
+  'use strict';
+
+  describe('ProfileEditAccountController', function() {
+
+    var ProfileEditAccountController,
+        $httpBackend,
+        messageCenterService,
+        Authentication;
+
+    var user = {
+      _id: 'user',
+      displayName: 'User',
+      emailTemporary: 'foo@foo.com'
+    };
+
+    // Load the main application module
+    beforeEach(module(AppConfig.appModuleName));
+
+    beforeEach(inject(function(
+      $templateCache,
+      _$httpBackend_,
+      _Authentication_,
+      _messageCenterService_
+    ) {
+      $httpBackend = _$httpBackend_;
+      Authentication = _Authentication_;
+
+      messageCenterService = _messageCenterService_;
+      spyOn(messageCenterService, 'add').and.callThrough();
+
+      $templateCache.put('/modules/pages/views/home.client.view.html', '');
+    }));
+
+    afterEach(function() {
+      $httpBackend.verifyNoOutstandingExpectation();
+      $httpBackend.verifyNoOutstandingRequest();
+    });
+
+    describe('Logged in user', function() {
+
+      beforeEach(function(done) {
+        inject(function($controller) {
+          Authentication.user = user;
+          ProfileEditAccountController = $controller('ProfileEditAccountController', {
+            messageCenterService: messageCenterService
+          });
+          done();
+        });
+      });
+
+      describe('resend email confirmation', function() {
+
+        it('can resend email', function() {
+          $httpBackend.expect('POST', '/api/auth/resend-confirmation').respond(200);
+          ProfileEditAccountController.resendUserEmailConfirm();
+          $httpBackend.flush();
+          expect(messageCenterService.add).toHaveBeenCalledWith(
+            'success',
+            'Confirmation email resent.'
+          );
+        });
+
+        it('can show an error message during failure', function() {
+          $httpBackend.expect('POST', '/api/auth/resend-confirmation').respond(500);
+          ProfileEditAccountController.resendUserEmailConfirm();
+          $httpBackend.flush();
+          expect(messageCenterService.add).toHaveBeenCalledWith(
+            'danger',
+            'Something went wrong.'
+          );
+        });
+
+      });
+
+    });
+
+  });
+
+}());

--- a/modules/users/tests/client/profile-edit-account.client.controller.tests.js
+++ b/modules/users/tests/client/profile-edit-account.client.controller.tests.js
@@ -49,6 +49,42 @@
         });
       });
 
+      describe('change email address', function() {
+
+        it('can update email address', function() {
+          ProfileEditAccountController.user.emailTemporary = 'new@email.com';
+          var expectedPutData = {
+            _id: 'user',
+            displayName: 'User',
+            emailTemporary: 'new@email.com'
+          };
+          $httpBackend.expect('PUT', '/api/users', expectedPutData).respond(200);
+          ProfileEditAccountController.updateUserEmail();
+          $httpBackend.flush();
+          expect(messageCenterService.add).toHaveBeenCalledWith(
+            'success',
+            'Check your email for further instructions.'
+          );
+        });
+
+        it('can show an error message during failure', function() {
+          ProfileEditAccountController.user.emailTemporary = 'new@email.com';
+          $httpBackend.expect('PUT', '/api/users').respond(500);
+          ProfileEditAccountController.updateUserEmail();
+          $httpBackend.flush();
+          expect(ProfileEditAccountController.emailError).toEqual('Something went wrong.');
+        });
+
+        it('can show a custom error message during failure', function() {
+          ProfileEditAccountController.user.emailTemporary = 'new@email.com';
+          $httpBackend.expect('PUT', '/api/users').respond(400, { message: 'custom error' });
+          ProfileEditAccountController.updateUserEmail();
+          $httpBackend.flush();
+          expect(ProfileEditAccountController.emailError).toEqual('custom error');
+        });
+
+      });
+
       describe('resend email confirmation', function() {
 
         it('can resend email', function() {

--- a/modules/users/tests/client/profile-edit-account.client.controller.tests.js
+++ b/modules/users/tests/client/profile-edit-account.client.controller.tests.js
@@ -103,19 +103,19 @@
           $httpBackend.flush();
           expect(messageCenterService.add).toHaveBeenCalledWith(
             'danger',
-            'Something went wrong.'
+            'Error: Something went wrong.'
           );
         });
 
         it('can show an custom error message during failure', function() {
           $httpBackend.expect('POST', '/api/auth/resend-confirmation').respond(400, {
-            message: 'my customer error'
+            message: 'my custom error'
           });
           ProfileEditAccountController.resendUserEmailConfirm();
           $httpBackend.flush();
           expect(messageCenterService.add).toHaveBeenCalledWith(
             'danger',
-            'Error: my customer error'
+            'Error: my custom error'
           );
         });
 

--- a/modules/users/tests/server/user.server.routes.tests.js
+++ b/modules/users/tests/server/user.server.routes.tests.js
@@ -50,6 +50,7 @@ describe('User CRUD tests', function () {
       lastName: 'Name',
       displayName: 'Full Name',
       email: 'test@test.com',
+      emailTemporary: 'test@test.com', // unconfirmed users have this set
       emailToken: 'initial email token',
       username: credentials.username.toLowerCase(),
       displayUsername: credentials.username,


### PR DESCRIPTION
Ok, should all work now.

* added under `/api/auth` not `/api/users` as I think it relates more to auth concerns
* it sends the `signup` email template but with the _campaign_ field marked as `resend-confirmation`. I don't know if you need to configure those somewhere

There is quite a lot of non-DRY code in this area, but I kept it simple as this is another concern.