### PR TITLE
Refactoring server application service to enable modularity

### DIFF
--- a/config/lib/app.js
+++ b/config/lib/app.js
@@ -1,0 +1,66 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+var config = require('../config'),
+    mongoose = require('./mongoose'),
+    express = require('./express'),
+    chalk = require('chalk');
+
+// Initialize Models
+mongoose.loadModels();
+
+module.exports.init = function init(callback) {
+
+  // Debug Node.js C/C++ native code modules on dev mode
+  // @link https://www.npmjs.com/package/segfault-handler
+  if (process.env.NODE_ENV === 'development') {
+    var SegfaultHandler = require('segfault-handler');
+    SegfaultHandler.registerHandler('segfault.log');
+    console.log('Logging possible segfault errors to ./segfault.log');
+  }
+
+  mongoose.connect(function (db) {
+    // Initialize express
+    var app = express.init(db);
+    if (callback) callback(app, db, config);
+  });
+};
+
+module.exports.start = function start(callback) {
+
+  var _this = this;
+
+  _this.init(function (app, db, config) {
+
+    // Start the app by listening on <port> at <host>
+    app.listen(config.port, config.host, function () {
+
+      // Check in case mailer config is still set to default values (a common problem)
+      if (config.mailer.service && config.mailer.service === 'MAILER_SERVICE_PROVIDER') {
+        console.warn(chalk.red('Remember to setup mailer from ./config/env/local.js - some features won\'t work without it.'));
+      }
+
+      // Logging initialization
+      console.log(chalk.white('--'));
+      console.log(chalk.green(new Date()));
+      console.log(chalk.green('Environment:\t\t' + process.env.NODE_ENV));
+      console.log(chalk.green('Database:\t\t' + config.db.uri));
+      console.log(chalk.green('HTTPS:\t\t\t' + (config.https ? 'on' : 'off')));
+      console.log(chalk.green('Port:\t\t\t' + config.port));
+      console.log(chalk.green('Image processor:\t' + config.imageProcessor));
+      console.log(chalk.green('Phusion Passenger:\t' + (typeof(PhusionPassenger) !== 'undefined' ? 'on' : 'off')));
+
+      // Reset console color
+      console.log(chalk.white('--'));
+      console.log('');
+      console.log(chalk.white('Trustroots is up and running now.'));
+      console.log('');
+
+      if (callback) callback(app, db, config);
+    });
+
+  });
+
+};

--- a/config/lib/mongoose.js
+++ b/config/lib/mongoose.js
@@ -9,16 +9,22 @@ var config = require('../config'),
     mongoose = require('mongoose');
 
 // Load the mongoose models
-module.exports.loadModels = function() {
+module.exports.loadModels = function(callback) {
   // Globbing model files
   config.files.server.models.forEach(function(modelPath) {
     require(path.resolve(modelPath));
   });
+
+  if (callback) callback();
 };
 
 // Initialize Mongoose
-module.exports.connect = function(cb) {
+module.exports.connect = function(callback) {
   var _this = this;
+
+  // Use native promises
+  // You could use any ES6 promise constructor here, e.g. `bluebird`
+  mongoose.Promise = global.Promise;
 
   var db = mongoose.connect(config.db.uri, function (err) {
     // Log Error
@@ -33,14 +39,14 @@ module.exports.connect = function(cb) {
       _this.loadModels();
 
       // Call callback FN
-      if (cb) cb(db);
+      if (callback) callback(db);
     }
   });
 };
 
-module.exports.disconnect = function(cb) {
+module.exports.disconnect = function(callback) {
   mongoose.disconnect(function(err) {
     console.info(chalk.yellow('Disconnected from MongoDB.'));
-    cb(err);
+    callback(err);
   });
 };

--- a/server.js
+++ b/server.js
@@ -5,48 +5,6 @@
  * App's main entry file
  */
 
-// Debug Node.js C/C++ native code modules on dev mode
-// @link https://www.npmjs.com/package/segfault-handler
-if (process.env.NODE_ENV === 'development') {
-  var SegfaultHandler = require('segfault-handler');
-  SegfaultHandler.registerHandler('segfault.log');
-  console.log('Logging possible segfault errors to ./segfault.log');
-}
+var app = require('./config/lib/app');
 
-// Dependencies
-var config = require('./config/config'),
-    mongoose = require('./config/lib/mongoose'),
-    express = require('./config/lib/express'),
-    chalk = require('chalk');
-
-// Initialize mongoose
-mongoose.connect(function(db) {
-
-  // Initialize express
-  var app = express.init(db);
-
-  // Start the app by listening on <port>
-  app.listen(config.port);
-
-  // Check in case mailer config is still set to default values (a common problem)
-  if (config.mailer.service && config.mailer.service === 'MAILER_SERVICE_PROVIDER') {
-    console.warn(chalk.red('Remember to setup mailer from ./config/env/local.js - some features won\'t work without it.'));
-  }
-
-  // Logging initialization
-  console.log(chalk.white('--'));
-  console.log(chalk.green(new Date()));
-  console.log(chalk.green('Environment:\t\t' + process.env.NODE_ENV));
-  console.log(chalk.green('Database:\t\t' + config.db.uri));
-  console.log(chalk.green('HTTPS:\t\t\t' + (config.https ? 'on' : 'off')));
-  console.log(chalk.green('Port:\t\t\t' + config.port));
-  console.log(chalk.green('Image processor:\t' + config.imageProcessor));
-  console.log(chalk.green('Phusion Passenger:\t' + (typeof(PhusionPassenger) !== 'undefined' ? 'on' : 'off')));
-
-  // Reset console color
-  console.log(chalk.white('--'));
-  console.log('');
-  console.log(chalk.white('Trustroots is up and running now.'));
-  console.log('');
-
-});
+app.start();


### PR DESCRIPTION
- Use callbacks
- Provide app, db, config variables outside of server.js
- Pass Mongoose NodeJS ES6 promises instead of internal, deprecated
mpromise, fixes this warning:
```
Mongoose: mpromise (mongoose's default promise library) is deprecated, plug in your own promise library instead: http://mongoosejs.com/docs/promises.html
```

From most parts work from
https://github.com/meanjs/mean/commit/edb62344bc4af3cb28c3469dc7463c13a2
fc76a1 — it'll be easier to keep up with their work when our codebase is more similarly structured.