### PR TITLE
Add eslint-angular rules

### DIFF
--- a/.eslintrc-angular.js
+++ b/.eslintrc-angular.js
@@ -1,0 +1,45 @@
+module.exports = {
+  plugins: [
+    'angular'
+  ],
+  rules: {
+    'angular/component-limit': 0,
+    'angular/controller-as-route': 1,
+    'angular/controller-as-vm': 1,
+    'angular/controller-as': 1,
+    'angular/deferred': 1,
+    'angular/di-unused': 2,
+    'angular/directive-restrict': 0,
+    'angular/empty-controller': 2,
+    'angular/no-controller': 0,
+    'angular/no-inline-template': 0,
+    'angular/no-run-logic': 0,
+    'angular/no-services': 0,
+    'angular/on-watch': 0,
+    'angular/prefer-component': 0,
+    'angular/no-cookiestore': 2,
+    'angular/no-directive-replace': 0,
+    'angular/no-http-callback': 1,
+    'angular/angularelement': 2,
+    'angular/definedundefined': 2,
+    'angular/document-service': 2,
+    'angular/interval-service': 2,
+    'angular/json-functions': 2,
+    'angular/log': 1,
+    'angular/timeout-service': 2,
+    'angular/typecheck-array': 2,
+    'angular/typecheck-date': 2,
+    'angular/typecheck-function': 2,
+    'angular/typecheck-number': 2,
+    'angular/typecheck-object': 2,
+    'angular/typecheck-string': 2,
+    'angular/window-service': 2
+  },
+  env: {
+    browser: true,
+    jquery: true
+  },
+  settings: {
+    angular: 1
+  }
+};

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -104,17 +104,17 @@ gulp.task('watch', function() {
 
   // Add watch rules
   gulp.watch(defaultAssets.server.views).on('change', plugins.livereload.changed);
-  gulp.watch(defaultAssets.server.allJS, ['eslint']).on('change', plugins.livereload.changed);
+  gulp.watch(defaultAssets.server.allJS, ['lint']).on('change', plugins.livereload.changed);
   gulp.watch(defaultAssets.server.fontelloConfig, ['fontello']);
   gulp.watch(defaultAssets.client.less, ['clean:css', 'styles']);
 
   if (process.env.NODE_ENV === 'production') {
-    gulp.watch(defaultAssets.client.js, ['eslint', 'clean:js', 'scripts']);
-    gulp.watch(defaultAssets.server.gulpConfig, ['eslint']);
+    gulp.watch(defaultAssets.client.js, ['lint', 'clean:js', 'scripts']);
+    gulp.watch(defaultAssets.server.gulpConfig, ['lint']);
     gulp.watch(defaultAssets.client.views, ['clean:js', 'scripts']).on('change', plugins.livereload.changed);
   } else {
-    gulp.watch(defaultAssets.client.js, ['eslint']).on('change', plugins.livereload.changed);
-    gulp.watch(defaultAssets.server.gulpConfig, ['eslint']);
+    gulp.watch(defaultAssets.client.js, ['lint']).on('change', plugins.livereload.changed);
+    gulp.watch(defaultAssets.server.gulpConfig, ['lint']);
     gulp.watch(defaultAssets.client.views).on('change', plugins.livereload.changed);
   }
 });
@@ -157,6 +157,18 @@ gulp.task('eslint', function() {
 
   return gulp.src(assets)
     .pipe(plugins.eslint())
+    .pipe(plugins.eslint.format())
+    // To have the process exit with an error code (1) on
+    // lint error, return the stream and pipe to failAfterError last.
+    .pipe(plugins.eslint.failAfterError());
+});
+
+// ESLint JS linting task for Angular files
+gulp.task('eslint-angular', function() {
+  return gulp.src(defaultAssets.client.js)
+    .pipe(plugins.eslint({
+      configFile: '.eslintrc-angular.js'
+    }))
     .pipe(plugins.eslint.format())
     // To have the process exit with an error code (1) on
     // lint error, return the stream and pipe to failAfterError last.
@@ -343,14 +355,19 @@ gulp.task('karma:watch', function(done) {
   }, done).start();
 });
 
+// Run the project in development mode
+gulp.task('lint', function(done) {
+  runSequence(['eslint', 'eslint-angular'], done);
+});
+
 // Build assets for development mode
 gulp.task('build:dev', function(done) {
-  runSequence('env:dev', 'bower', 'eslint', 'clean', ['uibTemplatecache', 'styles'], done);
+  runSequence('env:dev', 'bower', 'lint', 'clean', ['uibTemplatecache', 'styles'], done);
 });
 
 // Build assets for production mode
 gulp.task('build:prod', function(done) {
-  runSequence('env:prod', 'bower', 'eslint', 'clean', ['styles', 'scripts'], done);
+  runSequence('env:prod', 'bower', 'lint', 'clean', ['styles', 'scripts'], done);
 });
 
 // Clean dist css and js files
@@ -360,11 +377,11 @@ gulp.task('clean', function(done) {
 
 // Run the project tests
 gulp.task('test', function(done) {
-  runSequence('env:test', 'copyConfig', 'makeUploadsDir', 'eslint', ['karma', 'mocha'], done);
+  runSequence('env:test', 'copyConfig', 'makeUploadsDir', 'lint', ['karma', 'mocha'], done);
 });
 
 gulp.task('test:server', function(done) {
-  runSequence('env:test', 'copyConfig', 'makeUploadsDir', 'eslint', 'mocha', done);
+  runSequence('env:test', 'copyConfig', 'makeUploadsDir', 'lint', 'mocha', done);
 });
 
 // Watch all server files for changes & run server tests (test:server) task on changes
@@ -373,11 +390,11 @@ gulp.task('test:server:watch', function(done) {
 });
 
 gulp.task('test:client', function(done) {
-  runSequence('env:test', 'copyConfig', 'makeUploadsDir', 'eslint', 'karma', done);
+  runSequence('env:test', 'copyConfig', 'makeUploadsDir', 'lint', 'karma', done);
 });
 
 gulp.task('test:client:watch', function(done) {
-  runSequence('env:test', 'copyConfig', 'makeUploadsDir', 'eslint', 'karma:watch', done);
+  runSequence('env:test', 'copyConfig', 'makeUploadsDir', 'lint', 'karma:watch', done);
 });
 
 // Run the project in development mode

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -355,7 +355,7 @@ gulp.task('karma:watch', function(done) {
   }, done).start();
 });
 
-// Run the project in development mode
+// Analyse code for potential errors
 gulp.task('lint', function(done) {
   runSequence(['eslint', 'eslint-angular'], done);
 });

--- a/modules/contacts/client/controllers/confirm-contact.client.controller.js
+++ b/modules/contacts/client/controllers/confirm-contact.client.controller.js
@@ -6,7 +6,7 @@
     .controller('ContactConfirmController', ContactConfirmController);
 
   /* @ngInject */
-  function ContactConfirmController($state, $stateParams, Authentication, Contact, contact) {
+  function ContactConfirmController($stateParams, Authentication, contact) {
 
     // ViewModel
     var vm = this;

--- a/modules/contacts/client/controllers/remove-contact.client.controller.js
+++ b/modules/contacts/client/controllers/remove-contact.client.controller.js
@@ -6,7 +6,7 @@
     .controller('ContactRemoveController', ContactRemoveController);
 
   /* @ngInject */
-  function ContactRemoveController($scope, $rootScope, $uibModalInstance, $timeout, messageCenterService, Contact, Authentication) {
+  function ContactRemoveController($scope, $rootScope, $uibModalInstance, messageCenterService, Contact, Authentication) {
 
     var contactToRemove = $scope.contactToRemove;
 

--- a/modules/core/client/app/config.js
+++ b/modules/core/client/app/config.js
@@ -4,6 +4,7 @@
 // eslint-disable-next-line no-unused-vars
 var AppConfig = (function () {
   // Init module configuration options
+  // eslint-disable-next-line angular/window-service
   var appEnv = window.env || 'production';
   var appModuleName = 'trustroots';
   var appModuleVendorDependencies = [

--- a/modules/core/client/app/init.js
+++ b/modules/core/client/app/init.js
@@ -54,6 +54,7 @@
   // Then define the init function for starting up the application
   angular.element(document).ready(function() {
     // Fixing facebook bug with redirect
+    // eslint-disable-next-line angular/window-service
     if (window.location.hash === '#_=_') window.location.hash = '';
 
     // Then init the app

--- a/modules/core/client/directives/tr-board-credits.client.directive.js
+++ b/modules/core/client/directives/tr-board-credits.client.directive.js
@@ -11,7 +11,6 @@
   /* @ngInject */
   function trBoardCreditsDirective() {
     return {
-      replace: true,
       template:
         '<span class="boards-credits" ng-if="app.photoCreditsCount">' +
         '  <span ng-if="app.photoCreditsCount === 1">Photo by</span>' +

--- a/modules/core/client/directives/tr-editor.client.directive.js
+++ b/modules/core/client/directives/tr-editor.client.directive.js
@@ -57,10 +57,10 @@
     .directive('trEditor', trEditorDirective);
 
   /* @ngInject */
-  function trEditorDirective($parse) {
+  function trEditorDirective($parse, $document) {
 
     function toInnerText(value) {
-      var tempEl = document.createElement('div'),
+      var tempEl = $document.createElement('div'),
           text;
       tempEl.innerHTML = value;
       text = tempEl.textContent || '';

--- a/modules/core/client/services/maplayers.client.service.js
+++ b/modules/core/client/services/maplayers.client.service.js
@@ -14,7 +14,7 @@
     .factory('MapLayersFactory', MapLayersFactory);
 
   /* @ngInject */
-  function MapLayersFactory($log, SettingsFactory, LocationService) {
+  function MapLayersFactory(SettingsFactory, LocationService) {
 
     var appSettings = SettingsFactory.get();
 

--- a/modules/messages/client/controllers/thread.client.controller.js
+++ b/modules/messages/client/controllers/thread.client.controller.js
@@ -15,7 +15,7 @@
     .controller('MessagesThreadController', MessagesThreadController);
 
   /* @ngInject */
-  function MessagesThreadController($rootScope, $scope, $stateParams, $state, $document, $window, $anchorScroll, $timeout, $filter, $analytics, Authentication, Messages, MessagesRead, messageCenterService, locker, appSettings, userTo) {
+  function MessagesThreadController($rootScope, $scope, $stateParams, $state, $timeout, $filter, $analytics, Authentication, Messages, MessagesRead, messageCenterService, locker, userTo) {
 
     // Go back to inbox on these cases
     // - No recepient defined

--- a/modules/messages/client/directives/unread-count.client.directive.js
+++ b/modules/messages/client/directives/unread-count.client.directive.js
@@ -15,7 +15,7 @@
     .directive('messagesUnreadCount', messagesUnreadCountDirective);
 
   /* @ngInject */
-  function messagesUnreadCountDirective($interval, MessagesCount, PollMessagesCount, Authentication) {
+  function messagesUnreadCountDirective(PollMessagesCount, Authentication) {
 
     var directive = {
       restrict: 'A',

--- a/modules/offers/client/controllers/offers-edit.client.controller.js
+++ b/modules/offers/client/controllers/offers-edit.client.controller.js
@@ -6,7 +6,7 @@
     .controller('OffersEditController', OffersEditController);
 
   /* @ngInject */
-  function OffersEditController($http, $timeout, $state, $stateParams, $location, leafletBoundsHelpers, OffersService, Authentication, messageCenterService, MapLayersFactory, offer, appSettings, LocationService) {
+  function OffersEditController($http, $state, $stateParams, leafletBoundsHelpers, OffersService, Authentication, messageCenterService, MapLayersFactory, offer, appSettings, LocationService) {
 
     // Default location for all TR maps,
     // Returns `{lat: Float, lng: Float, zoom: 4}`

--- a/modules/offers/client/controllers/offers-view.client.controller.js
+++ b/modules/offers/client/controllers/offers-view.client.controller.js
@@ -6,7 +6,7 @@
     .controller('OffersViewController', OffersViewController);
 
   /* @ngInject */
-  function OffersViewController($scope, $state, OffersByService, Authentication, leafletData, MapLayersFactory, LocationService) {
+  function OffersViewController($scope, OffersByService, MapLayersFactory, LocationService) {
 
     // ViewModel
     var vm = this;

--- a/modules/pages/client/config/pages.client.routes.js
+++ b/modules/pages/client/config/pages.client.routes.js
@@ -95,12 +95,15 @@
           /* @ngInject */
           function($state) {
             $state.go('home');
-          }
+          },
+        controllerAs: 'about'
       });
 
     /**
      * Work around redirecting to home on SEO rendered pages
      */
+    // Angular's `$window` service is not available for `config` blocks
+    // eslint-disable-next-line angular/window-service
     if (window.location.search.search('_escaped_fragment_') === -1) {
       $stateProvider.state('home', {
         url: '/?tribe',

--- a/modules/pages/client/controllers/home.client.controller.js
+++ b/modules/pages/client/controllers/home.client.controller.js
@@ -15,7 +15,7 @@
   }
 
   /* @ngInject */
-  function HomeController($stateParams, $state, $scope, Authentication, TribesService, TribeService) {
+  function HomeController($stateParams, Authentication, TribesService, TribeService) {
 
     var headerHeight = angular.element('#tr-header').height() || 0;
 

--- a/modules/search/client/controllers/search-signup.client.controller.js
+++ b/modules/search/client/controllers/search-signup.client.controller.js
@@ -6,7 +6,7 @@
     .controller('SearchSignupController', SearchSignupController);
 
   /* @ngInject */
-  function SearchSignupController($stateParams, $timeout, MapLayersFactory, LocationService) {
+  function SearchSignupController($stateParams, MapLayersFactory, LocationService) {
 
     // ViewModel
     var vm = this;

--- a/modules/search/client/controllers/search.client.controller.js
+++ b/modules/search/client/controllers/search.client.controller.js
@@ -6,7 +6,7 @@
     .controller('SearchController', SearchController);
 
   /* @ngInject */
-  function SearchController($scope, $http, $q, $state, $stateParams, $timeout, $analytics, OffersService, leafletBoundsHelpers, Authentication, Languages, leafletData, messageCenterService, MapLayersFactory, appSettings, locker, LocationService) {
+  function SearchController($scope, $http, $q, $stateParams, $timeout, $analytics, OffersService, leafletBoundsHelpers, Authentication, leafletData, messageCenterService, MapLayersFactory, appSettings, locker, LocationService) {
 
     // `search-map-canvas` is id of <leaflet> element
     var mapId = 'search-map-canvas';

--- a/modules/tags/client/controllers/tribe.client.controller.js
+++ b/modules/tags/client/controllers/tribe.client.controller.js
@@ -20,6 +20,7 @@
 
     // `tr-tribe-join-button` and `tr-tribe-join` directives expect
     // `tribe` to be directly on their scope, as they don't have their own scope.
+    // eslint-disable-next-line angular/controller-as
     $scope.tribe = tribe;
 
     /**

--- a/modules/tags/client/services/tribe.client.service.js
+++ b/modules/tags/client/services/tribe.client.service.js
@@ -32,7 +32,7 @@
      * Automatically clears cache on `get()`.
      */
     function fillCache(tribe) {
-      if (!angular.isDefined(tribe) || !angular.isDefined(tribe.slug)) {
+      if (angular.isUndefined(tribe) || angular.isUndefined(tribe.slug)) {
         $log.error('Missing tribe to cache.');
         return;
       } else {
@@ -55,7 +55,7 @@
      */
     function get(options) {
       return $q(function(resolve, reject) {
-        if (!angular.isDefined(options) || !angular.isDefined(options.tribeSlug) || !angular.isString(options.tribeSlug)) {
+        if (angular.isUndefined(options) || angular.isUndefined(options.tribeSlug) || !angular.isString(options.tribeSlug)) {
           $log.error('Missing tribeSlug');
           reject();
         } else if (cachedTribe && cachedTribe.slug === options.tribeSlug) {

--- a/modules/users/client/config/users.client.routes.js
+++ b/modules/users/client/config/users.client.routes.js
@@ -28,7 +28,8 @@
           /* @ngInject */
           function($state) {
             $state.go('profile-edit.account');
-          }
+          },
+        controllerAs: 'profileSettings'
       }).
 
       state('profile-edit', {

--- a/modules/users/client/controllers/profile-edit-photo.client.controller.js
+++ b/modules/users/client/controllers/profile-edit-photo.client.controller.js
@@ -6,7 +6,7 @@
     .controller('ProfileEditPhotoController', ProfileEditPhotoController);
 
   /* @ngInject */
-  function ProfileEditPhotoController($scope, $state, $window, Users, Authentication, messageCenterService, Upload, appSettings) {
+  function ProfileEditPhotoController($scope, $window, Users, Authentication, messageCenterService, Upload, appSettings) {
 
     // ViewModel
     var vm = this;

--- a/modules/users/client/controllers/profile.client.controller.js
+++ b/modules/users/client/controllers/profile.client.controller.js
@@ -6,7 +6,7 @@
     .controller('ProfileController', ProfileController);
 
   /* @ngInject */
-  function ProfileController($scope, $stateParams, $state, $location, $uibModal, $filter, $window, Languages, Users, Contact, Authentication, $timeout, messageCenterService, profile, contact) {
+  function ProfileController($scope, $stateParams, $state, $uibModal, $filter, Authentication, $timeout, profile, contact) {
 
     // No user defined at URL, just redirect to user's own profile
     if (!$stateParams.username) {

--- a/modules/users/client/controllers/signup.client.controller.js
+++ b/modules/users/client/controllers/signup.client.controller.js
@@ -6,7 +6,7 @@
     .controller('SignupController', SignupController);
 
   /* @ngInject */
-  function SignupController($scope, $rootScope, $timeout, $http, $q, $state, $stateParams, $uibModal, $window, Authentication, UserTagsService, messageCenterService, TribeService, TribesService) {
+  function SignupController($rootScope, $http, $state, $stateParams, $uibModal, Authentication, UserTagsService, messageCenterService, TribeService, TribesService) {
 
     // View Model
     var vm = this;
@@ -74,6 +74,7 @@
         if (withoutTribeId) {
           angular.forEach(tribes, function(suggestedTribe) {
             if (suggestedTribe._id !== withoutTribeId) {
+              // eslint-disable-next-line angular/controller-as-vm
               this.push(suggestedTribe);
             }
           }, suggestedTribes);
@@ -137,12 +138,7 @@
         $event.preventDefault();
       }
       $uibModal.open({
-        templateUrl: '/modules/users/views/authentication/rules-modal.client.view.html',
-        controller: function ($scope, $uibModalInstance) {
-          $scope.closeRules = function () {
-            $uibModalInstance.dismiss('cancel');
-          };
-        }
+        templateUrl: '/modules/users/views/authentication/rules-modal.client.view.html'
       });
     }
 

--- a/modules/users/client/views/authentication/rules-modal.client.view.html
+++ b/modules/users/client/views/authentication/rules-modal.client.view.html
@@ -1,8 +1,8 @@
 <div class="modal-header">
-  <button type="button" class="close" aria-label="Close" ng-click="closeRules()"><span aria-hidden="true">&times;</span></button>
+  <button type="button" class="close" aria-label="Close" ng-click="$dismiss()"><span aria-hidden="true">&times;</span></button>
   <h4 class="modal-title">Rules</h4>
 </div>
 <div class="modal-body" ng-include="'/modules/pages/views/rules-text.client.partial.html'"></div>
 <div class="modal-footer">
-  <button class="btn btn-primary" ng-click="closeRules()">Got it!</button>
+  <button class="btn btn-primary" ng-click="$dismiss()">Got it!</button>
 </div>

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "del": "~2.2.1",
     "eslint": "~2.2.0",
     "eslint-config-airbnb": "~6.0.2",
+    "eslint-plugin-angular": "~1.3.1",
     "express": "~4.14.0",
     "express-paginate": "~0.2.1",
     "express-session": "~1.14.0",


### PR DESCRIPTION
Lints client side javascript files with [Angular rules][1] using a
separate gulp task, because eslint [doesn’t support glob based
configurations][2] just yet.

[1]: https://github.com/Gillespie59/eslint-plugin-angular#rules
[2]: https://github.com/eslint/eslint/issues/3611

See Angular best practises #284