### PR TITLE
Add inline CSS to html emails

### DIFF
--- a/modules/core/server/services/email.server.service.js
+++ b/modules/core/server/services/email.server.service.js
@@ -5,6 +5,7 @@
  */
 var path = require('path'),
     async = require('async'),
+    juice = require('juice'),
     analyticsHandler = require(path.resolve('./modules/core/server/controllers/analytics.server.controller')),
     render = require(path.resolve('./config/lib/render')),
     agenda = require(path.resolve('./config/lib/agenda')),
@@ -226,7 +227,7 @@ exports.renderEmail = function(templateName, params, callback) {
       },
       from: 'Trustroots <' + config.mailer.from + '>',
       subject: params.subject,
-      html: result.html,
+      html: juice(result.html),
       text: result.text
     };
     callback(null, email);

--- a/modules/core/tests/server/services/email.server.service.tests.js
+++ b/modules/core/tests/server/services/email.server.service.tests.js
@@ -204,6 +204,7 @@ describe('service: email', function() {
     });
 
     emailService.renderEmail('reset-password', params, function(err, email) {
+      if (err) return done(err);
       email.html.should.containEql('<body style=');
       done();
     });

--- a/modules/core/tests/server/services/email.server.service.tests.js
+++ b/modules/core/tests/server/services/email.server.service.tests.js
@@ -193,4 +193,20 @@ describe('service: email', function() {
     });
   });
 
+  it('emails should have inline css styles', function(done) {
+    var params = emailService.addEmailBaseTemplateParams({
+      subject: 'test',
+      name: 'test',
+      email: 'test@test.com',
+      utmCampaign: 'test',
+      urlConfirmPlainText: '#',
+      urlConfirm: '#'
+    });
+
+    emailService.renderEmail('reset-password', params, function(err, email) {
+      email.html.should.containEql('<body style=');
+      done();
+    });
+  });
+
 });

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "gulp-util": "~3.0.7",
     "helmet": "~2.1.2",
     "html-to-text": "~2.1.3",
+    "juice": "~2.0.0",
     "lodash": "~4.14.0",
     "mean-seo": "~0.0.8",
     "merge-stream": "~1.0.0",


### PR DESCRIPTION
Mandrill had this at their service but since we moved to Sparkpost, we've had small issues with some clients showing emails without styles.

Inline styles are the way to go.