### PR TITLE
Send recurring reminders to complete signup

### DIFF
--- a/config/env/default.js
+++ b/config/env/default.js
@@ -46,7 +46,11 @@ module.exports = {
   limits: {
     // Messages shorter than this will be tagged 'short' in influxdb,
     // otherwise 'long'
-    longMessageMinimumLength: 170
+    longMessageMinimumLength: 170,
+    // How many signup reminders to send before giving up
+    maxSignupReminders: 3,
+    // How many signup reminders to process at once
+    maxProcessSignupReminders: 50
   },
   mailer: {
     from: process.env.MAILER_FROM || 'hello@trustroots.org',

--- a/config/lib/worker.js
+++ b/config/lib/worker.js
@@ -27,12 +27,19 @@ exports.start = function(options, callback) {
       { lockLifetime: 10000 },
       require(path.resolve('./modules/statistics/server/jobs/daily-statistics.server.job'))
     );
+    agenda.define(
+      'send signup reminders',
+      { lockLifetime: 10000, concurrency: 10 },
+      require(path.resolve('./modules/users/server/jobs/user-finish-signup.server.job'))
+    );
 
     // Schedule job(s)
 
     agenda.every('5 minutes', 'check unread messages');
     agenda.every('24 hours', 'daily statistics');
 
+
+    agenda.every('30 minutes', 'send signup reminders');
 
     // Start worker
 

--- a/modules/core/server/services/email.server.service.js
+++ b/modules/core/server/services/email.server.service.js
@@ -149,7 +149,7 @@ exports.sendSignupEmailConfirmation = function(user, callback) {
   var params = exports.addEmailBaseTemplateParams({
     subject: 'Confirm Email',
     name: user.displayName,
-    email: user.emailTemporary,
+    email: user.emailTemporary || user.email,
     urlConfirmPlainText: urlConfirm,
     urlConfirm: analyticsHandler.appendUTMParams(urlConfirm, {
       source: 'transactional-email',
@@ -175,6 +175,27 @@ exports.sendSupportRequest = function(replyTo, supportRequest, callback) {
   };
 
   exports.renderEmailAndSend('support-request', params, callback);
+};
+
+exports.sendSignupEmailReminder = function(user, callback) {
+
+  var urlConfirm = url + '/confirm-email/' + user.emailToken + '?signup',
+      utmCampaign = 'signup-reminder';
+
+  var params = exports.addEmailBaseTemplateParams({
+    subject: 'Complete your signup to Trustroots',
+    name: user.displayName,
+    email: user.emailTemporary || user.email,
+    urlConfirmPlainText: urlConfirm,
+    urlConfirm: analyticsHandler.appendUTMParams(urlConfirm, {
+      source: 'transactional-email',
+      medium: 'email',
+      campaign: utmCampaign
+    }),
+    utmCampaign: utmCampaign
+  });
+
+  exports.renderEmailAndSend('signup-reminder', params, callback);
 };
 
 /**

--- a/modules/core/server/views/email-templates-text/signup-reminder.server.view.html
+++ b/modules/core/server/views/email-templates-text/signup-reminder.server.view.html
@@ -1,0 +1,16 @@
+{% extends 'email.server.view.html' %}
+
+{% block content %}
+{{name}},
+
+We haven't heard from you since you signed up to Trustroots.
+
+Your profile will not be visible to others if you don't confirm your email address ({{email}}).
+
+It's easy — just click on the link below.
+
+<{{urlConfirmPlainText}}>
+
+Thank you very much for signing up with us!
+
+{% endblock %}

--- a/modules/core/server/views/email-templates/signup-reminder.server.view.html
+++ b/modules/core/server/views/email-templates/signup-reminder.server.view.html
@@ -1,0 +1,67 @@
+{% extends 'email.server.view.html' %}
+
+{% block content %}
+
+  <!-- MODULE ROW // -->
+  <tr>
+    <td align="center" valign="top">
+        <!-- CENTERING TABLE // -->
+          <!--
+            The centering table keeps the content
+              tables centered in the emailBody table,
+              in case its width is set to 100%.
+          -->
+        <table border="0" cellpadding="0" cellspacing="0" width="100%">
+            <tr>
+                <td align="center" valign="top">
+                    <!-- FLEXIBLE CONTAINER // -->
+                      <!--
+                        The flexible container has a set width
+                          that gets overridden by the media query.
+                          Most content tables within can then be
+                          given 100% widths.
+                      -->
+                    <table border="0" cellpadding="0" cellspacing="0" width="600" class="flexibleContainer">
+                        <tr>
+                            <td align="center" valign="top" width="600" class="flexibleContainerCell">
+
+
+                                  <!-- CONTENT TABLE // -->
+                                  <!--
+                                    The content table is the first element
+                                      that's entirely separate from the structural
+                                      framework of the email.
+                                  -->
+                                  <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                                      <tr>
+                                          <td valign="top" class="textContent">
+
+                                              <p>{{name}},</p>
+                                              <p>We haven't heard from you since you signed up to Trustroots.</p>
+                                              <p>Your profile will not be visible to others if you don't confirm your email address ({{email}}).</p>
+                                              <p>It's easy — just click on the link below.</p>
+                                              <p>Thank you very much for signing up with us!</p>
+
+                                          </td>
+                                      </tr>
+                                  </table>
+                                  <!-- // CONTENT TABLE -->
+
+
+                              </td>
+                          </tr>
+                      </table>
+                      <!-- // FLEXIBLE CONTAINER -->
+                  </td>
+              </tr>
+          </table>
+          <!-- // CENTERING TABLE -->
+      </td>
+  </tr>
+  <!-- // MODULE ROW -->
+
+  {% include 'partials/button.server.view.html' with {'buttonUrl': urlConfirm, 'buttonTitle': 'Confirm now'} %}
+
+  {% include 'partials/copypasteurl.server.view.html' with {'url': urlConfirmPlainText} %}
+
+{% endblock %}

--- a/modules/core/tests/server/services/email.server.service.tests.js
+++ b/modules/core/tests/server/services/email.server.service.tests.js
@@ -273,4 +273,25 @@ describe('Service: email', function() {
     });
   });
 
+  it('can send signup reminder email', function(done) {
+    var user = {
+      _id: 'user-id',
+      username: 'username',
+      displayName: 'Firstname Lastname',
+      email: 'email@test.com',
+      emailTemporary: 'email@test.com',
+      emailToken: 'email-token'
+    };
+    emailService.sendSignupEmailReminder(user, function(err) {
+      if (err) return done(err);
+      jobs.length.should.equal(1);
+      jobs[0].type.should.equal('send email');
+      jobs[0].data.subject.should.equal('Complete your signup to Trustroots');
+      jobs[0].data.text.should.containEql('Your profile will not be visible to others if you don\'t confirm your email address (' + user.emailTemporary + ').');
+      jobs[0].data.text.should.containEql('/confirm-email/' + user.emailToken + '?signup');
+      jobs[0].data.to.name.should.equal(user.displayName);
+      jobs[0].data.to.address.should.equal(user.email);
+      done();
+    });
+  });
 });

--- a/modules/core/tests/server/worker.tests.js
+++ b/modules/core/tests/server/worker.tests.js
@@ -145,6 +145,11 @@ describe('Worker tests', function() {
     jobNames.should.containEql('daily statistics');
   });
 
+  it('defines [send signup reminders] job', function() {
+    var jobNames = _.map(definedJobs, 'name');
+    jobNames.should.containEql('send signup reminders');
+  });
+
   it('defines two repeating jobs', function() {
     scheduledJobs.length.should.equal(2);
   });

--- a/modules/core/tests/server/worker.tests.js
+++ b/modules/core/tests/server/worker.tests.js
@@ -150,8 +150,8 @@ describe('Worker tests', function() {
     jobNames.should.containEql('send signup reminders');
   });
 
-  it('defines two repeating jobs', function() {
-    scheduledJobs.length.should.equal(2);
+  it('defines right number of repeating jobs', function() {
+    scheduledJobs.length.should.equal(3);
   });
 
   it('only schedules defined jobs', function() {

--- a/modules/users/server/controllers/users/users.authentication.server.controller.js
+++ b/modules/users/server/controllers/users/users.authentication.server.controller.js
@@ -299,7 +299,13 @@ exports.confirmEmail = function(req, res) {
         {
           $unset: {
             emailTemporary: 1,
-            emailToken: 1
+            emailToken: 1,
+            // Note that `publicReminderCount` and `publicReminderSent` get reset now each
+            // time user confirms any email change, even if they didn't confirm their profile yet.
+            // That's fine: we'll just start sending 'finish signup' notifications from scratch
+            // to the new email. That old email before the change might've been wrong anyway...
+            publicReminderCount: 1,
+            publicReminderSent: 1
           },
           $set: {
             public: true,

--- a/modules/users/server/controllers/users/users.profile.server.controller.js
+++ b/modules/users/server/controllers/users/users.profile.server.controller.js
@@ -359,6 +359,8 @@ exports.update = function(req, res) {
       delete req.body.resetPasswordToken;
       delete req.body.resetPasswordExpires;
       delete req.body.additionalProvidersData;
+      delete req.body.publicReminderCount;
+      delete req.body.publicReminderSent;
 
       // Merge existing user
       var user = req.user;
@@ -632,6 +634,10 @@ exports.sanitizeProfile = function(profile, authenticatedUser) {
   delete profile.emailToken;
   delete profile.password;
   delete profile.salt;
+
+  // This information is not sensitive, but isn't needed at frontend
+  delete profile.publicReminderCount;
+  delete profile.publicReminderSent;
 
   return profile;
 };

--- a/modules/users/server/jobs/user-finish-signup.server.job.js
+++ b/modules/users/server/jobs/user-finish-signup.server.job.js
@@ -86,7 +86,7 @@ module.exports = function(job, agendaDone) {
                   publicReminderCount: 1
                 }
               },
-              function(err, user) {
+              function(err) {
                 if (err) {
                   console.error('Failed to mark user\'s reminder sent.');
                 }

--- a/modules/users/server/jobs/user-finish-signup.server.job.js
+++ b/modules/users/server/jobs/user-finish-signup.server.job.js
@@ -1,0 +1,110 @@
+'use strict';
+
+/**
+ * Task that checks for users who didn't finish their signup process and thus
+ * have `public:false` in their profile. The script sends 3 reminder emails
+ * to these users in 3 day intervals, starting 24h after signup.
+ *
+ * Keeps count of reminder emails at user's model.
+ */
+
+
+/**
+ * Module dependencies.
+ */
+var path = require('path'),
+    emailService = require(path.resolve('./modules/core/server/services/email.server.service')),
+    async = require('async'),
+    moment = require('moment'),
+    mongoose = require('mongoose'),
+    User = mongoose.model('User');
+
+// How many reminder emails we should send?
+var maxReminders = 3;
+
+module.exports = function(job, agendaDone) {
+  async.waterfall([
+
+    // Find un-confirmed users
+    function(done) {
+
+      // Ignore very recently signed up users
+      var createdTimeAgo = moment().subtract(moment.duration({ 'hours': 4 }));
+
+      // Ignore very recently reminded users
+      var remindedTimeAgo = moment().subtract(moment.duration({ 'days': 2 }));
+
+      User
+        .find({
+          public: false,
+          created: {
+            $lt: createdTimeAgo
+          }
+        })
+        .and([
+          {
+            $or: [
+              { publicReminderCount: { $lt: maxReminders } },
+              { publicReminderCount: { $exists: false } }
+            ]
+          },
+          {
+            $or: [
+              { publicReminderSent: { $lt: remindedTimeAgo } },
+              { publicReminderSent: { $exists: false } }
+            ]
+          }
+        ])
+        .limit(50)
+        .exec(function(err, users) {
+          done(err, users);
+        });
+
+    },
+
+    // Send emails
+    function(users, done) {
+
+      if (users.length > 0) {
+
+        users.forEach(function(user) {
+
+          emailService.sendSignupEmailReminder(user, function(err) {
+            if (err) {
+              console.error('Failed to send user\'s reminder.');
+              console.error(err);
+              // Continue regardless the failure so that we can process other
+              // reminders without getting stuck here
+              done();
+            } else {
+              // Mark reminder sent and update the reminder count
+              User.findByIdAndUpdate(
+                { _id: user._id },
+                {
+                  publicReminderSent: new Date(),
+                  $inc: { publicReminderCount: 1 }
+                },
+                function(err) {
+                  if (err) {
+                    console.error('Failed to mark user\'s reminder sent.');
+                    console.error(err);
+                  }
+                  done();
+                }
+              );
+            }
+          });
+
+        });
+      } else {
+        // No users to send emails to
+        done();
+      }
+
+    }
+
+  ], function(err) {
+    return agendaDone(err);
+  });
+
+};

--- a/modules/users/server/models/user.server.model.js
+++ b/modules/users/server/models/user.server.model.js
@@ -236,6 +236,14 @@ var UserSchema = new Schema({
     type: Boolean,
     default: false
   },
+  /* Count and latest date of emails sent to remind about un-finished signup
+     Will be removed once user sets `public:true` */
+  publicReminderCount: {
+    type: Number
+  },
+  publicReminderSent: {
+    type: Date
+  },
   /* For reset password */
   resetPasswordToken: {
     type: String

--- a/modules/users/tests/server/jobs/user-finish-signup.server.job.tests.js
+++ b/modules/users/tests/server/jobs/user-finish-signup.server.job.tests.js
@@ -1,0 +1,210 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+var _ = require('lodash'),
+    path = require('path'),
+    should = require('should'),
+    testutils = require(path.resolve('./testutils')),
+    config = require(path.resolve('./config/config')),
+    moment = require('moment'),
+    mongoose = require('mongoose'),
+    User = mongoose.model('User');
+
+/**
+ * Globals
+ */
+var unConfirmedUser,
+    _unConfirmedUser,
+    confirmedUser,
+    _confirmedUser,
+    userFinishSignupJobHandler;
+
+describe('Job: user finish signup', function() {
+
+  var jobs = testutils.catchJobs();
+
+  before(function() {
+    userFinishSignupJobHandler = require(path.resolve('./modules/users/server/jobs/user-finish-signup.server.job'));
+  });
+
+  // Create an unconfirmed user
+  beforeEach(function (done) {
+
+    // Create a new user
+    _unConfirmedUser = {
+      public: false,
+      firstName: 'Full',
+      lastName: 'Name',
+      displayName: 'Full Name',
+      email: 'test@test.com',
+      emailTemporary: 'test@test.com', // unconfirmed users have this set
+      emailToken: 'initial email token',
+      username: 'user_unconfirmed',
+      displayUsername: 'user_unconfirmed',
+      password: 'M3@n.jsI$Aw3$0m3',
+      provider: 'local',
+      created: moment().subtract(moment.duration({ 'hours': 4 }))
+    };
+
+    unConfirmedUser = new User(_unConfirmedUser);
+
+    // Save a user to the test db
+    unConfirmedUser.save(done);
+  });
+
+  // Create a confirmed user
+  beforeEach(function (done) {
+
+    _confirmedUser = {
+      public: true,
+      firstName: 'Full',
+      lastName: 'Name',
+      displayName: 'Full Name',
+      email: 'confirmed-test@test.com',
+      username: 'user_confirmed',
+      displayUsername: 'user_confirmed',
+      password: 'M3@n.jsI$Aw3$0m4',
+      provider: 'local',
+      created: moment().subtract(moment.duration({ 'hours': 4 }))
+    };
+
+    confirmedUser = new User(_confirmedUser);
+
+    // Save a user to the test db
+    confirmedUser.save(done);
+  });
+
+  it('Do not remind unconfirmed users <4 hours after their signup', function(done) {
+    unConfirmedUser.created = moment().subtract(moment.duration({ 'hours': 3 }));
+    unConfirmedUser.save(function(err) {
+      if (err) return done(err);
+
+      userFinishSignupJobHandler({}, function(err) {
+        if (err) return done(err);
+        jobs.length.should.equal(0);
+        done();
+      });
+
+    });
+  });
+
+  it('Remind unconfirmed users >4 hours after their signup', function(done) {
+    userFinishSignupJobHandler({}, function(err) {
+      if (err) return done(err);
+
+      jobs.length.should.equal(1);
+      jobs[0].type.should.equal('send email');
+      jobs[0].data.subject.should.equal('Complete your signup to Trustroots');
+      jobs[0].data.to.address.should.equal(_unConfirmedUser.email);
+
+      User.findOne({ email: _unConfirmedUser.email }, function(err, user) {
+        if (err) return done(err);
+        user.publicReminderCount.should.equal(1);
+        should.exist(user.publicReminderSent);
+        done();
+      });
+
+    });
+  });
+
+  it('Remind unconfirmed users 2nd time >2 days after previous notification', function(done) {
+    unConfirmedUser.publicReminderCount = 1;
+    unConfirmedUser.publicReminderSent = moment().subtract(moment.duration({ 'days': 2 }));
+    unConfirmedUser.save(function(err) {
+      if (err) return done(err);
+      userFinishSignupJobHandler({}, function(err) {
+        if (err) return done(err);
+
+        jobs.length.should.equal(1);
+        jobs[0].type.should.equal('send email');
+        jobs[0].data.subject.should.equal('Complete your signup to Trustroots');
+        jobs[0].data.to.address.should.equal(_unConfirmedUser.email);
+
+        User.findOne({ email: _unConfirmedUser.email }, function(err, user) {
+          if (err) return done(err);
+          user.publicReminderCount.should.equal(2);
+          should.exist(user.publicReminderSent);
+          done();
+        });
+
+      });
+    });
+  });
+
+  it('Remind unconfirmed users 3rd time >2 days after previous notification', function(done) {
+    unConfirmedUser.publicReminderCount = 2;
+    unConfirmedUser.publicReminderSent = moment().subtract(moment.duration({ 'days': 2 }));
+    unConfirmedUser.save(function(err) {
+      if (err) return done(err);
+      userFinishSignupJobHandler({}, function(err) {
+        if (err) return done(err);
+
+        jobs.length.should.equal(1);
+        jobs[0].type.should.equal('send email');
+        jobs[0].data.subject.should.equal('Complete your signup to Trustroots');
+        jobs[0].data.to.address.should.equal(_unConfirmedUser.email);
+
+        User.findOne({ email: _unConfirmedUser.email }, function(err, user) {
+          if (err) return done(err);
+          user.publicReminderCount.should.equal(3);
+          should.exist(user.publicReminderSent);
+          done();
+        });
+
+      });
+    });
+  });
+
+  it('Do not remind unconfirmed users 4rd time >2 days after previous notification', function(done) {
+    unConfirmedUser.publicReminderCount = 3;
+    unConfirmedUser.publicReminderSent = moment().subtract(moment.duration({ 'days': 2 }));
+    unConfirmedUser.save(function(err) {
+      if (err) return done(err);
+      userFinishSignupJobHandler({}, function(err) {
+        if (err) return done(err);
+        jobs.length.should.equal(0);
+        User.findOne({ email: _unConfirmedUser.email }, function(err, user) {
+          if (err) return done(err);
+          user.publicReminderCount.should.equal(3);
+          should.exist(user.publicReminderSent);
+          done();
+        });
+      });
+    });
+  });
+
+  it('Remind multiple unconfirmed users >4 hours after their signup, but no more than maximum amount of notifications at once', function(done) {
+
+    // Create test users
+    var _users = [];
+    for (var i = 1; i <= config.limits.maxProcessSignupReminders+1; i++) {
+      var loopVars = {
+        username: 'l' + i + _unConfirmedUser.username,
+        displayUsername: 'l' + i + _unConfirmedUser.displayUsername,
+        emailToken: 'l' + i + _unConfirmedUser.emailToken,
+        emailTemporary: 'l' + i + _unConfirmedUser.emailTemporary,
+        email: 'l' + i + _unConfirmedUser.email
+      };
+      var _unConfirmedUserLooped = _.merge(_.clone(_unConfirmedUser), loopVars);
+      _users.push(_unConfirmedUserLooped);
+    }
+
+    // Save all users to the test db
+    User.insertMany(_users, function(err) {
+      if (err) return done(err);
+
+      userFinishSignupJobHandler({}, function(err) {
+        if (err) return done(err);
+
+        jobs.length.should.equal(config.limits.maxProcessSignupReminders);
+        done();
+      });
+    });
+  });
+
+  afterEach(function (done) {
+    User.remove().exec(done);
+  });
+});

--- a/modules/users/tests/server/jobs/user-finish-signup.server.job.tests.js
+++ b/modules/users/tests/server/jobs/user-finish-signup.server.job.tests.js
@@ -179,7 +179,7 @@ describe('Job: user finish signup', function() {
 
     // Create test users
     var _users = [];
-    for (var i = 1; i <= config.limits.maxProcessSignupReminders+1; i++) {
+    for (var i = 1; i <= config.limits.maxProcessSignupReminders + 1; i++) {
       var loopVars = {
         username: 'l' + i + _unConfirmedUser.username,
         displayUsername: 'l' + i + _unConfirmedUser.displayUsername,

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "mkdir-recursive": "~0.2.2",
     "mkdirp": "~0.5.1",
     "mmmagic": "~0.4.4",
+    "moment": "~2.15.1",
     "mongodb": "~2.2.4",
     "mongoose": "~4.6.3",
     "mongoose-beautiful-unique-validation": "~5.1.1",


### PR DESCRIPTION
Sends 3 reminder emails. First one already after 4 hours of signup if user didn't confirm their email. Next two in 2 day intervals.

The email template/text is the same for all 3 emails.