### PR TITLE
[WIP] Add InfluxDB and collect some metrics

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -69,6 +69,24 @@ at [localhost:1081](http://localhost:1081).
 - Keep an eye on console in case of compiling errors.
 - [Read more](https://github.com/Trustroots/trustroots/wiki/Development)
 
+## Enable collecting statistics
+
+* 1. [Install InfluxDB](https://docs.influxdata.com/influxdb/latest/introduction/installation/) 0.9+ and run it (type `influxd`) at default port (8086)
+* 2. Add InfluxDB configuration to your `./config/env/local.js`:
+```
+influxdb: {
+  enabled: true,
+  options: {
+    host: 'localhost',
+    port: 8086, // default 8086
+    protocol: 'http', // default 'http'
+    // username: '',
+    // password: '',
+    database: 'trustroots'
+  }
+}
+```
+* 3. Optionally to observe metrics, you can [install Grafana](http://docs.grafana.org/installation/), but you can also observe data trough InfluxDB admin panel, too: [http://localhost:8083/](http://localhost:8083/)
 
 ## Mock data
 

--- a/config/env/default.js
+++ b/config/env/default.js
@@ -32,6 +32,17 @@ module.exports = {
                    'edit', 'settings', 'username', 'user', ' demo', 'test', 'support', 'networks', 'profile', 'avatar', 'mini',
                    'photo', 'account', 'api', 'modify', 'feedback', 'security', 'accounts', 'tribe', 'tag', 'community'
                   ],
+  influxdb: {
+    enabled: false,
+    options: {
+      host: 'localhost',
+      port: 8086, // default 8086
+      protocol: 'http', // default 'http'
+      // username: '',
+      // password: '',
+      database: 'trustroots'
+    }
+  },
   mailer: {
     from: process.env.MAILER_FROM || 'hello@trustroots.org',
     options: {

--- a/config/env/local.sample.js
+++ b/config/env/local.sample.js
@@ -13,6 +13,21 @@
 
 module.exports = {
 
+  // Uncomment if you have installed InfluxDB and would like to store collected statistics
+  /*
+  influxdb: {
+    enabled: true,
+    options: {
+      host: 'localhost',
+      port: 8086, // default 8086
+      protocol: 'http', // default 'http'
+      // username: '',
+      // password: '',
+      database: 'trustroots'
+    }
+  },
+  */
+
   // Uncomment if you want to have Mapbox maps at development environment
   /*
   mapbox: {

--- a/config/env/test.js
+++ b/config/env/test.js
@@ -30,6 +30,9 @@ module.exports = {
     title: 'Trustroots test environment.',
     description: 'Trustroots test environment.'
   },
+  influxdb: {
+    enabled: false
+  },
   mapbox: {
     // Mapbox is publicly exposed to the frontend
     user: process.env.MAPBOX_USERNAME || 'trustroots',

--- a/config/lib/worker.js
+++ b/config/lib/worker.js
@@ -22,9 +22,17 @@ exports.start = function(options, callback) {
       require(path.resolve('./modules/messages/server/jobs/message-unread.server.job'))
     );
 
+    agenda.define(
+      'daily statistics',
+      { lockLifetime: 10000 },
+      require(path.resolve('./modules/statistics/server/jobs/daily-statistics.server.job'))
+    );
+
     // Schedule job(s)
 
     agenda.every('5 minutes', 'check unread messages');
+    agenda.every('24 hours', 'daily statistics');
+
 
     // Start worker
 

--- a/modules/core/client/config/core.client.config.js
+++ b/modules/core/client/config/core.client.config.js
@@ -1,0 +1,27 @@
+(function () {
+  'use strict';
+
+  angular
+    .module('core')
+    .config(CoreConfig);
+
+  /* @ngInject */
+  function CoreConfig($httpProvider) {
+    // Config HTTP Error Handling
+    // Set the httpProvider "not authorized" interceptor
+    $httpProvider.interceptors.push(CoreServiceUnavailable);
+  }
+
+  /* @ngInject */
+  function CoreServiceUnavailable($q, $rootScope) {
+    return {
+      responseError: function(rejection) {
+        if (rejection.status === 503) {
+          $rootScope.$broadcast('serviceUnavailable');
+        }
+        return $q.reject(rejection);
+      }
+    };
+  }
+
+}());

--- a/modules/core/client/controllers/app.client.controller.js
+++ b/modules/core/client/controllers/app.client.controller.js
@@ -9,7 +9,7 @@
     .controller('AppController', AppController);
 
   /* @ngInject */
-  function AppController($scope, $rootScope, $window, $state, $analytics, Authentication, SettingsFactory, Languages, locker, PollMessagesCount) {
+  function AppController($scope, $rootScope, $uibModal, $window, $state, $analytics, Authentication, SettingsFactory, Languages, locker, PollMessagesCount) {
 
     // ViewModel
     var vm = this;
@@ -77,6 +77,26 @@
      * Initialize controller
      */
     function activate() {
+
+      /**
+       * Show "service unavailable" badge if http interceptor sends us this signal
+       */
+      $rootScope.$on('serviceUnavailable', function() {
+        $uibModal.open({
+          ariaLabelledBy: 'Service unavailable',
+          template:
+            '<div class="modal-body lead text-center">' +
+            '  <p class="lead">Unfortunately Trustroots is down for a bit of maintenance right now.</p>' +
+            '  <p>We expect to be back in a couple minutes. Thanks for your patience.</p>' +
+            '  <p>In the meantime, check our ' +
+            '    <a href="https://twitter.com/trustroots" target="_blank">Twitter account</a> or ' +
+            '    <a href="http://status.trustroots.org/" target="_blank">status page</a> for news.</p>' +
+            '</div>' +
+            '<div class="modal-footer">' +
+            '  <button class="btn btn-primary" type="button" ng-click="$dismiss()">OK</button>' +
+            '</div>'
+        });
+      });
 
       /**
        * Snif and apply user changes

--- a/modules/core/server/services/influx.server.service.js
+++ b/modules/core/server/services/influx.server.service.js
@@ -1,0 +1,65 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+var path = require('path'),
+    influx = require('influx'),
+    config = require(path.resolve('./config/config'));
+
+/**
+ * Get InfluxDB Client
+ */
+exports.getClient = function(callback) {
+  if (!config.influxdb ||
+      !config.influxdb.enabled ||
+      !config.influxdb.options ||
+      !config.influxdb.options.host ||
+      !config.influxdb.options.database) {
+    return callback(new Error('No InfluxDB configured.'));
+  }
+  callback(null, influx(config.influxdb.options));
+};
+
+/**
+ * Write point to InfluxDB
+ *
+ * `values` can be either an object or a single value. For the latter the columname is set to value.
+ * You can set the time by passing an object propety called time. The time an be either an integer value or a Date object.
+ * When providing a single value, don't forget to adjust the time precision accordingly. The default value is `ms`.
+ */
+exports.writePoint = function(seriesName, values, tags, callback) {
+
+  if (!seriesName || typeof seriesName !== 'string' || seriesName.length === 0) {
+    return callback(new Error('InfluxDB Service: no `seriesName` defined.'));
+  }
+
+  if (values === undefined || values === null) {
+    return callback(new Error('InfluxDB Service: no `values` defined.'));
+  }
+
+  if (!tags || typeof tags !== 'object') {
+    return callback(new Error('InfluxDB Service: no `tags` defined.'));
+  }
+
+  // Turn `values` into object so that we can add time if it's missing
+  if (typeof values !== 'object') {
+    values = {
+      value: values
+    };
+  }
+
+  // Add current time to `values` if it's missing
+  if (!values.time) {
+    values.time = new Date();
+  }
+
+  exports.getClient(function(err, client) {
+    if (err) {
+      return callback(err);
+    }
+
+    // `callback` will return `function (err, response)`
+    client.writePoint(seriesName, values, tags, callback);
+  });
+};

--- a/modules/core/tests/server/core.server.config.tests.js
+++ b/modules/core/tests/server/core.server.config.tests.js
@@ -22,7 +22,7 @@ describe('Testing exposing environment as a variable to layout', function () {
       // Set env to development for this test
       process.env.NODE_ENV = env;
 
-      // Gget application
+      // Get application
       app = express.init(mongoose);
       agent = request.agent(app);
 

--- a/modules/core/tests/server/services/email.server.service.tests.js
+++ b/modules/core/tests/server/services/email.server.service.tests.js
@@ -7,7 +7,7 @@ var path = require('path'),
 
 var emailService;
 
-describe('service: email', function() {
+describe('Service: email', function() {
 
   var jobs = testutils.catchJobs();
 

--- a/modules/core/tests/server/services/influx.server.service.tests.js
+++ b/modules/core/tests/server/services/influx.server.service.tests.js
@@ -1,0 +1,46 @@
+'use strict';
+
+var path = require('path'),
+    should = require('should'),
+    influxService = require(path.resolve('./modules/core/server/services/influx.server.service'));
+
+describe('Service: influx', function() {
+
+  it('Getting client returns error if no InfluxDB configured', function(done) {
+    influxService.getClient(function(err) {
+      err.message.should.equal('No InfluxDB configured.');
+      done();
+    });
+  });
+
+  it('Writing point returns error with no seriesName', function(done) {
+    influxService.writePoint(null, 1, { 'tag': 'tag' }, function(err) {
+      err.message.should.equal('InfluxDB Service: no `seriesName` defined.');
+      done();
+    });
+  });
+
+  it('Writing point returns error with no value', function(done) {
+    influxService.writePoint('test', null, { 'tag': 'tag' }, function(err) {
+      err.message.should.equal('InfluxDB Service: no `values` defined.');
+      done();
+    });
+  });
+
+  it('Writing point returns error with no tag', function(done) {
+    influxService.writePoint('test', 1, null, function(err) {
+      err.message.should.equal('InfluxDB Service: no `tags` defined.');
+      done();
+    });
+  });
+
+  /*
+  it('Writing point should succeed with 0 value', function(done) {
+    influxService.writePoint('test', 0, { 'tag':'tag' }, function(err) {
+      err.message.should.equal('InfluxDB Service: No `values` defined.');
+      done();
+    });
+  });
+  */
+
+});

--- a/modules/core/tests/server/worker.tests.js
+++ b/modules/core/tests/server/worker.tests.js
@@ -4,7 +4,7 @@ var _ = require('lodash'),
     path = require('path'),
     sinon = require('sinon');
 
-describe('worker', function() {
+describe('Worker tests', function() {
 
   var agenda = require(path.resolve('./config/lib/agenda')),
       worker = require(path.resolve('./config/lib/worker'));
@@ -140,8 +140,13 @@ describe('worker', function() {
     jobNames.should.containEql('check unread messages');
   });
 
-  it('defines one repeating job', function() {
-    scheduledJobs.length.should.equal(1);
+  it('defines [daily statistics] job', function() {
+    var jobNames = _.map(definedJobs, 'name');
+    jobNames.should.containEql('daily statistics');
+  });
+
+  it('defines two repeating jobs', function() {
+    scheduledJobs.length.should.equal(2);
   });
 
   it('only schedules defined jobs', function() {

--- a/modules/statistics/server/jobs/daily-statistics.server.job.js
+++ b/modules/statistics/server/jobs/daily-statistics.server.job.js
@@ -1,0 +1,42 @@
+'use strict';
+
+/**
+ * Task that collects daily statistics and sends them to InfluxDB
+ */
+
+/**
+ * Module dependencies.
+ */
+var path = require('path'),
+    config = require(path.resolve('./config/config')),
+    influxService = require(path.resolve('./modules/core/server/services/influx.server.service')),
+    statistics = require(path.resolve('./modules/statistics/server/controllers/statistics.server.controller'));
+
+module.exports = function(job, agendaDone) {
+
+  statistics.getUsersCount(function(err, count) {
+
+    if (err) {
+      console.error('Daily statistics: failed fetching user count.');
+      console.error(err);
+      return agendaDone(err);
+    }
+
+    // Save to influx here
+    influxService.writePoint('members', count, { members: 'members' }, function(err, result) {
+      if (err) {
+        // InfluxDB was not enabled, don't scream out error
+        if (config.influxdb || !config.influxdb.enabled) {
+          console.log('Skipped storing daily statistics: no InfluxDB configured.');
+          // Let `agendaDone()` succeed
+          err = null;
+        } else {
+          console.error('Daily statistics: failed writing to InfluxDB.');
+          console.error(err);
+        }
+      }
+      agendaDone(err);
+    });
+  });
+
+};

--- a/modules/statistics/server/routes/statistics.server.routes.js
+++ b/modules/statistics/server/routes/statistics.server.routes.js
@@ -5,6 +5,6 @@ module.exports = function(app) {
   var statistics = require('../controllers/statistics.server.controller');
 
   // Setting up the statistics api
-  app.route('/api/statistics').get(statistics.get);
+  app.route('/api/statistics').get(statistics.getPublicStatistics);
 
 };

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "gulp-util": "~3.0.7",
     "helmet": "~2.1.2",
     "html-to-text": "~2.1.3",
+    "influx": "~4.2.1",
     "juice": "~2.0.0",
     "lodash": "~4.15.0",
     "merge-stream": "~1.0.0",


### PR DESCRIPTION
### Prerequisites:
* 1. [Install InfluxDB](https://docs.influxdata.com/influxdb/latest/introduction/installation/) v0.9+
* 2. Run it: `influxd`
* 3. Open admin panel [http://localhost:8083/](http://localhost:8083/) and create a database: `CREATE DATABASE "trustroots"`
* 4. Add InfluxDB configuration to your `./config/env/local.js`:
```
influxdb: {
  enabled: true,
  options: {
    host: 'localhost',
    port: 8086, // default 8086
    protocol: 'http', // default 'http'
    // username: '',
    // password: '',
    database: 'trustroots'
  }
}
```
* 5. Optionally to observe metrics, you can [install Grafana](http://docs.grafana.org/installation/), but you can also [query data](https://docs.influxdata.com/influxdb/latest/guides/querying_data/) trough InfluxDB admin panel or CLI.

### TODO:
Initial metrics:
- [x] User count
- [ ] Our KPI?
- [ ] Message response rates?
- [ ] Signups and other recurring actions
- [ ] More info with records (e.g. types: Counter, Gauge...)