### PR TITLE
added emailTemporary to fix (sometimes) failing test

### DIFF
--- a/modules/users/tests/server/user.server.routes.tests.js
+++ b/modules/users/tests/server/user.server.routes.tests.js
@@ -857,6 +857,7 @@ describe('User CRUD tests', function () {
 
     _user2.username = 'user2_username';
     _user2.email = 'user2_email@test.com';
+    _user2.emailTemporary = 'user2_email@test.com';
 
     var credentials2 = {
       username: 'username2',


### PR DESCRIPTION
Otherwise the `_user2.emailTemporary` equals `_user1.emailTemporary`.

Then in [`users.update`, the user2 matches and can be returned](https://github.com/Trustroots/trustroots/blob/master/modules/users/server/controllers/users/users.profile.server.controller.js#L294-L299), the [check on line 303](https://github.com/Trustroots/trustroots/blob/master/modules/users/server/controllers/users/users.profile.server.controller.js#L303) passes and the test fails with [`Error: expected 403 "Forbidden", got 200 "OK"`](https://travis-ci.org/mrkvon/trustroots/builds/166139128).