### PR TITLE
user reply rate [finished, abandoned]

### DIFF
--- a/config/lib/worker.js
+++ b/config/lib/worker.js
@@ -28,10 +28,25 @@ exports.start = function(options, callback) {
       require(path.resolve('./modules/statistics/server/jobs/daily-statistics.server.job'))
     );
 
+    agenda.define(
+      'update reply rate',
+      { lockLifetime: 10000 },
+      require(path.resolve('./modules/users/server/jobs/reply-rate.server.jobs'))
+        .updateUser
+    );
+
+    agenda.define(
+      'update expired reply rates',
+      { lockLifetime: 10000 },
+      require(path.resolve('./modules/users/server/jobs/reply-rate.server.jobs'))
+        .updateExpiredUsers
+    );
+
     // Schedule job(s)
 
     agenda.every('5 minutes', 'check unread messages');
     agenda.every('24 hours', 'daily statistics');
+    agenda.every('24 hours', 'update expired reply rates');
 
 
     // Start worker

--- a/modules/core/tests/server/worker.tests.js
+++ b/modules/core/tests/server/worker.tests.js
@@ -145,8 +145,18 @@ describe('Worker tests', function() {
     jobNames.should.containEql('daily statistics');
   });
 
-  it('defines two repeating jobs', function() {
-    scheduledJobs.length.should.equal(2);
+  it('defines [update reply rate] job', function() {
+    var jobNames = _.map(definedJobs, 'name');
+    jobNames.should.containEql('update reply rate');
+  });
+
+  it('defines [update expired reply rates] job', function() {
+    var jobNames = _.map(definedJobs, 'name');
+    jobNames.should.containEql('update expired reply rates');
+  });
+
+  it('defines three repeating jobs', function() {
+    scheduledJobs.length.should.equal(3);
   });
 
   it('only schedules defined jobs', function() {

--- a/modules/messages/server/controllers/messages.server.controller.js
+++ b/modules/messages/server/controllers/messages.server.controller.js
@@ -17,7 +17,8 @@ var _ = require('lodash'),
     agenda = require(path.resolve('./config/lib/agenda')),
     Message = mongoose.model('Message'),
     Thread = mongoose.model('Thread'),
-    User = mongoose.model('User');
+    User = mongoose.model('User'),
+    ObjectId = mongoose.Types.ObjectId;
 
 
 /**
@@ -308,17 +309,26 @@ exports.send = function(req, res) {
           res.json(message);
 
           // ...and run agenda job to update sender and receiver reply rates
-          // naive, no check whether it is necessary
-          // TODO maybe check if the message is first or first reply in thread
-          // if first, update only receiver
-          // if first reply, update only sender
-          agenda.now('update reply rate',
-            { userId: String(message.userFrom._id) });
-          // we schedule updating reply rate of receiver later
-          // give the receiver opportunity to reply fast
-          // without her reply rate going down
-          agenda.schedule('in 6 hours', 'update reply rate',
-            { userId: String(message.userTo._id) });
+          //
+          // find out which is the position of the message
+          exports.positionInThread(message, function (err, position) {
+            switch (position) {
+              case 'first':
+                // if first, update only receiver
+                // we schedule updating reply rate of receiver later
+                // give the receiver opportunity to reply fast
+                // without her reply rate going down
+                agenda.schedule('in 6 hours', 'update reply rate',
+                  { userId: String(message.userTo._id) });
+                break;
+              case 'firstReply':
+                // if first reply, update only sender
+                agenda.now('update reply rate',
+                  { userId: String(message.userFrom._id) });
+                break;
+              default:
+            }
+          });
 
           return;
         });
@@ -335,6 +345,81 @@ exports.send = function(req, res) {
 
 };
 
+/**
+ * @callback positionCallback
+ *
+ * @param {Error}
+ * @param {String} position - one of ['first', 'firstReply', 'other']
+ * @param {Number} [replyTime] - only if position === 'firstReply'; milliseconds
+ */
+
+/**
+ * Find out what is the position of the message within it's thread
+ * Possible return values: 'first', 'firstReply', 'other'
+ * and replyTime in milliseconds when it is firstReply
+ *
+ * asynchronous
+ * @param {MongooseObject} message
+ * @param {positionCallback} callback
+ */
+exports.positionInThread = function (message, callback) {
+  // get basic info about the message;
+  var userFrom = String(message.userFrom._id || message.userFrom);
+  var userTo = String(message.userTo._id || message.userTo);
+  var messageId = String(message._id);
+
+  // find the oldest messages of the thread in both ways
+  async.parallel([
+
+    function findOneWayOldestMessage(done) {
+      Message
+        .findOne({
+          userFrom: new ObjectId(userFrom),
+          userTo: new ObjectId(userTo)
+        })
+        .sort({ created: 1 })
+        .exec(done);
+    },
+
+    function findOtherWayOldestMessage(done) {
+      Message
+        .findOne({
+          userFrom: new ObjectId(userTo),
+          userTo: new ObjectId(userFrom)
+        })
+        .sort({ created: 1 })
+        .exec(done);
+    }
+  ], function (err, results) {
+    // both messages as objects or null
+    var oneWay = results[0] && results[0].toObject(); // returns null or object
+    var otherWay = results[1] && results[1].toObject(); // returns null or obj.
+
+    // oneWay should always be found
+    if (!oneWay) return callback(new Error('Provided message doesn\'t exist'));
+
+    // message === oneWay?
+    var oneWayIsThis = String(oneWay._id) === messageId;
+
+    if (oneWayIsThis) {
+      // the older of [oneWay, otherWay] is first, newer is firstReply
+      var oneWayIsLater = Boolean(otherWay) && otherWay.created < oneWay.created;
+      if (oneWayIsLater) {
+
+        // our message is the newer one
+        var replyTime = oneWay.created.getTime() - otherWay.created.getTime();
+        return callback(null, 'firstReply', replyTime);
+
+      } else {
+        // our message is the older one or the only one of the two
+        return callback(null, 'first');
+      }
+    } else {
+      // the message is later
+      return callback(null, 'other');
+    }
+  });
+};
 
 /**
  * Thread of messages

--- a/modules/messages/server/controllers/messages.server.controller.js
+++ b/modules/messages/server/controllers/messages.server.controller.js
@@ -319,12 +319,12 @@ exports.send = function(req, res) {
                 // give the receiver opportunity to reply fast
                 // without her reply rate going down
                 agenda.schedule('in 6 hours', 'update reply rate',
-                  { userId: String(message.userTo._id) });
+                  { userId: String(message.userTo._id) }, function () {});
                 break;
               case 'firstReply':
                 // if first reply, update only sender
                 agenda.now('update reply rate',
-                  { userId: String(message.userFrom._id) });
+                  { userId: String(message.userFrom._id) }, function () {});
                 break;
               default:
             }

--- a/modules/messages/tests/server/message-position.server.controller.tests.js
+++ b/modules/messages/tests/server/message-position.server.controller.tests.js
@@ -1,0 +1,176 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+var mongoose = require('mongoose'),
+    path = require('path'),
+    _ = require('lodash'),
+    async = require('async'),
+    User = mongoose.model('User'),
+    Message = mongoose.model('Message'),
+    messageController = require(path.resolve(
+      './modules/messages/server/controllers/messages.server.controller'));
+
+
+require('should');
+
+describe('function messageController.positionInThread', function () {
+
+  // Before every test we create 2 users
+  var users = [];
+  var userData = function (no) {
+    return {
+      firstName: 'Full',
+      lastName: 'Name',
+      displayName: 'Full Name',
+      email: 'user' + no + '@test.com',
+      username: 'username' + no,
+      password: 'password123',
+      provider: 'local'
+    };
+  };
+
+  beforeEach(function(done) {
+    users = [];
+    async.eachSeries([0, 1],
+      function (userNo, callback) {
+        var user = new User(userData(userNo));
+        users.push(user);
+        user.save(callback);
+      }, done);
+  });
+
+  // After each test removing all the messages and users
+  afterEach(function(done) {
+    Message.remove().exec(function() {
+      User.remove().exec(done);
+    });
+  });
+
+  // Reusables in different Contexts
+  // reused function to create messages
+  function messageData(stub) {
+    return {
+      userFrom: users[stub[0]]._id,
+      userTo: users[stub[1]]._id,
+      content: _.repeat('.', 50),
+      created: stub[2] || new Date()
+    };
+  }
+  // a day in milliseconds
+  var day = 24 * 3600 * 1000;
+
+  context('only one way messages', function () {
+    var messages;
+
+    // here we create some messages
+    // messageData - array of messages: [userFromNo, userToNo, created]
+    var messageDataStubs = [
+      [0, 1, new Date(Date.now() - 3 * day)],
+      [0, 1, new Date(Date.now() - 2 * day)],
+      [0, 1, new Date(Date.now() - 1 * day)]
+    ];
+
+    beforeEach(function (done) {
+      messages = [];
+      // saving the messages to mongoDB
+      async.eachSeries(messageDataStubs,
+        function (messageStub, callback) {
+          var message = new Message(messageData(messageStub));
+          messages.push(message);
+          message.save(callback);
+        }, done);
+    });
+
+    it('[first message] should say `first`', function (done) {
+      messageController.positionInThread(messages[0], function (err, resp) {
+        if (err) return done(err);
+
+        try {
+          resp.should.equal('first');
+          return done();
+        } catch (e) {
+          return done(e);
+        }
+      });
+    });
+
+    it('[other message] should say `other`', function (done) {
+      messageController.positionInThread(messages[2], function (err, resp) {
+        if (err) return done(err);
+
+        try {
+          resp.should.equal('other');
+          return done();
+        } catch (e) {
+          return done(e);
+        }
+      });
+    });
+  });
+
+  context('both way messages', function () {
+    var messages;
+
+    // here we create some messages
+    // messageData - array of messages: [userFromNo, userToNo, created]
+    var messageDataStubs = [
+      [0, 1, new Date(Date.now() - 3 * day)],
+      [0, 1, new Date(Date.now() - 2 * day)],
+      [1, 0, new Date(Date.now() - 1 * day)],
+      [1, 0, new Date(Date.now() - 0.5 * day)]
+    ];
+
+    beforeEach(function (done) {
+      messages = [];
+      // saving the messages to mongoDB
+      async.eachSeries(messageDataStubs,
+        function (messageStub, callback) {
+          var message = new Message(messageData(messageStub));
+          messages.push(message);
+          message.save(callback);
+        }, done);
+    });
+
+    it('[first message] should say `first`', function (done) {
+      messageController.positionInThread(messages[0], function (err, resp) {
+        if (err) return done(err);
+
+        try {
+          resp.should.equal('first');
+          return done();
+        } catch (e) {
+          return done(e);
+        }
+      });
+    });
+
+    it('[first reply] should say `firstReply`', function (done) {
+      messageController.positionInThread(messages[2], function (err, resp, replyTime) {
+        if (err) return done(err);
+
+        try {
+          resp.should.equal('firstReply');
+          replyTime.should.be.approximately(2 * day, 1000);
+          return done();
+        } catch (e) {
+          return done(e);
+        }
+      });
+    });
+
+    it('[other message] should say `other`', function (done) {
+      messageController.positionInThread(messages[3], function (err, resp) {
+        if (err) return done(err);
+
+        try {
+          resp.should.equal('other');
+          return done();
+        } catch (e) {
+          return done(e);
+        }
+      });
+    });
+  });
+});

--- a/modules/users/client/views/profile/profile-view-basics.client.view.html
+++ b/modules/users/client/views/profile/profile-view-basics.client.view.html
@@ -15,6 +15,16 @@
       <span ng-if="profileCtrl.profile.gender" ng-class="{ 'text-capitalize': !profileCtrl.profile.birthdate }">{{ profileCtrl.profile.gender }}.</span>
     </div>
 
+    <!-- Reply Rate -->
+    <div class="profile-sidebar-section" ng-if="::(profileCtrl.profile.replyRate || profileCtrl.profile.replyTime)">
+      <span ng-if="::profileCtrl.profile.replyRate">
+        Replied to {{ ::profileCtrl.profile.replyRate }}
+      </span>
+      <span ng-if="::profileCtrl.profile.replyTime">
+        in {{ ::profileCtrl.profile.replyTime }} on average
+      </span>
+    </div>
+
     <div class="profile-sidebar-section">
       Member since <time ng-bind="profileCtrl.profile.created | date:'mediumDate'"></time>
     </div>

--- a/modules/users/server/controllers/user-reply-rate.server.controller.js
+++ b/modules/users/server/controllers/user-reply-rate.server.controller.js
@@ -1,0 +1,269 @@
+'use strict';
+/**
+ * Module dependencies.
+ */
+var path = require('path'),
+    async = require('async'),
+    mongoose = require('mongoose');
+
+require(path.resolve('./modules/messages/server/models/message.server.model'));
+
+var Message = mongoose.model('Message');
+var ObjectId = mongoose.Types.ObjectId;
+
+/**
+ * A callback for the asynchronous module.exports.read
+ *
+ * @callback readCallback
+ * @param {error} error
+ * @param {Object} result
+ * @param {string} result.replyRate - user's reply rate in %
+ * @param {string} result.replyTime - user's average reply time described
+ */
+
+/**
+ * (asynchronous)
+ * Read from database and process the replyRate of user with userId
+ *
+ * @param {string|ObjectId} userId - id of user to get the replyRate from
+ * @param {readCallback} callback - result is object with parameters replyRate
+ * and replyTime
+ */
+module.exports.read = function (userId, callback) {
+  module.exports.readFromDatabase(new ObjectId(userId), function (err, result) {
+    if (err) {
+      return callback(err);
+    }
+
+    var processed = module.exports.process(result);
+    return callback(null, processed);
+  });
+};
+
+/**
+ * A callback for the asynchronous module.exports.readFromDatabase
+ *
+ * @callback readFromDatabaseCallback
+ * @param {error} error
+ * @param {Object} result
+ * @param {number} result.replied - amount of user's replied threads
+ * @param {number} result.notReplied - amount of user's unreplied threads
+ * @param {number|null} result.replyTime - average reply time of user in ms,
+ * null when result.replied === 0
+ */
+
+/**
+ * (asynchronous)
+ * Read amount of replied threads, not replied threads and average reply time
+ * of user with userId
+ *
+ * @param {string|ObjectId} userId - id of user to get the replyRate from
+ * @param {readFromDatabaseCallback} callback
+ */
+module.exports.readFromDatabase = function (userId, callback) {
+  async.waterfall([
+    function (done) {
+      // we want to get amount of replied and notReplied threads, and average
+      // replyTime of user with userId which she didn't start and which were
+      // started more than 6 months ago (approximated to 180 days)
+      Message.aggregate([
+        // match all the messages which user either sent or received
+        {
+          $match: {
+            $or: [
+              { userFrom: userId },
+              { userTo: userId }
+            ]
+          }
+        },
+        // sort from oldest to newest
+        {
+          $sort: { created: 1 }
+        },
+        // group messages into the threads
+        // note whether our user was sender (fromMe = true)
+        {
+          $group: {
+            _id: { $cond: [
+              { $eq: ['$userFrom', userId] },
+              '$userTo',
+              '$userFrom'
+            ] },
+            messages: {
+              $push: {
+                fromMe: { $cond: [
+                  { $eq: ['$userFrom', userId] },
+                  true,
+                  false
+                ] },
+                created: '$created'
+              }
+            }
+          }
+        },
+        // keep only threads which user didn't start
+        // keep only threads started less than 180 days ago
+        {
+          $match: {
+            'messages.0.fromMe': false,
+            'messages.0.created': {
+              $gt: new Date(Date.now() - 180 * 24 * 3600 * 1000)
+            }
+          }
+        },
+        // rename _id => id
+        {
+          $project: {
+            messages: 1,
+            id: '$_id',
+            _id: 0
+          }
+        },
+        // release messages from the threads
+        {
+          $unwind: '$messages'
+        },
+        // sort from oldest to newest
+        {
+          $sort: { created: 1 }
+        },
+        // group messages into groups separated by thread and whether sent or
+        // received
+        {
+          $group: {
+            _id: { id: '$id', fromMe: '$messages.fromMe' },
+            messages: { $push: '$messages.created' }
+          }
+        },
+        // keep only the oldest message of each group and rename stuff
+        {
+          $project: {
+            id: '$_id.id',
+            _id: 0,
+            fromMe: '$_id.fromMe',
+            created: { $arrayElemAt: ['$messages', 0] }
+          }
+        },
+        // sort from oldest created
+        {
+          $sort: { created: 1 }
+        },
+        // group by threads
+        {
+          $group: {
+            _id: '$id',
+            messages: {
+              $push: '$created'
+            }
+          }
+        },
+        // count replyTime = oldest reply created - oldest first message created
+        // or replyTime is 0 when no reply
+        // count replied === 1 when not responded (only oldest received message)
+        // count replied === 2 when responded (both oldest received & sent
+        // messages are present)
+        {
+          $project: {
+            _id: 0,
+            replied: { $size: '$messages' },
+            replyTime: { $cond: [
+              { $eq: [{ $size: '$messages' }, 2] },
+              { $subtract: [
+                { $arrayElemAt: ['$messages', 1] },
+                { $arrayElemAt: ['$messages', 0] }
+              ] },
+              0
+            ] }
+          }
+        },
+        // group by `replied` (1 for notResponded, 2 for responded)
+        // count average reply time of responded threads
+        // count amount of responded & non-responded threads by user
+        {
+          $group: {
+            _id: '$replied',
+            replyTime: { $avg: '$replyTime' },
+            count: { $sum: 1 }
+          }
+        }
+      ])
+      .exec(done); // end of the query
+      // returned array of 0-2 objects { id: (1| 2), replyTime: (0| ms), count:
+      // number }
+    },
+
+    function (resp, done) {
+      // the data about replied threads from query
+      var repliedOutput = resp.find(function (elem) {
+        return elem._id === 2;
+      });
+      // the data about notReplied threads from query
+      var notRepliedOutput = resp.find(function (elem) {
+        return elem._id === 1;
+      });
+
+      // fetch the reply-rate values from query data
+      var replied = repliedOutput ? repliedOutput.count : 0;
+      var notReplied = notRepliedOutput ? notRepliedOutput.count : 0;
+      var replyTime = repliedOutput ? repliedOutput.replyTime : null;
+
+      // return values
+      return done(null, {
+        replied: replied,
+        notReplied: notReplied,
+        replyTime: replyTime
+      });
+    }
+  ], callback);
+};
+
+/**
+ * @typedef {Object} ReplyData
+ * @property {string} replyRate - Reply rate of user for display. Empty string
+ * when no threads received by the user
+ * @property {string} replyTime - Average reply time of user for display. Empty
+ * string if no received threads replied
+ */
+
+/**
+ * (synchronous)
+ * process the data from module.exports.readFromDatabase to readable replyRate
+ * and replyTime
+ *
+ * @param {Object} data
+ * @param {number} data.replied - # of replied threads
+ * @param {number} data.notReplied - # of not replied threads
+ * @param {number|null} data.replyTime - average reply time
+ * @returns {ReplyData} replyRate and replyTime for display
+ */
+module.exports.process = function (data) {
+  // replyRate in % or empty string when not countable
+  var replyRate = data.replied + data.notReplied > 0
+    ? Math.round(data.replied * 100 / (data.replied + data.notReplied)) + '%'
+    : '';
+
+  // length of a day in milliseconds
+  var day = 24 * 3600 * 1000;
+
+  var replyTime;
+
+  // generate the approximate average replyTime described by words
+  if (data.replyTime === null) { // not available
+    replyTime = '';
+  } else if (data.replyTime < day) { // less than a day
+    replyTime = 'less than a day';
+  } else if (data.replyTime < 7 * day) { // 1 - 7 days
+    var dayCount = Math.round(data.replyTime / day);
+    replyTime = dayCount + ' day' + (dayCount > 1 ? 's' : ''); // '# days'
+  } else if (data.replyTime < 32 * day) { // 7 days - 1 month
+    var weekCount = Math.round(data.replyTime / (7 * day));
+    replyTime = weekCount + ' week' + (weekCount > 1 ? 's' : ''); // '# weeks'
+  } else {
+    replyTime = 'more than a month';
+  }
+
+  return {
+    replyRate: replyRate,
+    replyTime: replyTime
+  };
+};

--- a/modules/users/server/controllers/users/users.profile.server.controller.js
+++ b/modules/users/server/controllers/users/users.profile.server.controller.js
@@ -571,7 +571,7 @@ exports.userByUsername = function(req, res, next, username) {
         });
     },
 
-    // Sanitize and return profile
+    // Sanitize & return profile
     function(profile) {
       req.profile = exports.sanitizeProfile(profile, req.user);
       return next();

--- a/modules/users/server/controllers/users/users.profile.server.controller.js
+++ b/modules/users/server/controllers/users/users.profile.server.controller.js
@@ -60,7 +60,8 @@ exports.userProfileFields = [
   'additionalProvidersData.twitter.screen_name', // For Twitter profile links
   'additionalProvidersData.github.login', // For GitHub profile links
   'replyRate',
-  'replyTime'
+  'replyTime',
+  'medianReplyTime'
 ].join(' ');
 
 // Restricted set of profile fields when only really "miniprofile" is needed
@@ -365,6 +366,7 @@ exports.update = function(req, res) {
       delete req.body.additionalProvidersData;
       delete req.body.replyRate;
       delete req.body.replyTime;
+      delete req.body.medianReplyTime;
       delete req.body.replyExpire;
 
       // Merge existing user
@@ -621,16 +623,19 @@ exports.sanitizeProfile = function(profile, authenticatedUser) {
     });
   }
 
-  // Convert replyRate and replyTime to output format
+  // Convert replyRate, medianReplyTime and replyTime to output format
   var replyStats = userReplyRate.display({
     replyRate: profile.replyRate,
-    replyTime: profile.replyTime
+    replyTime: profile.replyTime,
+    medianReplyTime: profile.medianReplyTime
   });
   delete profile.replyRate;
   delete profile.replyTime;
+  delete profile.medianReplyTime;
   delete profile.replyExpire;
   profile.replyRate = replyStats.replyRate;
   profile.replyTime = replyStats.replyTime;
+  profile.medianReplyTime = replyStats.medianReplyTime;
 
   // Profile does not belong to currently authenticated user
   // Remove data we don't need from other member's profile

--- a/modules/users/server/controllers/users/users.profile.server.controller.js
+++ b/modules/users/server/controllers/users/users.profile.server.controller.js
@@ -10,6 +10,8 @@ var _ = require('lodash'),
     tribesHandler = require(path.resolve('./modules/tags/server/controllers/tribes.server.controller')),
     tagsHandler = require(path.resolve('./modules/tags/server/controllers/tags.server.controller')),
     emailService = require(path.resolve('./modules/core/server/services/email.server.service')),
+    userReplyRate =
+  require(path.resolve('./modules/users/server/controllers/user-reply-rate.server.controller')),
     config = require(path.resolve('./config/config')),
     async = require('async'),
     crypto = require('crypto'),
@@ -564,9 +566,27 @@ exports.userByUsername = function(req, res, next, username) {
         });
     },
 
-    // Sanitize & return profile
+    // Sanitize profile
+    function(profile, done) {
+      profile = exports.sanitizeProfile(profile, req.user);
+      return done(null, profile);
+    },
+
+    // Add replyRate and replyTime to profile
+    function(profile, done) {
+      userReplyRate.read(profile._id, function (err, result) {
+        if (err) return done(err);
+
+        profile.replyRate = result.replyRate;
+        profile.replyTime = result.replyTime;
+
+        return done(null, profile);
+      });
+    },
+
+    // Return profile
     function(profile) {
-      req.profile = exports.sanitizeProfile(profile, req.user);
+      req.profile = profile;
       return next();
     }
 

--- a/modules/users/server/jobs/reply-rate.server.jobs.js
+++ b/modules/users/server/jobs/reply-rate.server.jobs.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var path = require('path'),
+    replyRateController =
+  require(path.resolve('./modules/users/server/controllers/user-reply-rate.server.controller')),
+    updateUserReplyRate = replyRateController.updateUserReplyRate,
+    updateExpiredReplyRates = replyRateController.updateExpiredReplyRates;
+
+exports.updateUser = function (job, done) {
+  var data = job.attrs.data;
+  var userId = data.userId;
+
+  updateUserReplyRate(userId, function (err) {
+    if (err) {
+      return done(err);
+    }
+    return done();
+  });
+};
+
+exports.updateExpiredUsers = function (job, done) {
+  updateExpiredReplyRates(function (err) {
+    if (err) {
+      return done(err);
+    }
+    return done();
+  });
+};

--- a/modules/users/server/models/user.server.model.js
+++ b/modules/users/server/models/user.server.model.js
@@ -246,6 +246,18 @@ var UserSchema = new Schema({
   /* Tags & Tribes user is member of */
   member: {
     type: [UserMemberSchema]
+  },
+  replyRate: {
+    type: Number,
+    default: null
+  },
+  replyTime: {
+    type: Number,
+    default: null
+  },
+  replyExpire: {
+    type: Date,
+    default: null
   }
 });
 

--- a/modules/users/server/models/user.server.model.js
+++ b/modules/users/server/models/user.server.model.js
@@ -255,6 +255,10 @@ var UserSchema = new Schema({
     type: Number,
     default: null
   },
+  medianReplyTime: {
+    type: Number,
+    default: null
+  },
   replyExpire: {
     type: Date,
     default: null

--- a/modules/users/tests/server/user-reply-rate.server.controller.tests.js
+++ b/modules/users/tests/server/user-reply-rate.server.controller.tests.js
@@ -1,0 +1,210 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+var mongoose = require('mongoose'),
+    path = require('path'),
+    _ = require('lodash'),
+    async = require('async'),
+    User = mongoose.model('User'),
+    Message = mongoose.model('Message'),
+    replyRateModule =
+  require(path.resolve('./modules/users/server/controllers/user-reply-rate.server.controller'));
+require('should');
+
+/**
+ * Unit tests
+ */
+describe('Reply Rate and Time Unit Test', function () {
+
+  // here we create the users
+  var users = [];
+  var userData = function (no) {
+    return {
+      firstName: 'Full',
+      lastName: 'Name',
+      displayName: 'Full Name',
+      email: 'user' + no + '@test.com',
+      username: 'username' + no,
+      password: 'password123',
+      provider: 'local'
+    };
+  };
+  beforeEach(function(done) {
+    async.eachSeries([0, 1, 2, 3, 4, 5, 6, 7],
+      function (userNo, callback) {
+        var user = new User(userData(userNo));
+        users.push(user);
+        user.save(callback);
+      }, done);
+  });
+
+  // here we create some messages
+  var day = 24 * 3600 * 1000;
+  // messageData - array of messages: [userFromNo, userToNo, created]
+  var messageDataStubs = [
+    // general testing
+    [1, 0, new Date(Date.now() - 5 * day)],
+    [0, 1, new Date(Date.now() - 4 * day)],
+    [0, 1, new Date(Date.now() - 3.1 * day)],
+    [1, 0, new Date(Date.now() - 3 * day)],
+    [2, 0, new Date(Date.now() - 4 * day)],
+    [0, 2, new Date(Date.now() - 2 * day)],
+    [3, 0, new Date(Date.now() - 4 * day)],
+    [0, 3, new Date(Date.now() - 1 * day)],
+    [4, 0, new Date(Date.now() - 2 * day)],
+    // testing ignoring old threads
+    [2, 1, new Date(Date.now() - 179 * day)],
+    [1, 2, new Date(Date.now() - 10 * day)],
+    [3, 1, new Date(Date.now() - 181 * day)],
+    [1, 3, new Date(Date.now() - 1 * day)],
+    [4, 1, new Date(Date.now() - 179 * day)],
+    [5, 1, new Date(Date.now() - 181 * day)],
+    // testing ignoring threads started by user
+    [2, 3, new Date(Date.now() - 3 * day)],
+    [3, 2, new Date(Date.now() - 2 * day)],
+    [4, 2, new Date(Date.now() - 4 * day)],
+    [2, 4, new Date(Date.now() - 3 * day)],
+    [2, 5, new Date(Date.now() - 2 * day)],
+    // user 6 didn't receive anything
+    // user 7 doesn't respond anything
+    [6, 7, new Date(Date.now() - 1 * day)]
+  ];
+  var messageData = function (stub) {
+    return {
+      userFrom: users[stub[0]]._id,
+      userTo: users[stub[1]]._id,
+      content: _.repeat('.', 50),
+      created: stub[2] || new Date()
+    };
+  };
+  beforeEach(function (done) {
+    // saving the messages to mongoDB
+    async.eachSeries(messageDataStubs,
+      function (messageStub, callback) {
+        var message = new Message(messageData(messageStub));
+        message.save(callback);
+      }, done);
+  });
+
+  // after each test removing all the messages and users
+  afterEach(function(done) {
+    Message.remove().exec(function() {
+      User.remove().exec(done);
+    });
+  });
+
+  it('should return amount of replied and unreplied threads of user',
+    function (done) {
+      replyRateModule.readFromDatabase(users[0]._id, function (err, resp) {
+        if (err) return done(err);
+        try {
+          resp.should.have.property('replied', 3);
+          resp.should.have.property('notReplied', 1);
+          return done();
+        } catch (e) {
+          return done(e);
+        }
+      });
+    });
+
+  it('should return average replyTime of replied threads by user',
+    function (done) {
+      replyRateModule.readFromDatabase(users[0]._id, function (err, resp) {
+        if (err) return done(err);
+        try {
+          resp.should.have.property('replyTime');
+          (resp.replyTime).should.be.approximately(2 * day, 10);
+          return done();
+        } catch (e) {
+          return done(e);
+        }
+      });
+    });
+
+  it('should ignore threads started more than 180 days ago',
+    function (done) {
+      replyRateModule.readFromDatabase(users[1]._id, function (err, resp) {
+        if (err) return done(err);
+        try {
+          resp.should.have.property('replied', 1);
+          resp.should.have.property('notReplied', 1);
+          return done();
+        } catch (e) {
+          return done(e);
+        }
+      });
+    });
+
+  it('should ignore threads started by the user',
+    function (done) {
+      replyRateModule.readFromDatabase(users[2]._id, function (err, resp) {
+        if (err) return done(err);
+        try {
+          resp.should.have.property('replied', 1);
+          resp.should.have.property('notReplied', 0);
+          return done();
+        } catch (e) {
+          return done(e);
+        }
+      });
+    });
+
+  context('no new-enough threads to the user started', function () {
+    it('should show 0 replied and not replied',
+      function (done) {
+        replyRateModule.readFromDatabase(users[6]._id, function (err, resp) {
+          if (err) return done(err);
+          try {
+            resp.should.have.property('replied', 0);
+            resp.should.have.property('notReplied', 0);
+            return done();
+          } catch (e) {
+            return done(e);
+          }
+        });
+      });
+
+    it('should show null reply time',
+      function (done) {
+        replyRateModule.readFromDatabase(users[6]._id, function (err, resp) {
+          if (err) return done(err);
+          try {
+            resp.should.have.property('replyTime', null);
+            return done();
+          } catch (e) {
+            return done(e);
+          }
+        });
+      });
+  });
+
+  context('some threads to user started and user replied none', function () {
+    it('should show 0 replied and some not replied',
+      function (done) {
+        replyRateModule.readFromDatabase(users[7]._id, function (err, resp) {
+          if (err) return done(err);
+          try {
+            resp.should.have.property('replied', 0);
+            resp.should.have.property('notReplied', 1);
+            return done();
+          } catch (e) {
+            return done(e);
+          }
+        });
+      });
+    it('should show null reply time',
+      function (done) {
+        replyRateModule.readFromDatabase(users[7]._id, function (err, resp) {
+          if (err) return done(err);
+          try {
+            resp.should.have.property('replyTime', null);
+            return done();
+          } catch (e) {
+            return done(e);
+          }
+        });
+      });
+  });
+});

--- a/modules/users/tests/server/user-reply-rate.server.controller.tests.js
+++ b/modules/users/tests/server/user-reply-rate.server.controller.tests.js
@@ -56,14 +56,16 @@ describe('Reply Rate and Time Unit Test', function () {
     // messageData - array of messages: [userFromNo, userToNo, created]
     var messageDataStubs = [
       // general testing
+      // average replyTime = 2 days
+      // median replyTime = 2.6 days
       [1, 0, new Date(Date.now() - 5 * day)],
-      [0, 1, new Date(Date.now() - 4 * day)],
+      [0, 1, new Date(Date.now() - 4.3 * day)], // 0.7 day
       [0, 1, new Date(Date.now() - 3.1 * day)],
       [1, 0, new Date(Date.now() - 3 * day)],
-      [2, 0, new Date(Date.now() - 4 * day)],
-      [0, 2, new Date(Date.now() - 2 * day)],
+      [2, 0, new Date(Date.now() - 4.7 * day)],
+      [0, 2, new Date(Date.now() - 2 * day)], // 2.7 days
       [3, 0, new Date(Date.now() - 4 * day)],
-      [0, 3, new Date(Date.now() - 1 * day)],
+      [0, 3, new Date(Date.now() - 1.4 * day)], // 2.6 days
       [4, 0, new Date(Date.now() - 2 * day)],
       // testing ignoring old threads
       [2, 1, new Date(Date.now() - 179 * day)],
@@ -123,6 +125,20 @@ describe('Reply Rate and Time Unit Test', function () {
           try {
             resp.should.have.property('replyTime');
             (resp.replyTime).should.be.approximately(2 * day, 10);
+            return done();
+          } catch (e) {
+            return done(e);
+          }
+        });
+      });
+
+    it('should return median replyTime of replied threads by user',
+      function (done) {
+        replyRateModule.readFromDatabase(users[0]._id, function (err, resp) {
+          if (err) return done(err);
+          try {
+            resp.should.have.property('medianReplyTime');
+            (resp.medianReplyTime).should.be.approximately(2.6 * day, 10);
             return done();
           } catch (e) {
             return done(e);
@@ -236,13 +252,13 @@ describe('Reply Rate and Time Unit Test', function () {
     // messageData - array of messages: [userFromNo, userToNo, created]
     var messageDataStubs = [
       [1, 0, new Date(Date.now() - 5 * day)],
-      [0, 1, new Date(Date.now() - 4 * day)],
+      [0, 1, new Date(Date.now() - 4.3 * day)],
       [0, 1, new Date(Date.now() - 3.1 * day)],
       [1, 0, new Date(Date.now() - 3 * day)],
-      [2, 0, new Date(Date.now() - 4 * day)],
+      [2, 0, new Date(Date.now() - 4.7 * day)],
       [0, 2, new Date(Date.now() - 2 * day)],
       [3, 0, new Date(Date.now() - 4 * day)],
-      [0, 3, new Date(Date.now() - 1 * day)],
+      [0, 3, new Date(Date.now() - 1.4 * day)],
       [4, 0, new Date(Date.now() - 2 * day)],
       // testing old message
       [5, 1, new Date(Date.now() - 179.5 * day)],
@@ -272,7 +288,7 @@ describe('Reply Rate and Time Unit Test', function () {
         }, done);
     });
 
-    it('should return user profile with replyRate, replyTime, replyExpire',
+    it('should return user profile with replyRate, replyTime, medianReplyTime, replyExpire',
       function (done) {
         replyRateModule.updateUserReplyRate(users[0]._id, function (err, resp) {
           if (err) return done(err);
@@ -280,6 +296,8 @@ describe('Reply Rate and Time Unit Test', function () {
             resp.should.have.property('replyRate', 0.75);
             resp.should.have.property('replyTime');
             (resp.replyTime).should.be.approximately(2 * day, 10);
+            resp.should.have.property('medianReplyTime');
+            (resp.medianReplyTime).should.be.approximately(2.6 * day, 10);
             resp.should.have.property('replyExpire',
               new Date(oldestMessageCreated.getTime() + 180 * day));
             return done();
@@ -376,10 +394,12 @@ describe('Reply Rate and Time Unit Test', function () {
     it('[reply rate] should return data as expected', function () {
       var output = replyRateModule.display({
         replyRate: 0.3371,
-        replyTime: 7 * 24 * 3600 * 1000 + 7549
+        replyTime: 7 * 24 * 3600 * 1000 + 7549,
+        medianReplyTime: 5 * 24 * 3600 * 1000 - 3312
       });
       output.should.have.property('replyRate', '34%');
       output.should.have.property('replyTime', '1 week');
+      output.should.have.property('medianReplyTime', '5 days');
     });
   });
 });

--- a/modules/users/tests/server/user-reply-rate.server.controller.tests.js
+++ b/modules/users/tests/server/user-reply-rate.server.controller.tests.js
@@ -18,7 +18,7 @@ require('should');
  */
 describe('Reply Rate and Time Unit Test', function () {
 
-  // here we create the users
+  // Before every test we create 8 users username0 - username7
   var users = [];
   var userData = function (no) {
     return {
@@ -31,7 +31,9 @@ describe('Reply Rate and Time Unit Test', function () {
       provider: 'local'
     };
   };
+
   beforeEach(function(done) {
+    users = [];
     async.eachSeries([0, 1, 2, 3, 4, 5, 6, 7],
       function (userNo, callback) {
         var user = new User(userData(userNo));
@@ -40,124 +42,127 @@ describe('Reply Rate and Time Unit Test', function () {
       }, done);
   });
 
-  // here we create some messages
-  var day = 24 * 3600 * 1000;
-  // messageData - array of messages: [userFromNo, userToNo, created]
-  var messageDataStubs = [
-    // general testing
-    [1, 0, new Date(Date.now() - 5 * day)],
-    [0, 1, new Date(Date.now() - 4 * day)],
-    [0, 1, new Date(Date.now() - 3.1 * day)],
-    [1, 0, new Date(Date.now() - 3 * day)],
-    [2, 0, new Date(Date.now() - 4 * day)],
-    [0, 2, new Date(Date.now() - 2 * day)],
-    [3, 0, new Date(Date.now() - 4 * day)],
-    [0, 3, new Date(Date.now() - 1 * day)],
-    [4, 0, new Date(Date.now() - 2 * day)],
-    // testing ignoring old threads
-    [2, 1, new Date(Date.now() - 179 * day)],
-    [1, 2, new Date(Date.now() - 10 * day)],
-    [3, 1, new Date(Date.now() - 181 * day)],
-    [1, 3, new Date(Date.now() - 1 * day)],
-    [4, 1, new Date(Date.now() - 179 * day)],
-    [5, 1, new Date(Date.now() - 181 * day)],
-    // testing ignoring threads started by user
-    [2, 3, new Date(Date.now() - 3 * day)],
-    [3, 2, new Date(Date.now() - 2 * day)],
-    [4, 2, new Date(Date.now() - 4 * day)],
-    [2, 4, new Date(Date.now() - 3 * day)],
-    [2, 5, new Date(Date.now() - 2 * day)],
-    // user 6 didn't receive anything
-    // user 7 doesn't respond anything
-    [6, 7, new Date(Date.now() - 1 * day)]
-  ];
-  var messageData = function (stub) {
-    return {
-      userFrom: users[stub[0]]._id,
-      userTo: users[stub[1]]._id,
-      content: _.repeat('.', 50),
-      created: stub[2] || new Date()
-    };
-  };
-  beforeEach(function (done) {
-    // saving the messages to mongoDB
-    async.eachSeries(messageDataStubs,
-      function (messageStub, callback) {
-        var message = new Message(messageData(messageStub));
-        message.save(callback);
-      }, done);
-  });
-
-  // after each test removing all the messages and users
+  // After each test removing all the messages and users
   afterEach(function(done) {
     Message.remove().exec(function() {
       User.remove().exec(done);
     });
   });
 
-  it('should return amount of replied and unreplied threads of user',
-    function (done) {
-      replyRateModule.readFromDatabase(users[0]._id, function (err, resp) {
-        if (err) return done(err);
-        try {
-          resp.should.have.property('replied', 3);
-          resp.should.have.property('notReplied', 1);
-          return done();
-        } catch (e) {
-          return done(e);
-        }
-      });
+  describe('replyRateModule.readFromDatabase', function () {
+
+    // here we create some messages
+    var day = 24 * 3600 * 1000;
+    // messageData - array of messages: [userFromNo, userToNo, created]
+    var messageDataStubs = [
+      // general testing
+      [1, 0, new Date(Date.now() - 5 * day)],
+      [0, 1, new Date(Date.now() - 4 * day)],
+      [0, 1, new Date(Date.now() - 3.1 * day)],
+      [1, 0, new Date(Date.now() - 3 * day)],
+      [2, 0, new Date(Date.now() - 4 * day)],
+      [0, 2, new Date(Date.now() - 2 * day)],
+      [3, 0, new Date(Date.now() - 4 * day)],
+      [0, 3, new Date(Date.now() - 1 * day)],
+      [4, 0, new Date(Date.now() - 2 * day)],
+      // testing ignoring old threads
+      [2, 1, new Date(Date.now() - 179 * day)],
+      [1, 2, new Date(Date.now() - 10 * day)],
+      [3, 1, new Date(Date.now() - 181 * day)],
+      [1, 3, new Date(Date.now() - 1 * day)],
+      [4, 1, new Date(Date.now() - 179 * day)],
+      [5, 1, new Date(Date.now() - 181 * day)],
+      // testing ignoring threads started by user
+      [2, 3, new Date(Date.now() - 3 * day)],
+      [3, 2, new Date(Date.now() - 2 * day)],
+      [4, 2, new Date(Date.now() - 4 * day)],
+      [2, 4, new Date(Date.now() - 3 * day)],
+      [2, 5, new Date(Date.now() - 2 * day)],
+      // user 6 didn't receive anything
+      // user 7 doesn't respond anything
+      [6, 7, new Date(Date.now() - 1 * day)]
+    ];
+
+    var oldestMessageCreated = messageDataStubs[0][2];
+
+    var messageData = function (stub) {
+      return {
+        userFrom: users[stub[0]]._id,
+        userTo: users[stub[1]]._id,
+        content: _.repeat('.', 50),
+        created: stub[2] || new Date()
+      };
+    };
+    beforeEach(function (done) {
+      // saving the messages to mongoDB
+      async.eachSeries(messageDataStubs,
+        function (messageStub, callback) {
+          var message = new Message(messageData(messageStub));
+          message.save(callback);
+        }, done);
     });
 
-  it('should return average replyTime of replied threads by user',
-    function (done) {
-      replyRateModule.readFromDatabase(users[0]._id, function (err, resp) {
-        if (err) return done(err);
-        try {
-          resp.should.have.property('replyTime');
-          (resp.replyTime).should.be.approximately(2 * day, 10);
-          return done();
-        } catch (e) {
-          return done(e);
-        }
-      });
-    });
-
-  it('should ignore threads started more than 180 days ago',
-    function (done) {
-      replyRateModule.readFromDatabase(users[1]._id, function (err, resp) {
-        if (err) return done(err);
-        try {
-          resp.should.have.property('replied', 1);
-          resp.should.have.property('notReplied', 1);
-          return done();
-        } catch (e) {
-          return done(e);
-        }
-      });
-    });
-
-  it('should ignore threads started by the user',
-    function (done) {
-      replyRateModule.readFromDatabase(users[2]._id, function (err, resp) {
-        if (err) return done(err);
-        try {
-          resp.should.have.property('replied', 1);
-          resp.should.have.property('notReplied', 0);
-          return done();
-        } catch (e) {
-          return done(e);
-        }
-      });
-    });
-
-  context('no new-enough threads to the user started', function () {
-    it('should show 0 replied and not replied',
+    it('should return amount of replied and unreplied threads of user',
       function (done) {
-        replyRateModule.readFromDatabase(users[6]._id, function (err, resp) {
+        replyRateModule.readFromDatabase(users[0]._id, function (err, resp) {
           if (err) return done(err);
           try {
-            resp.should.have.property('replied', 0);
+            resp.should.have.property('replied', 3);
+            resp.should.have.property('notReplied', 1);
+            return done();
+          } catch (e) {
+            return done(e);
+          }
+        });
+      });
+
+    it('should return average replyTime of replied threads by user',
+      function (done) {
+        replyRateModule.readFromDatabase(users[0]._id, function (err, resp) {
+          if (err) return done(err);
+          try {
+            resp.should.have.property('replyTime');
+            (resp.replyTime).should.be.approximately(2 * day, 10);
+            return done();
+          } catch (e) {
+            return done(e);
+          }
+        });
+      });
+
+    it('should return creation time of the oldest thread (counting expire date)',
+      function (done) {
+        replyRateModule.readFromDatabase(users[0]._id, function (err, resp) {
+          if (err) return done(err);
+          try {
+            resp.should.have.property('oldest', oldestMessageCreated);
+            return done();
+          } catch (e) {
+            return done(e);
+          }
+        });
+      });
+
+    it('should ignore threads started more than 180 days ago',
+      function (done) {
+        replyRateModule.readFromDatabase(users[1]._id, function (err, resp) {
+          if (err) return done(err);
+          try {
+            resp.should.have.property('replied', 1);
+            resp.should.have.property('notReplied', 1);
+            return done();
+          } catch (e) {
+            return done(e);
+          }
+        });
+      });
+
+    it('should ignore threads started by the user',
+      function (done) {
+        replyRateModule.readFromDatabase(users[2]._id, function (err, resp) {
+          if (err) return done(err);
+          try {
+            resp.should.have.property('replied', 1);
             resp.should.have.property('notReplied', 0);
             return done();
           } catch (e) {
@@ -166,12 +171,132 @@ describe('Reply Rate and Time Unit Test', function () {
         });
       });
 
-    it('should show null reply time',
+    context('no new-enough threads to the user started', function () {
+      it('should show 0 replied and not replied',
+        function (done) {
+          replyRateModule.readFromDatabase(users[6]._id, function (err, resp) {
+            if (err) return done(err);
+            try {
+              resp.should.have.property('replied', 0);
+              resp.should.have.property('notReplied', 0);
+              return done();
+            } catch (e) {
+              return done(e);
+            }
+          });
+        });
+
+      it('should show null reply time',
+        function (done) {
+          replyRateModule.readFromDatabase(users[6]._id, function (err, resp) {
+            if (err) return done(err);
+            try {
+              resp.should.have.property('replyTime', null);
+              return done();
+            } catch (e) {
+              return done(e);
+            }
+          });
+        });
+    });
+
+    context('some threads to user started and user replied none', function () {
+      it('should show 0 replied and some not replied',
+        function (done) {
+          replyRateModule.readFromDatabase(users[7]._id, function (err, resp) {
+            if (err) return done(err);
+            try {
+              resp.should.have.property('replied', 0);
+              resp.should.have.property('notReplied', 1);
+              return done();
+            } catch (e) {
+              return done(e);
+            }
+          });
+        });
+
+      it('should show null reply time',
+        function (done) {
+          replyRateModule.readFromDatabase(users[7]._id, function (err, resp) {
+            if (err) return done(err);
+            try {
+              resp.should.have.property('replyTime', null);
+              return done();
+            } catch (e) {
+              return done(e);
+            }
+          });
+        });
+    });
+  });
+
+  describe('replyRateModule.updateUserReplyRate', function () {
+    // here we create some messages
+    var day = 24 * 3600 * 1000;
+    // messageData - array of messages: [userFromNo, userToNo, created]
+    var messageDataStubs = [
+      [1, 0, new Date(Date.now() - 5 * day)],
+      [0, 1, new Date(Date.now() - 4 * day)],
+      [0, 1, new Date(Date.now() - 3.1 * day)],
+      [1, 0, new Date(Date.now() - 3 * day)],
+      [2, 0, new Date(Date.now() - 4 * day)],
+      [0, 2, new Date(Date.now() - 2 * day)],
+      [3, 0, new Date(Date.now() - 4 * day)],
+      [0, 3, new Date(Date.now() - 1 * day)],
+      [4, 0, new Date(Date.now() - 2 * day)],
+      // testing old message
+      [5, 1, new Date(Date.now() - 179.5 * day)],
+      [1, 5, new Date(Date.now() - 4 * day)],
+      [1, 5, new Date(Date.now() - 3.1 * day)],
+      [5, 1, new Date(Date.now() - 3 * day)],
+      [6, 1, new Date(Date.now() - 4 * day)],
+      [1, 6, new Date(Date.now() - 2 * day)]
+    ];
+
+    var oldestMessageCreated = messageDataStubs[0][2];
+
+    var messageData = function (stub) {
+      return {
+        userFrom: users[stub[0]]._id,
+        userTo: users[stub[1]]._id,
+        content: _.repeat('.', 50),
+        created: stub[2] || new Date()
+      };
+    };
+    beforeEach(function (done) {
+      // saving the messages to mongoDB
+      async.eachSeries(messageDataStubs,
+        function (messageStub, callback) {
+          var message = new Message(messageData(messageStub));
+          message.save(callback);
+        }, done);
+    });
+
+    it('should return user profile with replyRate, replyTime, replyExpire',
       function (done) {
-        replyRateModule.readFromDatabase(users[6]._id, function (err, resp) {
+        replyRateModule.updateUserReplyRate(users[0]._id, function (err, resp) {
           if (err) return done(err);
           try {
-            resp.should.have.property('replyTime', null);
+            resp.should.have.property('replyRate', 0.75);
+            resp.should.have.property('replyTime');
+            (resp.replyTime).should.be.approximately(2 * day, 10);
+            resp.should.have.property('replyExpire',
+              new Date(oldestMessageCreated.getTime() + 180 * day));
+            return done();
+          } catch (e) {
+            return done(e);
+          }
+        });
+      });
+
+    it('[old] should return replyExpire 1 day from now',
+      function (done) {
+        replyRateModule.updateUserReplyRate(users[1]._id, function (err, resp) {
+          if (err) return done(err);
+          try {
+            resp.should.have.property('replyExpire');
+            (resp.replyExpire.getTime()).should.be
+              .approximately(Date.now() + day, 2000);
             return done();
           } catch (e) {
             return done(e);
@@ -180,31 +305,81 @@ describe('Reply Rate and Time Unit Test', function () {
       });
   });
 
-  context('some threads to user started and user replied none', function () {
-    it('should show 0 replied and some not replied',
+  describe('replyRateModule.updateExpiredReplyRates', function () {
+    // here we add users with expired profiles
+    var expiredUsers = [];
+    var userData = function (no) {
+      return {
+        firstName: 'Full',
+        lastName: 'Name',
+        displayName: 'Full Name',
+        email: 'user' + no + '@test.com',
+        username: 'username' + no,
+        password: 'password123',
+        provider: 'local',
+        replyExpire: new Date(Date.now() - 1)
+      };
+    };
+
+    beforeEach(function(done) {
+      expiredUsers = [];
+      async.eachSeries([8, 9, 10],
+        function (userNo, callback) {
+          var user = new User(userData(userNo));
+          expiredUsers.push(user);
+          user.save(callback);
+        }, done);
+    });
+    // here we create some messages
+    var day = 24 * 3600 * 1000;
+    // messageData - array of messages: [userFromNo, userToNo, created]
+    var messageDataStubs = [
+      [1, 0, new Date(Date.now() - 5 * day)],
+      [0, 1, new Date(Date.now() - 4 * day)],
+      [0, 1, new Date(Date.now() - 3.1 * day)],
+      [1, 0, new Date(Date.now() - 3 * day)],
+      [2, 0, new Date(Date.now() - 4 * day)]
+    ];
+
+    var messageData = function (stub) {
+      return {
+        userFrom: users[stub[0]]._id,
+        userTo: users[stub[1]]._id,
+        content: _.repeat('.', 50),
+        created: stub[2] || new Date()
+      };
+    };
+    beforeEach(function (done) {
+      // saving the messages to mongoDB
+      async.eachSeries(messageDataStubs,
+        function (messageStub, callback) {
+          var message = new Message(messageData(messageStub));
+          message.save(callback);
+        }, done);
+    });
+
+    it('should update reply rates of 3 users',
       function (done) {
-        replyRateModule.readFromDatabase(users[7]._id, function (err, resp) {
+        replyRateModule.updateExpiredReplyRates(function (err, resp) {
           if (err) return done(err);
           try {
-            resp.should.have.property('replied', 0);
-            resp.should.have.property('notReplied', 1);
+            resp.should.equal(expiredUsers.length);
             return done();
           } catch (e) {
             return done(e);
           }
         });
       });
-    it('should show null reply time',
-      function (done) {
-        replyRateModule.readFromDatabase(users[7]._id, function (err, resp) {
-          if (err) return done(err);
-          try {
-            resp.should.have.property('replyTime', null);
-            return done();
-          } catch (e) {
-            return done(e);
-          }
-        });
+  });
+
+  describe('replyRateModule.display', function () {
+    it('[reply rate] should return data as expected', function () {
+      var output = replyRateModule.display({
+        replyRate: 0.3371,
+        replyTime: 7 * 24 * 3600 * 1000 + 7549
       });
+      output.should.have.property('replyRate', '34%');
+      output.should.have.property('replyTime', '1 week');
+    });
   });
 });

--- a/modules/users/tests/server/user-reply-rate.server.routes.tests.js
+++ b/modules/users/tests/server/user-reply-rate.server.routes.tests.js
@@ -49,7 +49,7 @@ describe('User Reply Rate Tests', function () {
 
   beforeEach(function(done) {
     users = [];
-    async.eachSeries(_.range(6),
+    async.eachSeries(_.range(10),
       function (userNo, callback) {
         var user = new User(userData(userNo));
         users.push(user);
@@ -62,17 +62,25 @@ describe('User Reply Rate Tests', function () {
   // messageData - array of messages: [userFromNo, userToNo, created]
   var messageDataStubs = [
     // general testing
-    // now replyRate of user0 is 50% and replyTime is 7 days
+    // now replyRate of user0 is 63% and replyTime is 7 days
+    // and medianReplyRate is 4 days
     // when user0 will reply to message 3->0
     // replyRate will be 75% and replyTime 6 days.
-    [1, 0, new Date(Date.now() - 15 * day)],
-    [0, 1, new Date(Date.now() - 4 * day)], // in 11 days
+    [1, 0, new Date(Date.now() - 27 * day)],
+    [0, 1, new Date(Date.now() - 4 * day)], // in 23 days
     [0, 1, new Date(Date.now() - 3.1 * day)],
     [1, 0, new Date(Date.now() - 3 * day)],
     [2, 0, new Date(Date.now() - 5 * day)],
     [0, 2, new Date(Date.now() - 2 * day)], // in 3 days
-    [3, 0, new Date(Date.now() - 4 * day)],
-    [4, 0, new Date(Date.now() - 2 * day)]
+    [3, 0, new Date(Date.now() - 4 * day)], // not replied
+    [4, 0, new Date(Date.now() - 2 * day)], // not replied
+    [5, 0, new Date(Date.now() - 6 * day)],
+    [0, 5, new Date(Date.now() - 2 * day)], // in 4 days
+    [6, 0, new Date(Date.now() - 5 * day)],
+    [0, 6, new Date(Date.now() - 1 * day)], // in 4 days
+    [7, 0, new Date(Date.now() - 3 * day)],
+    [0, 7, new Date(Date.now() - 2 * day)], // in 1 days
+    [8, 0, new Date(Date.now() - 7 * day)] // not replied
   ];
 
   var messageData = function (stub) {
@@ -128,29 +136,31 @@ describe('User Reply Rate Tests', function () {
         });
     });
 
-    it('should show replyRate and replyTime in user profile', function (done) {
-      agent.get('/api/users/' + users[0].username)
-        .expect(200)
-        .end(function (err, resp) {
-          if (err) return done(err);
-          try {
-            var response = resp.body;
+    it('should show replyRate, replyTime and medianReplyTime in user profile',
+      function (done) {
+        agent.get('/api/users/' + users[0].username)
+          .expect(200)
+          .end(function (err, resp) {
+            if (err) return done(err);
+            try {
+              var response = resp.body;
 
-            response.should.have.property('replyRate', '50%');
-            response.should.have.property('replyTime', '1 week');
+              response.should.have.property('replyRate', '63%');
+              response.should.have.property('replyTime', '1 week');
+              response.should.have.property('medianReplyTime', '4 days');
 
-            return done();
-          } catch (e) {
-            if (e) return done(e);
-          }
-        });
-    });
+              return done();
+            } catch (e) {
+              if (e) return done(e);
+            }
+          });
+      });
 
     it('should update receiver\'s reply stats when `first` message',
       function (done) {
         // Send a new message (first in a thread)
         agent.post('/api/messages')
-          .send({ content: 'hello there', userTo: users[5]._id.toString() })
+          .send({ content: 'hello there', userTo: users[9]._id.toString() })
           .expect(200)
           .end(function (err) {
             if (err) return done(err);
@@ -159,7 +169,7 @@ describe('User Reply Rate Tests', function () {
               jobs.length.should.equal(1);
               jobs[0].should.have.property('type', 'update reply rate');
               jobs[0].should.have.property('data', {
-                userId: users[5]._id.toString()
+                userId: users[9]._id.toString()
               });
               return done();
             } catch (e) {

--- a/modules/users/tests/server/user-reply-rate.server.routes.tests.js
+++ b/modules/users/tests/server/user-reply-rate.server.routes.tests.js
@@ -1,0 +1,193 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+var mongoose = require('mongoose'),
+    request = require('supertest'),
+    path = require('path'),
+    _ = require('lodash'),
+    async = require('async');
+require('should');
+
+var replyRateController =
+  require(path.resolve('./modules/users/server/controllers/user-reply-rate.server.controller')),
+    User = mongoose.model('User'),
+    Message = mongoose.model('Message'),
+    testutils = require(path.resolve('./testutils')),
+    express = require(path.resolve('./config/lib/express'));
+
+/**
+ * User reply rate test
+ */
+describe('User Reply Rate Tests', function () {
+  var app,
+      agent,
+      jobs = testutils.catchJobs();
+
+  before(function () {
+    // Get application
+    app = express.init(mongoose);
+    agent = request.agent(app);
+  });
+
+  // Before every test we create new users
+  var users = [];
+  var userData = function (no) {
+    return {
+      firstName: 'Full',
+      lastName: 'Name',
+      displayName: 'Full Name',
+      email: 'user' + no + '@test.com',
+      username: 'username' + no,
+      password: 'password123',
+      provider: 'local',
+      description: _.repeat('.', 200),
+      public: true
+    };
+  };
+
+  beforeEach(function(done) {
+    users = [];
+    async.eachSeries(_.range(6),
+      function (userNo, callback) {
+        var user = new User(userData(userNo));
+        users.push(user);
+        user.save(callback);
+      }, done);
+  });
+
+  // Before every test we create some messages
+  var day = 24 * 3600 * 1000;
+  // messageData - array of messages: [userFromNo, userToNo, created]
+  var messageDataStubs = [
+    // general testing
+    // now replyRate of user0 is 50% and replyTime is 7 days
+    // when user0 will reply to message 3->0
+    // replyRate will be 75% and replyTime 6 days.
+    [1, 0, new Date(Date.now() - 15 * day)],
+    [0, 1, new Date(Date.now() - 4 * day)], // in 11 days
+    [0, 1, new Date(Date.now() - 3.1 * day)],
+    [1, 0, new Date(Date.now() - 3 * day)],
+    [2, 0, new Date(Date.now() - 5 * day)],
+    [0, 2, new Date(Date.now() - 2 * day)], // in 3 days
+    [3, 0, new Date(Date.now() - 4 * day)],
+    [4, 0, new Date(Date.now() - 2 * day)]
+  ];
+
+  var messageData = function (stub) {
+    return {
+      userFrom: users[stub[0]]._id,
+      userTo: users[stub[1]]._id,
+      content: _.repeat('.', 50), // deeply meaningful message text
+      created: stub[2] || new Date()
+    };
+  };
+
+  // Save the messages to database
+  beforeEach(function (done) {
+    async.eachSeries(messageDataStubs,
+      function (messageStub, callback) {
+        var message = new Message(messageData(messageStub));
+        message.save(callback);
+      }, done);
+  });
+
+  // Initialize the user0's reply rate
+  beforeEach(function (done) {
+    replyRateController.updateUserReplyRate(users[0]._id, done);
+  });
+
+
+  // After each test removing all the messages and users
+  afterEach(function(done) {
+    Message.remove().exec(function() {
+      User.remove().exec(done);
+    });
+  });
+
+  context('signed in', function () {
+    // Sign in
+    beforeEach(function (done) {
+      agent.post('/api/auth/signin')
+        .send(_.pick(userData(0), ['username', 'password']))
+        .expect(200)
+        .end(function (err) {
+          if (err) return done(err);
+          return done();
+        });
+    });
+
+    // Sign out
+    afterEach(function (done) {
+      agent.get('/api/auth/signout')
+        .expect(302)
+        .end(function (err) {
+          if (err) return done(err);
+          return done();
+        });
+    });
+
+    it('should show replyRate and replyTime in user profile', function (done) {
+      agent.get('/api/users/' + users[0].username)
+        .expect(200)
+        .end(function (err, resp) {
+          if (err) return done(err);
+          try {
+            var response = resp.body;
+
+            response.should.have.property('replyRate', '50%');
+            response.should.have.property('replyTime', '1 week');
+
+            return done();
+          } catch (e) {
+            if (e) return done(e);
+          }
+        });
+    });
+
+    it('should update receiver\'s reply stats when `first` message',
+      function (done) {
+        // Send a new message (first in a thread)
+        agent.post('/api/messages')
+          .send({ content: 'hello there', userTo: users[5]._id.toString() })
+          .expect(200)
+          .end(function (err) {
+            if (err) return done(err);
+            try {
+              // Check that agenda was given a correct job
+              jobs.length.should.equal(1);
+              jobs[0].should.have.property('type', 'update reply rate');
+              jobs[0].should.have.property('data', {
+                userId: users[5]._id.toString()
+              });
+              return done();
+            } catch (e) {
+              return done(e);
+            }
+          });
+      });
+
+    it('should update sender\'s reply stats when `firstReply` message',
+      function (done) {
+        // Send a new message (first reply)
+        agent.post('/api/messages')
+          .send({ content: 'hello there', userTo: users[3]._id.toString() })
+          .expect(200)
+          .end(function (err) {
+            if (err) return done(err);
+            try {
+              // Check that agenda was given a correct job
+              jobs.length.should.equal(1);
+              jobs[0].should.have.property('type', 'update reply rate');
+              jobs[0].should.have.property('data', {
+                userId: users[0]._id.toString()
+              });
+              return done();
+            } catch (e) {
+              return done(e);
+            }
+          });
+      });
+  });
+});

--- a/testutils.js
+++ b/testutils.js
@@ -6,6 +6,7 @@ var path = require('path'),
 exports.catchJobs = function() {
 
   var jobs = [],
+      originalSchedule,
       originalNow;
 
   beforeEach(function() {
@@ -26,12 +27,26 @@ exports.catchJobs = function() {
 
     };
 
+    originalSchedule = agenda.schedule;
+    agenda.schedule = function(time, type, data, callback) {
+
+      // ensure it is plain data by serializing to json and back
+      jobs.push(JSON.parse(JSON.stringify({ type: type, data: data })));
+
+      // run in nextTick() to simulate async action that real agenda would do
+      process.nextTick(function() {
+        callback();
+      });
+
+    };
+
   });
 
   afterEach(function() {
 
     // Revert all changes we made
     agenda.now = originalNow;
+    agenda.schedule = originalSchedule;
 
   });
 


### PR DESCRIPTION
see #420 and #421 
- The `replyRate` and `replyTime` are currently served as a part of `GET /api/users/:username` JSON response
- The information is currently displayed in user profile in a form `Replied to {number}% in {time} on average`
  - `{time}` has values `less than a day`, `1 day`, `{2-7} days`, `1 week`, `{2-5} weeks`, `more than a month`
- The above is a first try and is open to suggestions for improvement
### TODO:
- [x] test + implement reading user's reply rate and time from database
- [x] wired into profile controller
- [x] basic view in client
- [x] rebase when #423 is merged to fix failing CI test
- [x] functional tests (testing server routes)
- [x] decide and implement a proper place for results within api
- [x] decide/implement caching the results somewhere
- [ ] review, fix, improve if applicable
- [ ] mean or median?
### maybe TODO:
- show absolute numbers ?
- choose a proper place for the `user-reply-rate.server.controller` and its tests
  - is the place of the new files ok?
- wire the user-reply-rate to the routes and api properly
  - is the agenda calling in messages.server.controller ok?
  - is the api output acceptable? (currently the /api/users/username has parameters i.e. `replyRate: '23%'` and `replyTime: '3 weeks'`); it can be changed to numbers if preferred.
- client tests (maybe unnecessary?)
- decide and implement a better UI design (should the data presentation in client be different?)
