### PR TITLE
#417 Add Agenda job to reactivate existing "no" hosts

### DIFF
--- a/config/env/default.js
+++ b/config/env/default.js
@@ -25,6 +25,7 @@ module.exports = {
   sessionCollection: 'sessions',
   domain: process.env.DOMAIN || 'localhost:3000',
   supportEmail: 'support@trustroots.org', // TO-address for support requests
+  surveyReactivateHosts: 'https://ideas.trustroots.org/?p=1302#page-1302', // Survey to send with host reactivation emails
   profileMinimumLength: 140, // Require User.profile.description to be >=140 chars to send messages
   // Strings not allowed as usernames and tag/tribe labels
   illegalStrings: ['trustroots', 'trust', 'roots', 're', 're:', 'fwd', 'fwd:', 'reply', 'admin', 'administrator', 'password',
@@ -50,7 +51,10 @@ module.exports = {
     // How many signup reminders to send before giving up
     maxSignupReminders: 3,
     // How many signup reminders to process at once
-    maxProcessSignupReminders: 50
+    maxProcessSignupReminders: 50,
+    // How long we should wait before trying to reactivate "no" hosts?
+    // Moment.js `duration` object literal http://momentjs.com/docs/#/durations/
+    timeToReactivateHosts: { days: 90 }
   },
   mailer: {
     from: process.env.MAILER_FROM || 'hello@trustroots.org',

--- a/config/lib/worker.js
+++ b/config/lib/worker.js
@@ -34,11 +34,18 @@ exports.start = function(options, callback) {
       require(path.resolve('./modules/users/server/jobs/user-finish-signup.server.job'))
     );
 
+    agenda.define(
+      'reactivate hosts',
+      { lockLifetime: 10000, concurrency: 1 },
+      require(path.resolve('./modules/offers/server/jobs/reactivate-hosts.server.job'))
+    );
+
     // Schedule job(s)
 
     agenda.every('5 minutes', 'check unread messages');
     agenda.every('24 hours', 'daily statistics');
     agenda.every('30 minutes', 'send signup reminders');
+    agenda.every('30 minutes', 'reactivate hosts');
 
     // Start worker
 

--- a/modules/core/server/services/email.server.service.js
+++ b/modules/core/server/services/email.server.service.js
@@ -198,6 +198,30 @@ exports.sendSignupEmailReminder = function(user, callback) {
   exports.renderEmailAndSend('signup-reminder', params, callback);
 };
 
+exports.sendReactivateHosts = function(user, callback) {
+  var urlOffer = url + '/offer',
+      utmCampaign = 'reactivate-hosts',
+      utmParams = {
+        source: 'transactional-email',
+        medium: 'email',
+        campaign: utmCampaign
+      };
+
+  var params = exports.addEmailBaseTemplateParams({
+    subject: user.firstName + ', start hosting on Trustroots again?',
+    firstName: user.firstName,
+    name: user.displayName,
+    email: user.email,
+    urlOfferPlainText: urlOffer,
+    urlOffer: analyticsHandler.appendUTMParams(urlOffer, utmParams),
+    urlSurveyPlainText: config.surveyReactivateHosts || false,
+    urlSurvey: config.surveyReactivateHosts ? analyticsHandler.appendUTMParams(config.surveyReactivateHosts, utmParams) : false,
+    utmCampaign: utmCampaign
+  });
+
+  exports.renderEmailAndSend('reactivate-hosts', params, callback);
+};
+
 /**
  * Add several parameters to be used to render transactional emails
  * These variables are used by email base template:

--- a/modules/core/server/views/email-templates-text/reactivate-hosts.server.view.html
+++ b/modules/core/server/views/email-templates-text/reactivate-hosts.server.view.html
@@ -1,0 +1,15 @@
+{% extends 'email.server.view.html' %}
+
+{% block content %}
+Hi {{firstName}},
+
+you haven't been hosting for a while, would you like to host again? Change your status here:
+<{{urlOfferPlainText}}>
+
+{% if urlSurveyPlainText %}
+If you've decided to stop hosting, we'd absolutely love to hear why on this 1 question survey:
+<{{urlSurveyPlainText}}>
+{% endif %}
+Thanks for being part of the Trustroots community!
+
+{% endblock %}

--- a/modules/core/server/views/email-templates/reactivate-hosts.server.view.html
+++ b/modules/core/server/views/email-templates/reactivate-hosts.server.view.html
@@ -1,0 +1,65 @@
+{% extends 'email.server.view.html' %}
+
+{% block content %}
+
+  <!-- MODULE ROW // -->
+  <tr>
+    <td align="center" valign="top">
+        <!-- CENTERING TABLE // -->
+          <!--
+            The centering table keeps the content
+              tables centered in the emailBody table,
+              in case its width is set to 100%.
+          -->
+        <table border="0" cellpadding="0" cellspacing="0" width="100%">
+            <tr>
+                <td align="center" valign="top">
+                    <!-- FLEXIBLE CONTAINER // -->
+                      <!--
+                        The flexible container has a set width
+                          that gets overridden by the media query.
+                          Most content tables within can then be
+                          given 100% widths.
+                      -->
+                    <table border="0" cellpadding="0" cellspacing="0" width="600" class="flexibleContainer">
+                        <tr>
+                            <td align="center" valign="top" width="600" class="flexibleContainerCell">
+
+                                  <!-- CONTENT TABLE // -->
+                                  <!--
+                                    The content table is the first element
+                                      that's entirely separate from the structural
+                                      framework of the email.
+                                  -->
+                                  <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                                      <tr>
+                                          <td valign="top" class="textContent">
+
+                                              <p>Hi {{firstName}},</p>
+                                              <p>you haven't been hosting for a while, would you like to host again?<br>
+                                                <a href="{{urlOffer}}">Change your status here</a>.</p>
+                                              {% if urlSurvey %}
+                                                <p>If you've decided to stop hosting, we'd absolutely love to<br>
+                                                  hear why on <a href="{{urlSurvey}}">this 1 question survey</a>.</p>
+                                              {% endif %}
+                                              <p>Thanks for being part of the Trustroots community!</p>
+
+                                          </td>
+                                      </tr>
+                                  </table>
+                                  <!-- // CONTENT TABLE -->
+
+
+                              </td>
+                          </tr>
+                      </table>
+                      <!-- // FLEXIBLE CONTAINER -->
+                  </td>
+              </tr>
+          </table>
+          <!-- // CENTERING TABLE -->
+      </td>
+  </tr>
+  <!-- // MODULE ROW -->
+
+{% endblock %}

--- a/modules/core/tests/server/services/email.server.service.tests.js
+++ b/modules/core/tests/server/services/email.server.service.tests.js
@@ -98,6 +98,29 @@ describe('Service: email', function() {
     });
   });
 
+  it('can send host reactivation email', function(done) {
+    var urlOffer = (config.https ? 'https' : 'http') + '://' + config.domain + '/offer';
+    var user = {
+      firstName: 'first',
+      lastName: 'last',
+      displayName: 'first last',
+      email: 'test@test.com'
+    };
+    emailService.sendReactivateHosts(user, function(err) {
+      if (err) return done(err);
+      jobs.length.should.equal(1);
+      jobs[0].type.should.equal('send email');
+      jobs[0].data.subject.should.equal(user.firstName + ', start hosting on Trustroots again?');
+      jobs[0].data.to.name.should.equal(user.displayName);
+      jobs[0].data.to.address.should.equal(user.email);
+      jobs[0].data.html.should.containEql('Hi ' + user.firstName + ',');
+      jobs[0].data.text.should.containEql('Hi ' + user.firstName + ',');
+      jobs[0].data.html.should.containEql(urlOffer);
+      jobs[0].data.text.should.containEql(urlOffer);
+      done();
+    });
+  });
+
   context('confirm contact', function() {
 
     var user = {

--- a/modules/core/tests/server/worker.tests.js
+++ b/modules/core/tests/server/worker.tests.js
@@ -150,8 +150,13 @@ describe('Worker tests', function() {
     jobNames.should.containEql('send signup reminders');
   });
 
+  it('defines [reactivate hosts] job', function() {
+    var jobNames = _.map(definedJobs, 'name');
+    jobNames.should.containEql('reactivate hosts');
+  });
+
   it('defines right number of repeating jobs', function() {
-    scheduledJobs.length.should.equal(3);
+    scheduledJobs.length.should.equal(4);
   });
 
   it('only schedules defined jobs', function() {

--- a/modules/offers/server/controllers/offers.server.controller.js
+++ b/modules/offers/server/controllers/offers.server.controller.js
@@ -327,6 +327,9 @@ exports.offerByUserId = function(req, res, next, userId) {
     }
     delete offer.locationFuzzy;
 
+    // Never send this field
+    delete offer.reactivateReminderSent;
+
     req.offer = offer;
     next();
   });
@@ -372,6 +375,9 @@ exports.offerById = function(req, res, next, offerId) {
         offer.location = offer.locationFuzzy;
       }
       delete offer.locationFuzzy;
+
+      // Never send this field
+      delete offer.reactivateReminderSent;
 
       req.offer = offer;
       next();

--- a/modules/offers/server/jobs/reactivate-hosts.server.job.js
+++ b/modules/offers/server/jobs/reactivate-hosts.server.job.js
@@ -1,0 +1,93 @@
+'use strict';
+
+/**
+ * Task that checks for hosting offers that are set to "no" and were modified
+ * longer than 3 months ago. Sends these users one reminder asking if they still
+ * would like to keep their hosting status as "no".
+ *
+ * Keeps count of reminder emails at offer model.
+ */
+
+
+/**
+ * Module dependencies.
+ */
+var path = require('path'),
+    emailService = require(path.resolve('./modules/core/server/services/email.server.service')),
+    config = require(path.resolve('./config/config')),
+    async = require('async'),
+    moment = require('moment'),
+    mongoose = require('mongoose'),
+    Offer = mongoose.model('Offer');
+
+module.exports = function(job, agendaDone) {
+  async.waterfall([
+
+    // Find "no" hosting offers
+    function(done) {
+
+      // Ignore only offers modified within past X days
+      // Has to be a JS Date object, not a Moment object
+      var updatedTimeAgo = moment().subtract(moment.duration(config.limits.timeToReactivateHosts)).toDate();
+
+      Offer
+        .find({
+          status: 'no',
+          updated: {
+            $lt: updatedTimeAgo
+          },
+          // Only offers we didn't notify yet
+          reactivateReminderSent: {
+            $exists: false
+          }
+        })
+        .populate('user', 'public email firstName displayName')
+        .exec(function(err, offers) {
+          done(err, offers || []);
+        });
+    },
+
+    // Send emails
+    function(offers, done) {
+      // No users to send emails to
+      if (!offers.length) {
+        return done();
+      }
+
+      async.eachSeries(offers, function(offer, callback) {
+
+        emailService.sendReactivateHosts(offer.user, function(err) {
+          if (err) {
+            return callback(err);
+          } else {
+            // Mark reactivation mail sent
+            Offer.findByIdAndUpdate(
+              offer._id,
+              {
+                $set: {
+                  reactivateReminderSent: new Date()
+                }
+              },
+              function(err) {
+                if (err) {
+                  console.error('Failed to mark offer\'s reactivation mail sent.');
+                }
+                callback(err);
+              }
+            );
+          }
+        });
+      }, function(err) {
+        done(err);
+      });
+
+    }
+
+  ], function(err) {
+    if (err) {
+      console.error(err);
+    }
+    return agendaDone(err);
+  });
+
+};

--- a/modules/offers/server/models/offer.server.model.js
+++ b/modules/offers/server/models/offer.server.model.js
@@ -48,6 +48,9 @@ var OfferSchema = new Schema({
   user: {
     type: Schema.ObjectId,
     ref: 'User'
+  },
+  reactivateReminderSent: {
+    type: Date
   }
 });
 

--- a/modules/offers/tests/server/jobs/reactivate-hosts.server.job.tests.js
+++ b/modules/offers/tests/server/jobs/reactivate-hosts.server.job.tests.js
@@ -1,0 +1,139 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+var path = require('path'),
+    should = require('should'),
+    testutils = require(path.resolve('./testutils')),
+    config = require(path.resolve('./config/config')),
+    moment = require('moment'),
+    mongoose = require('mongoose'),
+    User = mongoose.model('User'),
+    Offer = mongoose.model('Offer');
+
+/**
+ * Globals
+ */
+var user,
+    _user,
+    offer,
+    _offer,
+    reactivateHostsJobHandler;
+
+describe('Job: reactivate members with hosting offer status set to "no"', function() {
+
+  var jobs = testutils.catchJobs();
+
+  before(function() {
+    reactivateHostsJobHandler = require(path.resolve('./modules/offers/server/jobs/reactivate-hosts.server.job'));
+  });
+
+  // Create user
+  beforeEach(function (done) {
+
+    // Create a new user
+    _user = {
+      public: true,
+      firstName: 'Full',
+      lastName: 'Name',
+      displayName: 'Full Name',
+      email: 'test@test.com',
+      username: 'jobtester',
+      displayUsername: 'jobtester',
+      password: 'M3@n.jsI$Aw3$0m3',
+      provider: 'local'
+    };
+
+    user = new User(_user);
+
+    // Save a user to the test db
+    user.save(done);
+  });
+
+  // Create a hosting offer
+  beforeEach(function (done) {
+
+    _offer = {
+      user: user._id,
+      status: 'no',
+      description: '<p>I can host! :)</p>',
+      noOfferDescription: '<p>I cannot host... :(</p>',
+      maxGuests: 1,
+      updated: moment().subtract(moment.duration(config.limits.timeToReactivateHosts)),
+      location: [52.498981209298776, 13.418329954147339],
+      locationFuzzy: [52.50155039101136, 13.42255019882177]
+    };
+
+    offer = new Offer(_offer);
+
+    // Save offer to the test db
+    offer.save(done);
+  });
+
+  it('Send reactivation email for offers modified longer than configured limit ago', function(done) {
+
+    // This should not be there before notifications are sent
+    should.not.exist(offer.reactivateReminderSent);
+
+    reactivateHostsJobHandler({}, function(err) {
+      if (err) return done(err);
+
+      jobs.length.should.equal(1);
+      jobs[0].type.should.equal('send email');
+      jobs[0].data.subject.should.equal(_user.firstName + ', start hosting on Trustroots again?');
+      jobs[0].data.to.address.should.equal(_user.email);
+
+      Offer.findOne({ user: user._id }, function(err, offerRes) {
+        if (err) return done(err);
+        should.exist(offerRes.reactivateReminderSent);
+        done();
+      });
+
+    });
+  });
+
+  it('Send reactivation email for un-confirmed profiles', function(done) {
+
+    // This should not be there before notifications are sent
+    should.not.exist(offer.reactivateReminderSent);
+
+    user.public = false;
+    user.save(function(err) {
+      if (err) return done(err);
+
+      reactivateHostsJobHandler({}, function(err) {
+        if (err) return done(err);
+
+        jobs.length.should.equal(1);
+        jobs[0].type.should.equal('send email');
+        jobs[0].data.subject.should.equal(_user.firstName + ', start hosting on Trustroots again?');
+        jobs[0].data.to.address.should.equal(_user.email);
+
+        Offer.findOne({ user: user._id }, function(err, offerRes) {
+          if (err) return done(err);
+          should.exist(offerRes.reactivateReminderSent);
+          done();
+        });
+      });
+    });
+  });
+
+  it('Do not send reactivation email for offers modified less than configured limit ago', function(done) {
+    offer.updated = new Date();
+    offer.save(function(err) {
+      if (err) return done(err);
+      reactivateHostsJobHandler({}, function(err) {
+        if (err) return done(err);
+        jobs.length.should.equal(0);
+        done();
+      });
+    });
+  });
+
+  afterEach(function (done) {
+    Offer.remove().exec(function() {
+      User.remove().exec(done);
+    });
+  });
+});

--- a/modules/offers/tests/server/offer.server.model.tests.js
+++ b/modules/offers/tests/server/offer.server.model.tests.js
@@ -31,9 +31,11 @@ describe('Offer Model Unit Tests:', function() {
       provider: 'local'
     });
 
-    // Create users
-    user.save(function() {
+    // Save user and hosting offer
+    user.save(function(err, user) {
+      should.not.exist(err);
       offer = new Offer({
+        user: user._id,
         status: 'yes',
         description: '<p>I can host! :)</p>',
         noOfferDescription: '<p>I cannot host... :(</p>',
@@ -48,7 +50,6 @@ describe('Offer Model Unit Tests:', function() {
 
   describe('Method Save', function() {
     it('should be able to save without problems', function(done) {
-
       offer.save(function(err) {
         should.not.exist(err);
         return done();


### PR DESCRIPTION
These are mostly users who were hosting at some point, but turned it off due being busy or went traveling. We suspect they didn't remember to turn it on again, so we're just checking in.

- Send email to users who have "no" hosting offer with old enough timestamp (3 months), asking them if they would like to host again
- Mark their hosting offer notified at hosting offer document
- Email also has survey link so that people can elaborate why wouldn't they want to host anymore

Closes #417