### PR TITLE
Upgrade node-influx to v5

### DIFF
--- a/modules/core/server/services/influx.server.service.js
+++ b/modules/core/server/services/influx.server.service.js
@@ -4,7 +4,7 @@
  * Module dependencies.
  */
 var path = require('path'),
-    influx = require('influx'),
+    Influx = require('influx'),
     _ = require('lodash'),
     config = require(path.resolve('./config/config'));
 
@@ -23,12 +23,14 @@ exports.getClient = function(callback) {
     return callback(new Error('No InfluxDB configured.'));
   }
 
-  // check passed so we send configuration to influx()
-  callback(null, influx(config.influxdb.options));
+  // Init Influx client with configuration
+  var client = new Influx.InfluxDB(config.influxdb.options);
+
+  callback(null, client);
 };
 
 /**
- * Write point to InfluxDB
+ * Write measurement to InfluxDB
  *
  * fields - object of field key: value pairs. To save to influxdb.
  *   - key in camelCase
@@ -44,12 +46,12 @@ exports.getClient = function(callback) {
  * influxdb (camelCase)
  * @param {Object} fields - key: value pairs will be saved in influxdb as field
  * key: field value
- * @param {number|Date} [fields.time=new Date()] - time of measurement with precision ms
+ * @param {number|Date} [fields.time=new Date()] - time of measurement with precision nanosecond
  * @param {Object} tags - key: value pairs will be saved in influxdb as tag key:
  * tag value
  * @param {function} callback - expected to be like function (err, result) {}
  */
-exports.writePoint = function(measurementName, fields, tags, callback) {
+exports.writeMeasurement = function(measurementName, fields, tags, callback) {
 
   if (!measurementName || typeof measurementName !== 'string'
     || measurementName.length === 0) {
@@ -74,6 +76,12 @@ exports.writePoint = function(measurementName, fields, tags, callback) {
       return callback(err);
     }
 
-    client.writePoint(measurementName, fields, tags, callback);
+    client.writeMeasurement(measurementName, [
+      {
+        fields: fields,
+        tags: tags
+      }
+    ]);
+
   });
 };

--- a/modules/core/server/services/influx.server.service.js
+++ b/modules/core/server/services/influx.server.service.js
@@ -66,6 +66,11 @@ exports.writeMeasurement = function(measurementName, fields, tags, callback) {
     return callback(new Error('InfluxDB Service: no `tags` defined.'));
   }
 
+  // Validate time: it should always be a `Date` object
+  if (fields.time && !_.isDate(fields.time)) {
+    return callback(new Error('InfluxDB Service: expected `fields.time` to be `Date` object.'));
+  }
+
   // Add current time to `fields` if it's missing
   if (!fields.time) {
     fields.time = new Date();

--- a/modules/core/tests/server/services/influx.server.service.tests.js
+++ b/modules/core/tests/server/services/influx.server.service.tests.js
@@ -33,7 +33,7 @@ describe('Service: influx', function() {
   });
 
   it('Writing point returns error with no measurementName', function(done) {
-    influxService.writePoint(null, { value: 1 }, { tag: 'tag' }, function(err) {
+    influxService.writeMeasurement(null, { value: 1 }, { tag: 'tag' }, function(err) {
       try {
         err.message.should.equal('InfluxDB Service: no `measurementName` defined.');
         return done();
@@ -45,7 +45,7 @@ describe('Service: influx', function() {
   });
 
   it('Writing point returns error with no value', function(done) {
-    influxService.writePoint('test', null, { tag: 'tag' }, function(err) {
+    influxService.writeMeasurement('test', null, { tag: 'tag' }, function(err) {
       try {
         err.message.should.equal('InfluxDB Service: no `fields` defined.');
         return done();
@@ -56,7 +56,7 @@ describe('Service: influx', function() {
   });
 
   it('Writing point returns error with no tag', function(done) {
-    influxService.writePoint('test', { value: 1 }, null, function(err) {
+    influxService.writeMeasurement('test', { value: 1 }, null, function(err) {
       try {
         err.message.should.equal('InfluxDB Service: no `tags` defined.');
         return done();

--- a/modules/core/tests/server/services/influx.server.service.tests.js
+++ b/modules/core/tests/server/services/influx.server.service.tests.js
@@ -65,4 +65,41 @@ describe('Service: influx', function() {
       }
     });
   });
+
+  it('Writing point returns error with wrong time format (nanoseconds)', function(done) {
+    influxService.writeMeasurement('test', { value: 1, time: 1475985480231035600 }, { tag: 'tag' }, function(err) {
+      try {
+        err.message.should.equal('InfluxDB Service: expected `fields.time` to be `Date` object.');
+        return done();
+
+      } catch (e) {
+        return done(e);
+      }
+    });
+  });
+
+  it('Writing point returns error with wrong time format (milliseconds)', function(done) {
+    influxService.writeMeasurement('test', { value: 1, time: 1475985480231 }, { tag: 'tag' }, function(err) {
+      try {
+        err.message.should.equal('InfluxDB Service: expected `fields.time` to be `Date` object.');
+        return done();
+
+      } catch (e) {
+        return done(e);
+      }
+    });
+  });
+
+  it('Writing point returns error with wrong time format (string)', function(done) {
+    influxService.writeMeasurement('test', { value: 1, time: '2016-10-09T03:58:00.231035600Z' }, { tag: 'tag' }, function(err) {
+      try {
+        err.message.should.equal('InfluxDB Service: expected `fields.time` to be `Date` object.');
+        return done();
+
+      } catch (e) {
+        return done(e);
+      }
+    });
+  });
+
 });

--- a/modules/messages/server/services/message-to-influx.server.service.js
+++ b/modules/messages/server/services/message-to-influx.server.service.js
@@ -26,17 +26,6 @@ var Message = mongoose.model('Message');
  */
 
 /**
- * This is a callback for the exports.process
- *
- * @callback processMessageCallback
- * @param {error} error
- * @param {object} fields - object of field keys and values as they'll be saved
- * in influx
- * @param {object} tags - object of tag keys and values as they'll be saved in
- * influx
- */
-
-/**
  * this function is a shortcut for processing and sending the data to
  * influxService (which sends it to influxdb)
  * @param {object} message - a message object (as returned by mongoDB)
@@ -75,6 +64,17 @@ module.exports.save = function (message, callback) {
     }
   });
 };
+
+/**
+ * This is a callback for the exports.process
+ *
+ * @callback processMessageCallback
+ * @param {error} error
+ * @param {object} fields - object of field keys and values as they'll be saved
+ * in influx
+ * @param {object} tags - object of tag keys and values as they'll be saved in
+ * influx
+ */
 
 /**
  * this function gets some info about the message sent and then calls the callback
@@ -179,7 +179,7 @@ module.exports.process = function (message, callback) {
         userFrom: String(userFrom), // id of sender
         userTo: String(userTo), // id of receiver
         messageLength: msgLen, // length of the content
-        time: message.created.getTime() // creation timestamp (milliseconds)
+        time: message.created // creation time (Date)
       };
 
       // we measure the reply time only for the first replies (time since the

--- a/modules/messages/server/services/message-to-influx.server.service.js
+++ b/modules/messages/server/services/message-to-influx.server.service.js
@@ -208,5 +208,5 @@ module.exports.process = function (message, callback) {
  * @param {influxCallback} callback - a callback that handles the response
  */
 module.exports.send = function (fields, tags, callback) {
-  return influxService.writePoint('messageSent', fields, tags, callback);
+  return influxService.writeMeasurement('messageSent', fields, tags, callback);
 };

--- a/modules/messages/tests/server/message-to-influx-functional.server.service.tests.js
+++ b/modules/messages/tests/server/message-to-influx-functional.server.service.tests.js
@@ -18,9 +18,9 @@ var reachEventEmitter = new EventEmitter();
 
 // it will emit an event 'reachedInfluxdb' which should be caught in the tests
 
-// mocking the influxdb.writePoint()
+// mocking the influxdb.writeMeasurement()
 var influxdb = {
-  writePoint: function (measurement, fields, tags) {
+  writeMeasurement: function (measurement, fields, tags) {
     reachEventEmitter.emit('reachedInfluxdb', measurement, fields, tags);
   }
 };
@@ -157,14 +157,15 @@ describe('Message to influx server service Functional Test', function () {
 
       it('the data should have a proper format', function (done) {
         // we want to call the listener only once
-        reachEventEmitter.once('reachedInfluxdb', function (measurement, fields, tags) {
+        reachEventEmitter.once('reachedInfluxdb', function (measurement, points) {
           try {
             (measurement).should.equal('messageSent');
-            should.exist(fields);
-            should.exist(tags);
-            fields.should.have.property('messageLength');
-            tags.should.have.property('messageLengthType');
-            tags.should.have.property('position', 'first');
+            points.length.should.equal(1);
+            should.exist(points[0].fields);
+            should.exist(points[0].tags);
+            points[0].fields.should.have.property('messageLength');
+            points[0].tags.should.have.property('messageLengthType');
+            points[0].tags.should.have.property('position', 'first');
             return done();
           } catch (e) {
             return done(e);

--- a/modules/messages/tests/server/message-to-influx.server.service.tests.js
+++ b/modules/messages/tests/server/message-to-influx.server.service.tests.js
@@ -77,6 +77,10 @@ describe('Message to influx server service Unit Tests:', function() {
       async.waterfall([
 
         // defining the messages with some time difference
+        // @TODO the test should be refactored.
+        // the messages should have a constant given `created` time; It would
+        // enable precise testing and avoid the complexity of timeouts which is
+        // now
         function (done) {
           setTimeout(function () {
             message1to2 = new Message({
@@ -237,17 +241,19 @@ describe('Message to influx server service Unit Tests:', function() {
         });
       });
 
-    it('[every message] should give field with key `time` which is timestamp (integer) in specific range',
+    it('[every message] should give field with key `time` which is a Date in a specific range',
+      // @TODO the test should be rewriten to be more precise (see the todo near
+      // creating the testing messages)
       function (done) {
         messageToInfluxService.process(message1to2, function (err, fields) {
           if (err) return done(err);
           try {
             fields.should.have.property('time');
-            (typeof fields.time).should.be.exactly('number');
+            (fields.time).should.be.Date();
             // here we test wheter the number is between now and some not so
             // past time
-            (fields.time > 1400000000 * 1000).should.be.exactly(true);
-            (fields.time <= Date.now()).should.be.exactly(true);
+            (fields.time.getTime() > 1400000000 * 1000).should.be.exactly(true);
+            (fields.time.getTime() <= Date.now()).should.be.exactly(true);
             return done();
           } catch (err) {
             return done(err);

--- a/modules/statistics/server/jobs/daily-statistics.server.job.js
+++ b/modules/statistics/server/jobs/daily-statistics.server.job.js
@@ -22,7 +22,7 @@ module.exports = function (job, agendaDone) {
     }
 
     // Save to influx here
-    influxService.writePoint('members', { count: count }, { members: 'members' },
+    influxService.writeMeasurement('members', { count: count }, { members: 'members' },
       function (err, result) {
         if (err) {
           console.error('Daily statistics: failed writing to InfluxDB.');

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "gulp-util": "~3.0.7",
     "helmet": "~3.0.0",
     "html-to-text": "~2.1.3",
-    "influx": "~4.2.1",
+    "influx": "~5.0.0",
     "juice": "~3.0.1",
     "lodash": "~4.16.4",
     "merge-stream": "~1.0.0",

--- a/scripts/influxdb/fill-member-count-to-influx.js
+++ b/scripts/influxdb/fill-member-count-to-influx.js
@@ -170,7 +170,7 @@ async.waterfall([
       // console.log('\n  -> TO INFLUX: ' + cumulativeUserCount + ' [+' + countGroup.count + '] (' + countGroup._id.year + '-' + countGroup._id.month + '-' + countGroup._id.day + ')')
 
       // processing and saving the point to database
-      influxService.writePoint(
+      influxService.writeMeasurement(
         'members',
         {
           count: parseInt(cumulativeUserCount),


### PR DESCRIPTION
See breaking changes:
https://github.com/node-influx/node-influx/blob/master/CHANGELOG.md#2016-10-24-500-alpha4

Most notably rename `writePoint` to `writeMeasurement` to keep it clear
it uses `.writeMeasurement` from node-influx under the hood:
https://node-influx.github.io/class/src/index.js~InfluxDB.html#instance-method-writeMeasurement