### PR TITLE
#418 Add "tribes in common" directive

### DIFF
--- a/modules/offers/tests/server/offer.server.routes.tests.js
+++ b/modules/offers/tests/server/offer.server.routes.tests.js
@@ -24,6 +24,7 @@ var app,
     user3Id,
     offer1,
     offer2,
+    offer2Id,
     offer3,
     tribe1,
     tribe2,
@@ -191,7 +192,8 @@ describe('Offer CRUD tests', function() {
       // Save hosting offer 2
       function(done) {
         offer2.user = user2Id;
-        offer2.save(function(err) {
+        offer2.save(function(err, offer2) {
+          offer2Id = offer2._id;
           done(err);
         });
       },
@@ -208,7 +210,89 @@ describe('Offer CRUD tests', function() {
     });
   });
 
-  it('should not be able to read offer if not logged in', function(done) {
+  it('should not be able to read offer by offer id if not logged in', function(done) {
+
+    agent.get('/api/offers/' + offer2Id)
+      .expect(403)
+      .end(function(offerSaveErr, offerSaveRes) {
+
+        offerSaveRes.body.message.should.equal('Forbidden.');
+
+        // Call the assertion callback
+        return done(offerSaveErr);
+      });
+  });
+
+  it('should be able to read offers of other users by offer id when logged in', function(done) {
+    agent.post('/api/auth/signin')
+      // Logged in as `user1`
+      .send(credentials)
+      .expect(200)
+      .end(function(signinErr) {
+        // Handle signin error
+        if (signinErr) return done(signinErr);
+
+        // Get a offer from the other user by offer id
+        agent.get('/api/offers/' + offer2Id)
+          .expect(200)
+          .end(function(offerGetErr, offerGetRes) {
+            // Handle offer get error
+            if (offerGetErr) return done(offerGetErr);
+
+            // Set assertions
+            offerGetRes.body.user._id.should.equal(user2Id.toString());
+            offerGetRes.body.status.should.equal(offer2.status);
+            offerGetRes.body.description.should.equal(offer2.description);
+            offerGetRes.body.noOfferDescription.should.equal(offer2.noOfferDescription);
+            offerGetRes.body.maxGuests.should.equal(offer2.maxGuests);
+            offerGetRes.body.location.should.be.instanceof(Array).and.have.lengthOf(2);
+            offerGetRes.body.location[0].should.be.approximately(offer2.locationFuzzy[0], 0.0000000000001);
+            offerGetRes.body.location[1].should.be.approximately(offer2.locationFuzzy[1], 0.0000000000001);
+            offerGetRes.body.updated.should.not.be.empty();
+            should.not.exist(offerGetRes.body.locationFuzzy);
+
+            // Call the assertion callback
+            return done();
+          });
+
+      });
+  });
+
+  it('should be able to read offers by id and get populated memberships array', function(done) {
+    agent.post('/api/auth/signin')
+      // Logged in as `user1`
+      .send(credentials)
+      .expect(200)
+      .end(function(signinErr) {
+        // Handle signin error
+        if (signinErr) return done(signinErr);
+
+        // Get a offer from the other user by offer id
+        agent.get('/api/offers/' + offer2Id)
+          .expect(200)
+          .end(function(offerGetErr, offerGetRes) {
+            // Handle offer get error
+            if (offerGetErr) return done(offerGetErr);
+
+            // Set assertions
+            offerGetRes.body.user.member.length.should.equal(1);
+            offerGetRes.body.user.member[0].relation.should.equal('is');
+            offerGetRes.body.user.member[0].since.should.not.be.empty();
+            offerGetRes.body.user.member[0].tag._id.should.equal(tribe2Id.toString());
+            offerGetRes.body.user.member[0].tag.tribe.should.equal(tribe2.tribe);
+            offerGetRes.body.user.member[0].tag.color.should.equal(tribe2.color);
+            offerGetRes.body.user.member[0].tag.count.should.equal(tribe2.count);
+            offerGetRes.body.user.member[0].tag.slug.should.equal(tribe2.slug);
+            offerGetRes.body.user.member[0].tag.label.should.equal(tribe2.label);
+
+            // Call the assertion callback
+            return done();
+          });
+
+      });
+  });
+
+  it('should not be able to read offer by user id if not logged in', function(done) {
 
     agent.get('/api/offers-by/' + user2Id)
       .expect(403)

--- a/modules/search/client/less/sidebar.less
+++ b/modules/search/client/less/sidebar.less
@@ -150,3 +150,17 @@
   padding: 10px 0;
   font-size: 15px;
 }
+
+.search-result-tribes-common {
+  margin-top: 10px;
+  font-size: @font-size-small;
+  h4 {
+    color: @gray-light;
+    text-transform: uppercase;
+    font-size: @font-size-base;
+    line-height: @line-height-base;
+  }
+  a {
+    color: @text-color;
+  }
+}

--- a/modules/search/client/views/search-sidebar.client.view.html
+++ b/modules/search/client/views/search-sidebar.client.view.html
@@ -88,6 +88,11 @@
           </div>
         </div>
 
+        <div class="search-result-tribes-common"
+             ng-if="search.offer.user.member.length"
+             tr-tribes-in-common="::search.offer.user.member">
+        </div>
+
       </div>
       <div class="search-result-languages" ng-if="search.offer.user.languages.length">
         <h4>Languages</h4>

--- a/modules/tags/client/directives/tr-tribes-in-common.client.directive.js
+++ b/modules/tags/client/directives/tr-tribes-in-common.client.directive.js
@@ -1,0 +1,66 @@
+(function () {
+  'use strict';
+
+  /**
+   * List tribes in common between two lists of tribes
+   */
+  angular
+    .module('tags')
+    .directive('trTribesInCommon', trTribesInCommonDirective);
+
+  /* @ngInject */
+  function trTribesInCommonDirective(Authentication, TribeService) {
+    return {
+      templateUrl: '/modules/tags/views/directives/tr-tribes-in-common.client.view.html',
+      restrict: 'A',
+      replace: true,
+      scope: {
+        trTribesInCommon: '='
+      },
+      controller: trTribesInCommonController,
+      controllerAs: 'tribesInCommon'
+    };
+
+    /* @ngInject */
+    function trTribesInCommonController($scope, $state) {
+
+      // View Model
+      var vm = this;
+
+      // Exposed to the view
+      vm.openTribe = openTribe;
+      vm.memberships = [];
+
+      activate();
+
+      /**
+       * Initialize directive controller
+       */
+      function activate() {
+        var tribesInCommon = [];
+
+        // Loop all memberships (tags & tribes)
+        angular.forEach($scope.trTribesInCommon, function(membership) {
+          // If it's tribe and authenticated user has it as well, add to list
+          if (membership.tag.tribe === true && Authentication.user.memberIds.indexOf(membership.tag._id) > -1) {
+            tribesInCommon.push(membership);
+          }
+        });
+
+        vm.memberships = tribesInCommon;
+      }
+
+      /**
+       * Open tribe
+       */
+      function openTribe(tribe) {
+        // Put tribe object to cache to be used after
+        // page transition has finished,
+        // thus no need to reload tribe from the API
+        TribeService.fillCache(angular.copy(tribe));
+        $state.go('tribes.tribe', { 'tribe': tribe.slug });
+      }
+
+    }
+  }
+}());

--- a/modules/tags/client/views/directives/tr-tribes-in-common.client.view.html
+++ b/modules/tags/client/views/directives/tr-tribes-in-common.client.view.html
@@ -1,0 +1,10 @@
+<div>
+  <div ng-if="tribesInCommon.memberships.length" class="tribes-common">
+    <h4>Tribes in common</h4>
+    <ul class="list-inline">
+      <li ng-repeat="membership in ::tribesInCommon.memberships track by membership.tag._id">
+        <a class="tribe-link" ui-sref="tribes.tribe({ tribe: membership.tag.slug })" ng-click="tribesInCommon.openTribe(membership.tag)" ng-bind="::membership.tag.label"></a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/modules/tags/server/controllers/tribes.server.controller.js
+++ b/modules/tags/server/controllers/tribes.server.controller.js
@@ -18,7 +18,8 @@ exports.tribeFields = [
   'color',
   'image_UUID',
   'attribution',
-  'attribution_url'
+  'attribution_url',
+  'tribe'
 ].join(' ');
 
 /**

--- a/modules/tags/tests/server/tags.server.routes.test.js
+++ b/modules/tags/tests/server/tags.server.routes.test.js
@@ -107,6 +107,7 @@ describe('Tag CRUD tests', function () {
       .end(function(tribesReadErr, tribesReadRes) {
 
         tribesReadRes.body.should.have.length(1);
+        tribesReadRes.body[0].tribe.should.equal(true);
         tribesReadRes.body[0].label.should.equal('Awesome Tribe');
         tribesReadRes.body[0].slug.should.equal('awesome-tribe');
         tribesReadRes.body[0].attribution.should.equal(_tribe.attribution);
@@ -120,7 +121,6 @@ describe('Tag CRUD tests', function () {
 
 
         // These are at the model, but aren't exposed
-        should.not.exist(tribesReadRes.body[0].tribe);
         should.not.exist(tribesReadRes.body[0].synonyms);
         should.not.exist(tribesReadRes.body[0].labelHistory);
         should.not.exist(tribesReadRes.body[0].slugHistory);
@@ -145,6 +145,7 @@ describe('Tag CRUD tests', function () {
           .end(function(tribesReadErr, tribesReadRes) {
 
             tribesReadRes.body.should.have.length(1);
+            tribesReadRes.body[0].tribe.should.equal(true);
             tribesReadRes.body[0].label.should.equal('Awesome Tribe');
             tribesReadRes.body[0].slug.should.equal('awesome-tribe');
             tribesReadRes.body[0].attribution.should.equal(_tribe.attribution);
@@ -158,7 +159,6 @@ describe('Tag CRUD tests', function () {
 
 
             // These are at the model, but aren't exposed
-            should.not.exist(tribesReadRes.body[0].tribe);
             should.not.exist(tribesReadRes.body[0].synonyms);
             should.not.exist(tribesReadRes.body[0].labelHistory);
             should.not.exist(tribesReadRes.body[0].slugHistory);

--- a/modules/users/client/less/profile-view.less
+++ b/modules/users/client/less/profile-view.less
@@ -164,6 +164,24 @@
   }
 }
 
+// "Tribes in common" directive
+.profile-tribes-common {
+  h4 {
+    color: @gray-light;
+    text-transform: uppercase;
+    margin: 3px 0 0 0;
+    font-size: @font-size-base;
+    line-height: 20px;
+    font-weight: normal;
+  }
+  a {
+    color: @text-color;
+  }
+  padding-bottom: 10px;
+  margin-bottom: 10px;
+  border-bottom: 1px solid @gray-lighter;
+}
+
 // List of social accounts
 .social-profiles {
   margin-top: 5px;

--- a/modules/users/client/views/directives/tr-monkeybox.client.view.html
+++ b/modules/users/client/views/directives/tr-monkeybox.client.view.html
@@ -2,6 +2,12 @@
   <div class="panel-body">
     <div tr-avatar data-user="profile" data-size="64"></div>
     <h3><a ui-sref="profile.about({username: profile.username})" ng-bind="profile.displayName"></a></h3>
+
+    <div class="monkeybox-section"
+         ng-if="profile.member.length"
+         tr-tribes-in-common="::profile.member">
+    </div>
+
     <div class="monkeybox-section" ng-if="profile.languages.length">
       <h4>Languages</h4>
       <ul class="list-unstyled">

--- a/modules/users/client/views/profile/profile-view-about.client.view.html
+++ b/modules/users/client/views/profile/profile-view-about.client.view.html
@@ -48,7 +48,14 @@
         Tribes
       </div>
       <div class="panel-body">
-        <div tr-tribes-list="profileCtrl.memberships.tribes.is" is-own-profile="::profileCtrl.profile._id === app.user._id"></div>
+
+        <div class="profile-tribes-common"
+             ng-if="::profileCtrl.profile._id !== app.user._id"
+             tr-tribes-in-common="profileCtrl.profile.member"></div>
+
+        <div tr-tribes-list="profileCtrl.memberships.tribes.is"
+             is-own-profile="::profileCtrl.profile._id === app.user._id"></div>
+
       </div>
     </div>
 

--- a/modules/users/server/controllers/users/users.profile.server.controller.js
+++ b/modules/users/server/controllers/users/users.profile.server.controller.js
@@ -73,7 +73,7 @@ exports.userMiniProfileFields = [
 ].join(' ');
 
 // Mini + a few fields we'll need at listings
-exports.userListingProfileFields = exports.userMiniProfileFields + ' birthdate gender tagline';
+exports.userListingProfileFields = exports.userMiniProfileFields + ' member birthdate gender tagline';
 
 /**
  * Middleware to validate+process avatar upload field
@@ -538,7 +538,7 @@ exports.userByUsername = function(req, res, next, username) {
         exports.userProfileFields + ' public')
         .populate({
           path: 'member.tag',
-          select: tribesHandler.tribeFields + ' tribe', // Loads `tribe` fields for both `tribe:true` and `tribe:false` objects
+          select: tribesHandler.tribeFields,
           model: 'Tag',
           options: { sort: { count: -1 } }
         })
@@ -804,7 +804,7 @@ exports.getUserMemberships = function(req, res) {
     .findById(req.user._id, 'member')
     .populate({
       path: 'member.tag',
-      select: tagsHandler.tagFields + ' ' + tribesHandler.tribeFields + ' tribe',
+      select: tagsHandler.tagFields + ' ' + tribesHandler.tribeFields,
       model: 'Tag',
       options: { sort: { count: -1 } }
     })


### PR DESCRIPTION
Create directive which takes membership array and compares that to currently authenticated user's ids. Outputs a list of matching tribes.

Adds directive to:
- search results
- profile page (over tribes panel)
- message thread

Modify output of `/api/offers/:offerId` to include populated tags from member array.

Closes #418
