### PR TITLE
Periodically refresh FB tokens #250

### DIFF
--- a/config/env/default.js
+++ b/config/env/default.js
@@ -98,8 +98,8 @@ module.exports = {
   },
   facebook: {
     page: process.env.FACEBOOK_PAGE || '',
-    clientID: process.env.FACEBOOK_ID || 'APP_ID',
-    clientSecret: process.env.FACEBOOK_SECRET || 'APP_SECRET',
+    clientID: process.env.FACEBOOK_ID || false,
+    clientSecret: process.env.FACEBOOK_SECRET || false,
     callbackURL: '/api/auth/facebook/callback'
   },
   twitter: {

--- a/config/lib/facebook-api.js
+++ b/config/lib/facebook-api.js
@@ -1,0 +1,17 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+var fbgraph = require('fbgraph');
+
+/**
+ * Configure FB API version
+ * v2.8 is available at least until October 2018
+ *
+ * @link https://developers.facebook.com/docs/apps/versions
+ * @link https://developers.facebook.com/docs/apps/changelog
+ */
+fbgraph.setVersion('2.8');
+
+module.exports = fbgraph;

--- a/modules/core/client/config/core.client.run.js
+++ b/modules/core/client/config/core.client.run.js
@@ -1,0 +1,17 @@
+(function () {
+  'use strict';
+
+  angular
+    .module('core')
+    .run(coreRun);
+
+  /* @ngInject */
+  function coreRun(Facebook) {
+
+    // Attempt to initialize Facebook SDK on first page load
+    // If this fails, we'll try this again on successfull login
+    Facebook.init();
+
+  }
+
+}());

--- a/modules/core/client/directives/tr-share-fb.client.directive.js
+++ b/modules/core/client/directives/tr-share-fb.client.directive.js
@@ -1,0 +1,68 @@
+/* global FB */
+(function () {
+  'use strict';
+
+  /**
+   * FB Share button for current URL
+   */
+  angular
+    .module('core')
+    .directive('trShareFb', trShareFbDirective);
+
+  /* @ngInject */
+  function trShareFbDirective($rootScope, $window, Authentication) {
+
+    return {
+      restrict: 'A',
+      replace: true,
+      scope: false,
+      link: trShareFbDirectiveLink
+    };
+
+    function trShareFbDirectiveLink(scope, element) {
+
+      // Don't show share button if user isn't connected to FB
+      if (!Authentication.user || !Authentication.user.additionalProvidersData || !Authentication.user.additionalProvidersData.facebook) {
+        return;
+      }
+
+      // FB API ready, activate
+      if (angular.isDefined($window.FB)) {
+        activate();
+      } else {
+        // FB API was not ready, wait for the ready event
+        var watch = $rootScope.$on('facebookReady', function() {
+          activate();
+          // Removes watch:
+          watch();
+        });
+      }
+
+      /**
+       * Activate directive
+       */
+      function activate() {
+
+        var button = '<div ' +
+          'class="fb-share-button" ' +
+          'data-href="' + location.href + '" ' +
+          'data-layout="button_count" ' +
+          'data-size="small" ' +
+          'data-mobile-iframe="true"> ' +
+          '  <a class="fb-xfbml-parse-ignore" ' +
+          '    target="_blank" ' +
+          '    href="https://www.facebook.com/sharer/sharer.php?u=' + encodeURIComponent(location.href) + '">' +
+          '      Share' +
+          '  </a> ' +
+          '</div>';
+
+        element.html(button);
+
+        // Parse XFBML code
+        FB.XFBML.parse(element[0]);
+      }
+
+    }
+  }
+
+}());

--- a/modules/core/client/services/facebook.client.service.js
+++ b/modules/core/client/services/facebook.client.service.js
@@ -1,0 +1,140 @@
+/* global FB */
+(function () {
+  'use strict';
+
+  angular
+    .module('core')
+    .factory('Facebook', FacebookFactory);
+
+  /* @ngInject */
+  function FacebookFactory($log, $window, $document, $http, $rootScope, Authentication) {
+
+    var service = {
+      init: init
+    };
+
+    return service;
+
+    /**
+     * Load Facebook javascript SDK
+     * Will invoke `fbAsyncInit` when done.
+     */
+    function init() {
+
+      // Stop loading if the app doesn't have Facebook app ID defined
+      if (!angular.isString($window.facebookAppId) || $window.facebookAppId === '') {
+        $log.info('No Facebook app ID; skipping `FB.init()`');
+        return;
+      }
+
+      // Stop loading when:
+      // - user isn't authenticated
+      // - authenticated user isn't connected to FB
+      if (!Authentication.user || !Authentication.user.additionalProvidersData || !Authentication.user.additionalProvidersData.facebook) {
+        return;
+      }
+
+      // Run this function after SDK loads
+      $window.fbAsyncInit = fbAsyncInit;
+
+      // Initialize the `<script>`
+      (function(d) {
+        var js,
+            id = 'facebook-jssdk',
+            fjs = d.getElementsByTagName('script')[0];
+
+        // Don't add `<script>` tag twice
+        if (d.getElementById(id)) {
+          return;
+        }
+
+        js = d.createElement('script');
+        js.id = id;
+        js.async = true;
+        js.src = '//connect.facebook.net/en_US/sdk.js';
+        fjs.parentNode.insertBefore(js, fjs);
+
+      }($document[0]));
+
+    }
+
+    /**
+     * Executed when the SDK is loaded
+     * Initialize FB API and get user's authentication status (from FB)
+     */
+    function fbAsyncInit() {
+      FB.init({
+
+        // The app id of the web app;
+        // To register a new app visit Facebook App Dashboard
+        // https://developers.facebook.com/apps/
+        appId: $window.facebookAppId,
+
+        // Check the authentication status of user at the start up of the app?
+        // Above event listener `auth.statusChange` requires this to be `true`
+        status: true,
+
+        // Enable cookies to allow the server to access?
+        // the session
+        cookie: true,
+
+        // Parse XFBML?
+        xfbml: false,
+
+        // FB API version
+        // https://developers.facebook.com/docs/apps/changelog/
+        // https://developers.facebook.com/docs/apps/versions#howlong
+        version: 'v2.8'
+      });
+
+      // Get notified about user's authentication status to FB
+      // https://developers.facebook.com/docs/reference/javascript/FB.Event.subscribe/v2.8
+      // https://developers.facebook.com/docs/reference/javascript/FB.getLoginStatus/#status
+      FB.Event.subscribe('auth.statusChange', statusChangeCallback);
+
+      // Tell anything relying on `FB` that it's now available
+      $rootScope.$broadcast('facebookReady');
+    }
+
+    /**
+     * Handle FB login status
+     */
+    function statusChangeCallback(response) {
+      // `response.status` could be:
+      // - `connected`: logged in
+      // - `not_authorized`: logged in, but not authorized our app
+      // - `unknown`: logged out
+      if (response && response.status === 'connected') {
+        storeAuthResponse(response.authResponse);
+      }
+    }
+
+    /**
+     * Store new oAuth token to server
+     * authResponse:
+     * ```
+     * {
+     *   accessToken: String
+     *   expiresIn: Int
+     *   signedRequest: String
+     *   userID: String
+     * }
+     * ```
+     */
+    function storeAuthResponse(authResponse) {
+      if (!angular.isObject(authResponse)) {
+        return;
+      }
+
+      $http.put('/api/auth/facebook',
+        authResponse,
+        {
+          // Tells Angular-Loading-Bar to ignore this http request
+          // @link https://github.com/chieffancypants/angular-loading-bar#ignoring-particular-xhr-requests
+          ignoreLoadingBar: true
+        });
+    }
+
+  }
+
+}());

--- a/modules/tags/client/controllers/tribe.client.controller.js
+++ b/modules/tags/client/controllers/tribe.client.controller.js
@@ -6,7 +6,7 @@
     .controller('TribeController', TribeController);
 
   /* @ngInject */
-  function TribeController($scope, $state, tribe) {
+  function TribeController($scope, $state, tribe, Facebook) {
 
     var headerHeight = angular.element('#tr-header').height() || 0;
 
@@ -17,6 +17,7 @@
     vm.tribe = tribe;
     vm.windowHeight = angular.element('html').height() - headerHeight;
     vm.goBack = goBack;
+    vm.facebookIsActibe = Facebook.isActive;
 
     // `tr-tribe-join-button` and `tr-tribe-join` directives expect
     // `tribe` to be directly on their scope, as they don't have their own scope.

--- a/modules/tags/client/views/tribe.client.view.html
+++ b/modules/tags/client/views/tribe.client.view.html
@@ -63,12 +63,7 @@
               <a href="https://twitter.com/share" class="twitter-share-button" data-text="Join to meet, host and get hosted by Trustroots Tribe {{::tribeCtrl.tribe.label}}." data-via="trustroots">Tweet</a>
               <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if (!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
             </span>
-            <span class="tribe-share" ng-if="tribeCtrl.tribe.label && app.user.additionalProvidersData.facebook">
-              <span id="fb_share"></span>
-              <script>
-                document.getElementById('fb_share').innerHTML = '<iframe src="https://www.facebook.com/plugins/share_button.php?href=' + encodeURIComponent(location.href) + '&layout=button&mobile_iframe=true&appId=' + (window.facebookAppId || '') + '&width=58&height=20" width="58" height="20" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true"></iframe>';
-              </script>
-            </span>
+            <div ng-if="tribeCtrl.tribe.label" tr-share-fb></div>
           </div>
 
           <!-- For non authenticated members -->

--- a/modules/users/client/controllers/authentication.client.controller.js
+++ b/modules/users/client/controllers/authentication.client.controller.js
@@ -6,7 +6,7 @@
     .controller('AuthenticationController', AuthenticationController);
 
   /* @ngInject */
-  function AuthenticationController($scope, $rootScope, $http, $state, $stateParams, $analytics, Authentication, messageCenterService) {
+  function AuthenticationController($scope, $rootScope, $http, $state, $stateParams, $analytics, Authentication, messageCenterService, Facebook) {
 
     // If user is already signed in then redirect to search page
     if (Authentication.user) $state.go('search.map');
@@ -41,6 +41,9 @@
             category: 'authentication',
             label: 'Login success'
           });
+
+          // Initialize FB SDK
+          Facebook.init();
 
           // Redirect to where we were left off before sign-in page
           // See modules/core/client/controllers/main.client.controller.js

--- a/modules/users/server/config/strategies/facebook.js
+++ b/modules/users/server/config/strategies/facebook.js
@@ -3,16 +3,26 @@
 /**
  * Module dependencies.
  */
-var passport = require('passport'),
+var _ = require('lodash'),
+    passport = require('passport'),
     FacebookStrategy = require('passport-facebook').Strategy,
     users = require('../../controllers/users.server.controller');
 
 module.exports = function(config) {
   // Use facebook strategy
+  var clientID = _.get(config, 'facebook.clientID');
+  var clientSecret = _.get(config, 'facebook.clientSecret');
+  var callbackURL = _.get(config, 'facebook.callbackURL');
+
+  // Don't configure Facebook strategy if missing configuration
+  if (!clientID || !clientSecret || !callbackURL) {
+    return;
+  }
+
   passport.use(new FacebookStrategy({
-    clientID: config.facebook.clientID,
-    clientSecret: config.facebook.clientSecret,
-    callbackURL: config.facebook.callbackURL,
+    clientID: clientID,
+    clientSecret: clientSecret,
+    callbackURL: callbackURL,
     profileFields: ['id', 'name', 'displayName', 'emails', 'photos'],
     passReqToCallback: true,
     enableProof: false
@@ -28,7 +38,7 @@ module.exports = function(config) {
       firstName: profile.name.givenName,
       lastName: profile.name.familyName,
       displayName: profile.displayName,
-      email: profile.emails[0].value,
+      email: profile.emails && profile.emails.length ? profile.emails[0].value : '',
       provider: 'facebook',
       providerIdentifierField: 'id',
       providerData: providerData

--- a/modules/users/server/policies/users.server.policy.js
+++ b/modules/users/server/policies/users.server.policy.js
@@ -66,7 +66,7 @@ exports.invokeRolesPolicies = function() {
       permissions: ['get']
     }, {
       resources: '/api/auth/facebook',
-      permissions: ['get']
+      permissions: ['get', 'put']
     }, {
       resources: '/api/auth/facebook/callback',
       permissions: ['get']
@@ -91,6 +91,7 @@ exports.isAllowed = function(req, res, next) {
 
   // Non-public profiles are invisible
   if (req.profile && !req.profile.public && req.user && !req.profile._id.equals(req.user._id)) {
+    console.log('Non-public profiles are invisible');
     return res.status(404).json({
       message: errorHandler.getErrorMessageByKey('not-found')
     });
@@ -98,6 +99,7 @@ exports.isAllowed = function(req, res, next) {
 
   // No profile browsing for non-public users
   if (req.profile && req.user && !req.user.public && !req.profile._id.equals(req.user._id)) {
+    console.log('No profile browsing for non-public users');
     return res.status(403).json({
       message: errorHandler.getErrorMessageByKey('forbidden')
     });
@@ -116,6 +118,7 @@ exports.isAllowed = function(req, res, next) {
         // Access granted! Invoke next middleware
         return next();
       } else {
+        console.log('->policy 403');
         return res.status(403).json({
           message: errorHandler.getErrorMessageByKey('forbidden')
         });

--- a/modules/users/server/routes/auth.server.routes.js
+++ b/modules/users/server/routes/auth.server.routes.js
@@ -31,10 +31,16 @@ module.exports = function(app) {
   app.route('/api/auth/signout').get(users.signout);
 
   // Setting the facebook oauth routes
+  // See permissions:
+  // https://developers.facebook.com/docs/facebook-login/permissions
   app.route('/api/auth/facebook').all(usersPolicy.isAllowed)
     .get(passport.authenticate('facebook', {
-      scope: ['email']
-    }));
+      scope: [
+        'email',
+        'user_friends'
+      ]
+    }))
+    .put(users.updateFacebookOAuthToken);
   app.route('/api/auth/facebook/callback').all(usersPolicy.isAllowed)
     .get(users.oauthCallback('facebook'));
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "express": "~4.14.0",
     "express-paginate": "~0.2.1",
     "express-session": "~1.14.0",
+    "fbgraph": "~1.3.0",
     "git-rev": "~0.2.1",
     "glob": "~7.1.1",
     "gm": "~1.23.0",


### PR DESCRIPTION
- On first page load, if user is connected to FB, initialize FB api
- When initializing, get FB authentication status
- If logged in and connected to TR, send new short-lived token to API, turn it into long-lived token at the server and store it together with expiration date.

Additionally:
- Reimplement sharing Tribes to FB using a directive
- Fix handling missing emails from FB oAuth

Preliminarily work for #392 and other related features.

Closes #250 