### PR TITLE
Limit fields returned by messages API

### DIFF
--- a/modules/messages/server/controllers/messages.server.controller.js
+++ b/modules/messages/server/controllers/messages.server.controller.js
@@ -59,7 +59,8 @@ exports.inbox = function(req, res) {
     {
       page: req.query.page || 1,
       limit: req.query.limit || 20,
-      sort: 'field -updated',
+      sort: '-updated',
+      select: '_id message read updated userFrom userTo',
       populate: {
         path: 'userFrom userTo message',
         select: 'content ' + userHandler.userMiniProfileFields
@@ -310,7 +311,10 @@ exports.send = function(req, res) {
     // We'll need some info about related users, populate some fields
     function(message, done) {
       message
-        .populate('userFrom', userHandler.userMiniProfileFields)
+        .populate({
+          path: 'userFrom',
+          select: userHandler.userMiniProfileFields
+        })
         .populate({
           path: 'userTo',
           select: userHandler.userMiniProfileFields
@@ -318,6 +322,12 @@ exports.send = function(req, res) {
           if (err) {
             return done(err);
           }
+
+          // Turn to object to be able to delete fields
+          message = message.toObject();
+
+          // Don't return this field
+          delete message.notified;
 
           // Finally return saved message
           return res.json(message);
@@ -376,7 +386,8 @@ exports.threadByUser = function(req, res, next, userId) {
         {
           page: req.query.page || 1,
           limit: req.query.limit || 20,
-          sort: 'field -created',
+          sort: '-created',
+          select: '_id content created read userFrom userTo',
           populate: {
             path: 'userFrom userTo',
             select: userHandler.userMiniProfileFields

--- a/modules/messages/tests/server/message.server.routes.tests.js
+++ b/modules/messages/tests/server/message.server.routes.tests.js
@@ -144,11 +144,11 @@ describe('Message CRUD tests', function() {
                 } else {
 
                   // Set assertions
-                  (thread[0].userFrom._id.toString()).should.equal(userFromId.toString());
-                  (thread[0].userTo._id.toString()).should.equal(userToId.toString());
-                  (thread[0].content).should.equal('Message content');
-                  (thread[0].notified).should.equal(false);
-                  (thread[0].read).should.equal(false);
+                  thread[0].userFrom._id.should.equal(userFromId.toString());
+                  thread[0].userTo._id.should.equal(userToId.toString());
+                  thread[0].content.should.equal('Message content');
+                  thread[0].read.should.equal(false);
+                  should.not.exist(thread[0].notified);
 
                   // Call the assertion callback
                   return done();
@@ -612,11 +612,11 @@ describe('Message CRUD tests', function() {
                 .end(function(messageSaveErr, messageSaveRes) {
 
                   // Set assertions
-                  (messageSaveRes.body.userFrom._id.toString()).should.equal(userFromId.toString());
-                  (messageSaveRes.body.userTo._id.toString()).should.equal(userToId.toString());
+                  messageSaveRes.body.userFrom._id.should.equal(userFromId.toString());
+                  messageSaveRes.body.userTo._id.should.equal(userToId.toString());
                   messageSaveRes.body.content.should.equal('Message content');
-                  messageSaveRes.body.notified.should.equal(false);
                   messageSaveRes.body.read.should.equal(false);
+                  should.not.exist(messageSaveRes.body.notified);
 
                   // Call the assertion callback
                   return done(messageSaveErr);


### PR DESCRIPTION
Leaves out `notified` and `_v` fields which previously were sent trough.