### PR TITLE
added indexes to Message and Thread models

### DIFF
--- a/modules/messages/server/models/message.server.model.js
+++ b/modules/messages/server/models/message.server.model.js
@@ -41,12 +41,6 @@ var MessageSchema = new Schema({
   }
 });
 
-// This index is useful when searching Messages by both userFrom and userTo
-// Is probably not necessary thanks to Index Intersection
-// https://docs.mongodb.com/manual/core/index-intersection/#index-intersection-and-compound-indexes
-//
-// MessageSchema.index({ userFrom: 1, userTo: -1 });
-
 MessageSchema.plugin(mongoosePaginate);
 
 mongoose.model('Message', MessageSchema);

--- a/modules/messages/server/models/message.server.model.js
+++ b/modules/messages/server/models/message.server.model.js
@@ -23,11 +23,13 @@ var MessageSchema = new Schema({
   },
   userFrom: {
     type: Schema.ObjectId,
-    ref: 'User'
+    ref: 'User',
+    index: true
   },
   userTo: {
     type: Schema.ObjectId,
-    ref: 'User'
+    ref: 'User',
+    index: true
   },
   read: {
     type: Boolean,
@@ -38,6 +40,12 @@ var MessageSchema = new Schema({
     default: false
   }
 });
+
+// This index is useful when searching Messages by both userFrom and userTo
+// Is probably not necessary thanks to Index Intersection
+// https://docs.mongodb.com/manual/core/index-intersection/#index-intersection-and-compound-indexes
+//
+// MessageSchema.index({ userFrom: 1, userTo: -1 });
 
 MessageSchema.plugin(mongoosePaginate);
 

--- a/modules/messages/server/models/thread.server.model.js
+++ b/modules/messages/server/models/thread.server.model.js
@@ -17,11 +17,13 @@ var ThreadSchema = new Schema({
   },
   userFrom: {
     type: Schema.ObjectId,
-    ref: 'User'
+    ref: 'User',
+    index: true
   },
   userTo: {
     type: Schema.ObjectId,
-    ref: 'User'
+    ref: 'User',
+    index: true
   },
   // This points to the latest message inn this thread
   message: {
@@ -33,6 +35,12 @@ var ThreadSchema = new Schema({
     default: false
   }
 });
+
+// This index is useful when searching Threads by both userFrom and userTo
+// Is probably not necessary thanks to Index Intersection
+// https://docs.mongodb.com/manual/core/index-intersection/#index-intersection-and-compound-indexes
+//
+// ThreadSchema.index({ userFrom: 1, userTo: -1 });
 
 ThreadSchema.plugin(mongoosePaginate);
 

--- a/modules/messages/server/models/thread.server.model.js
+++ b/modules/messages/server/models/thread.server.model.js
@@ -36,12 +36,6 @@ var ThreadSchema = new Schema({
   }
 });
 
-// This index is useful when searching Threads by both userFrom and userTo
-// Is probably not necessary thanks to Index Intersection
-// https://docs.mongodb.com/manual/core/index-intersection/#index-intersection-and-compound-indexes
-//
-// ThreadSchema.index({ userFrom: 1, userTo: -1 });
-
 ThreadSchema.plugin(mongoosePaginate);
 
 mongoose.model('Thread', ThreadSchema);


### PR DESCRIPTION
#455 

__Edit:__

Now, I'm not sure if this is not too rushed. There are many [things](https://docs.mongodb.com/manual/core/data-model-operations/#data-model-indexes) - [to](https://docs.mongodb.com/manual/applications/indexes/) - [consider](https://docs.mongodb.com/manual/indexes/#additional-considerations) when designing indexes.

Were there any attempts to achieve this in the past? Is there any MongoDB indexing pro?

I.e. now i commented out the compound indexes on `userFrom` and `userTo` based on [this article](https://docs.mongodb.com/manual/core/index-intersection/#index-intersection-and-compound-indexes).