### PR TITLE
Fix failing test for client age filter

### DIFF
--- a/modules/core/client/filters/age.client.filter.js
+++ b/modules/core/client/filters/age.client.filter.js
@@ -4,7 +4,8 @@
   /**
    * Turn mongo date string into years
    *
-   * Input: '1986-05-30' or new Date(1986, 05, 30)
+   * Input: '1986-05-30' or new Date(1986, 04, 30)
+   * (00 - January, 04 - May in new Date())
    * Output: 28 years
    *
    * @link http://stackoverflow.com/a/24883386

--- a/modules/core/tests/client/age.client.filter.tests.js
+++ b/modules/core/tests/client/age.client.filter.tests.js
@@ -9,7 +9,8 @@
     // Load the main application module
     beforeEach(module(AppConfig.appModuleName));
 
-    var dateObj = new Date(1985, 11, 22),
+    // Note that 10 is November in Date
+    var dateObj = new Date(1985, 10, 22),
         ageDifMs = Date.now() - dateObj.getTime(),
         ageDate = new Date(ageDifMs), // miliseconds from epoch
         ageYears = Math.abs(ageDate.getUTCFullYear() - 1970);
@@ -19,7 +20,7 @@
     }));
 
     it('should return age in years from a date object', inject(function(ageyearsFilter) {
-      expect(ageyearsFilter(new Date(1985, 11, 22))).toBe(ageYears + ' years');
+      expect(ageyearsFilter(new Date(1985, 10, 22))).toBe(ageYears + ' years');
     }));
 
   });


### PR DESCRIPTION
Minimal changes only. Anything further would lead to inconsistencies or need for further refactor.

That can be done later.

The tests were failing because months are counted from 0 in javascript `Date`, not from 1 like common experience.