### PR TITLE
Simplify Influxdb service API and fix errors around tests

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -350,7 +350,7 @@ gulp.task('selenium', plugins.shell.task('python ./scripts/selenium/test.py'));
 gulp.task('mocha', function(done) {
   // Open mongoose connections
   var mongoose = require('./config/lib/mongoose');
-  // var agenda = require('./config/lib/agenda');
+  var agenda = require('./config/lib/agenda');
   var testSuites = changedTestFiles.length ? changedTestFiles : testAssets.tests.server;
   var error;
 
@@ -373,11 +373,11 @@ gulp.task('mocha', function(done) {
         // and pass the error state back to gulp
         // @todo: https://github.com/Trustroots/trustroots/issues/438
         // Mikael temporarily disabled this 11/2016 to fix crashing test-watching
-        // agenda._mdb.close(function() {
-        mongoose.disconnect(function() {
-          done(error);
+        agenda._mdb.close(function() {
+          mongoose.disconnect(function() {
+            done(error);
+          });
         });
-        // });
       });
   });
 

--- a/modules/core/server/services/influx.server.service.js
+++ b/modules/core/server/services/influx.server.service.js
@@ -6,7 +6,8 @@
 var path = require('path'),
     Influx = require('influx'),
     _ = require('lodash'),
-    config = require(path.resolve('./config/config'));
+    config = require(path.resolve('./config/config')),
+    log = require(path.resolve('./config/lib/logger'));
 
 /**
  * Get InfluxDB Client
@@ -36,7 +37,7 @@ exports.getClient = function(callback) {
  *   - key in camelCase
  *   - value - string or number (other options?)
  * You can specify time by passing a property called time (default: now)
- *   - time can either be an integer (default ms) or a date object.
+ *   - time should always be Date object.
  * tags - object of tag key: value pairs. To save to influxdb
  *   - key in camelCase
  *   - value should be string or will be casted to string
@@ -46,34 +47,56 @@ exports.getClient = function(callback) {
  * influxdb (camelCase)
  * @param {Object} fields - key: value pairs will be saved in influxdb as field
  * key: field value
- * @param {number|Date} [fields.time=new Date()] - time of measurement with precision nanosecond
+ * @param {number|Date} [fields.time=new Date()] - time of measurement
  * @param {Object} tags - key: value pairs will be saved in influxdb as tag key:
  * tag value
  * @param {function} callback - expected to be like function (err, result) {}
  */
 exports.writeMeasurement = function(measurementName, fields, tags, callback) {
 
+  var errorMessage;
+
   if (!measurementName || typeof measurementName !== 'string'
     || measurementName.length === 0) {
-    return callback(new Error('InfluxDB Service: no `measurementName` defined.'));
+    errorMessage = 'InfluxDB Service: no `measurementName` defined. #ghi3kH';
+    // Log the failure
+    log('error', errorMessage);
+    return callback(new Error(errorMessage));
   }
 
   if (!_.isPlainObject(fields)) {
-    return callback(new Error('InfluxDB Service: no `fields` defined.'));
+    errorMessage = 'InfluxDB Service: no `fields` defined. #ghugGJ';
+    // Log the failure
+    log('error', errorMessage, {
+      measurement: measurementName
+    });
+    return callback(new Error(errorMessage));
   }
 
   if (!_.isPlainObject(tags)) {
-    return callback(new Error('InfluxDB Service: no `tags` defined.'));
+    errorMessage = 'InfluxDB Service: no `tags` defined. #ghj3ig';
+    // Log the failure
+    log('error', errorMessage, {
+      measurement: measurementName
+    });
+    return callback(new Error(errorMessage));
   }
 
-  // Validate time: it should always be a `Date` object
-  if (fields.time && !_.isDate(fields.time)) {
-    return callback(new Error('InfluxDB Service: expected `fields.time` to be `Date` object.'));
-  }
-
-  // Add current time to `fields` if it's missing
   if (!fields.time) {
-    fields.time = new Date();
+    // Add current time to `fields` if it's missing
+    fields.time = new Date().getTime();
+  } else if (!_.isDate(fields.time)) {
+    // Validate time: it should always be a `Date` object
+    errorMessage = 'InfluxDB Service: expected `fields.time` to be `Date` object. #f93jkh';
+    // Log the failure
+    log('error', errorMessage, {
+      measurement: measurementName,
+      time: fields.time
+    });
+    return callback(new Error(errorMessage));
+  } else {
+    // Turn Date object into an integer (ms precision)
+    fields.time = fields.time.getTime();
   }
 
   exports.getClient(function(err, client) {
@@ -86,7 +109,19 @@ exports.writeMeasurement = function(measurementName, fields, tags, callback) {
         fields: fields,
         tags: tags
       }
-    ]);
+    ])
+    .then(function() {
+      if (callback) callback();
+    })
+    .catch(function(err) {
+      // Log the failure
+      log('error', 'InfluxDB Service: Error while writing to InfluxDB #fj38hh', {
+        error: err,
+        measurement: measurementName,
+        fields: fields,
+        tags: tags
+      });
+    });
 
   });
 };

--- a/modules/core/tests/server/services/influx.server.service.tests.js
+++ b/modules/core/tests/server/services/influx.server.service.tests.js
@@ -35,7 +35,7 @@ describe('Service: influx', function() {
   it('Writing point returns error with no measurementName', function(done) {
     influxService.writeMeasurement(null, { value: 1 }, { tag: 'tag' }, function(err) {
       try {
-        err.message.should.equal('InfluxDB Service: no `measurementName` defined.');
+        err.message.should.equal('InfluxDB Service: no `measurementName` defined. #ghi3kH');
         return done();
 
       } catch (e) {
@@ -47,7 +47,7 @@ describe('Service: influx', function() {
   it('Writing point returns error with no value', function(done) {
     influxService.writeMeasurement('test', null, { tag: 'tag' }, function(err) {
       try {
-        err.message.should.equal('InfluxDB Service: no `fields` defined.');
+        err.message.should.equal('InfluxDB Service: no `fields` defined. #ghugGJ');
         return done();
       } catch (e) {
         return done(e);
@@ -58,7 +58,7 @@ describe('Service: influx', function() {
   it('Writing point returns error with no tag', function(done) {
     influxService.writeMeasurement('test', { value: 1 }, null, function(err) {
       try {
-        err.message.should.equal('InfluxDB Service: no `tags` defined.');
+        err.message.should.equal('InfluxDB Service: no `tags` defined. #ghj3ig');
         return done();
       } catch (e) {
         return done(e);
@@ -69,7 +69,7 @@ describe('Service: influx', function() {
   it('Writing point returns error with wrong time format (nanoseconds)', function(done) {
     influxService.writeMeasurement('test', { value: 1, time: 1475985480231035600 }, { tag: 'tag' }, function(err) {
       try {
-        err.message.should.equal('InfluxDB Service: expected `fields.time` to be `Date` object.');
+        err.message.should.equal('InfluxDB Service: expected `fields.time` to be `Date` object. #f93jkh');
         return done();
 
       } catch (e) {
@@ -81,7 +81,7 @@ describe('Service: influx', function() {
   it('Writing point returns error with wrong time format (milliseconds)', function(done) {
     influxService.writeMeasurement('test', { value: 1, time: 1475985480231 }, { tag: 'tag' }, function(err) {
       try {
-        err.message.should.equal('InfluxDB Service: expected `fields.time` to be `Date` object.');
+        err.message.should.equal('InfluxDB Service: expected `fields.time` to be `Date` object. #f93jkh');
         return done();
 
       } catch (e) {
@@ -93,7 +93,7 @@ describe('Service: influx', function() {
   it('Writing point returns error with wrong time format (string)', function(done) {
     influxService.writeMeasurement('test', { value: 1, time: '2016-10-09T03:58:00.231035600Z' }, { tag: 'tag' }, function(err) {
       try {
-        err.message.should.equal('InfluxDB Service: expected `fields.time` to be `Date` object.');
+        err.message.should.equal('InfluxDB Service: expected `fields.time` to be `Date` object. #f93jkh');
         return done();
 
       } catch (e) {

--- a/modules/messages/tests/server/message-to-influx-functional.server.service.tests.js
+++ b/modules/messages/tests/server/message-to-influx-functional.server.service.tests.js
@@ -7,9 +7,9 @@ var mongoose = require('mongoose'),
     config = require(path.resolve('./config/config')),
     User = mongoose.model('User'),
     EventEmitter = require('events'),
+    Promise = require('promise'),
     Message = mongoose.model('Message'),
-    influxService =
-  require(path.resolve('./modules/core/server/services/influx.server.service')),
+    influxService = require(path.resolve('./modules/core/server/services/influx.server.service')),
     originalGetClient = influxService.getClient;
 
 // this emitter will emit event 'reachedInfluxdb' with variables measurement,
@@ -19,9 +19,13 @@ var reachEventEmitter = new EventEmitter();
 // it will emit an event 'reachedInfluxdb' which should be caught in the tests
 
 // mocking the influxdb.writeMeasurement()
+//
 var influxdb = {
   writeMeasurement: function (measurement, fields, tags) {
-    reachEventEmitter.emit('reachedInfluxdb', measurement, fields, tags);
+    return new Promise(function (resolve) {
+      reachEventEmitter.emit('reachedInfluxdb', measurement, fields, tags);
+      resolve();
+    });
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
     "validator": "~6.1.0",
     "winston": "~2.3.0",
     "winston-papertrail": "~1.0.3",
-    "winston": "~2.3.0",
     "yargs": "~6.3.0"
   },
   "devDependencies": {
@@ -138,6 +137,7 @@
     "mocha": "~3.1.2",
     "nodemailer-stub-transport": "~1.1.0",
     "phantomjs-prebuilt": ">=2.1",
+    "promise": "~7.1.1",
     "semver": "~5.3.0",
     "should": "~11.1.0",
     "sinon": "~1.17.5",


### PR DESCRIPTION
Always expect`fields.time` to be a `Date` and turn it to integer (ms
precision)