### PR TITLE
Display confirming email. Store email in signup token

### DIFF
--- a/modules/core/server/services/email.server.service.js
+++ b/modules/core/server/services/email.server.service.js
@@ -154,7 +154,7 @@ exports.sendChangeEmailConfirmation = function(user, callback) {
 
 exports.sendSignupEmailConfirmation = function(user, callback) {
 
-  var urlConfirm = url + '/confirm-email/' + user.emailToken + '?signup',
+  var urlConfirm = url + '/confirm-email/' + user.emailToken + '?signup=true',
       campaign = 'confirm-email';
 
   var params = exports.addEmailBaseTemplateParams({
@@ -192,7 +192,7 @@ exports.sendSupportRequest = function(replyTo, supportRequest, callback) {
 
 exports.sendSignupEmailReminder = function(user, callback) {
 
-  var urlConfirm = url + '/confirm-email/' + user.emailToken + '?signup',
+  var urlConfirm = url + '/confirm-email/' + user.emailToken + '?signup=true',
       campaign = 'signup-reminder';
 
   // This email is a reminder number `n` to this user

--- a/modules/core/tests/server/services/email.server.service.tests.js
+++ b/modules/core/tests/server/services/email.server.service.tests.js
@@ -275,7 +275,7 @@ describe('Service: email', function() {
       jobs[0].type.should.equal('send email');
       jobs[0].data.subject.should.equal('Complete your signup to Trustroots');
       jobs[0].data.text.should.containEql('Your profile will not be visible to others if you don\'t confirm your email address (' + user.emailTemporary + ').');
-      jobs[0].data.text.should.containEql('/confirm-email/' + user.emailToken + '?signup');
+      jobs[0].data.text.should.containEql('/confirm-email/' + user.emailToken + '?signup=true');
       jobs[0].data.to.name.should.equal(user.displayName);
       jobs[0].data.to.address.should.equal(user.email);
       done();

--- a/modules/users/client/controllers/confirm-email.client.controller.js
+++ b/modules/users/client/controllers/confirm-email.client.controller.js
@@ -6,7 +6,7 @@
     .controller('ConfirmEmailController', ConfirmEmailController);
 
   function getEmailFromToken(token) {
-    // old tokens have lenght 40 symbols
+    // old tokens have lenght 40 symbols. pullrequest #465
     if (token.length <= 40) {
       return null;
     }

--- a/modules/users/client/controllers/confirm-email.client.controller.js
+++ b/modules/users/client/controllers/confirm-email.client.controller.js
@@ -5,6 +5,18 @@
     .module('users')
     .controller('ConfirmEmailController', ConfirmEmailController);
 
+  function getEmailFromToken(token) {
+    // old tokens have lenght 40 symbols
+    if (token.length <= 40) {
+      return null;
+    }
+    var str = '';
+    for (var i = 40; i < token.length; i += 2) {
+      str += String.fromCharCode(parseInt(token.substr(i, 2), 16));
+    }
+    return str;
+  }
+
   /* @ngInject */
   function ConfirmEmailController($rootScope, $http, $state, $stateParams, Authentication) {
 
@@ -16,6 +28,7 @@
     vm.success = null;
     vm.error = null;
     vm.isLoading = false;
+    vm.email = getEmailFromToken($stateParams.token);
 
     // Is ?signup at the url (set only for first email confirms)
     vm.signup = angular.isDefined($stateParams.signup);

--- a/modules/users/client/views/authentication/confirm-email.client.view.html
+++ b/modules/users/client/views/authentication/confirm-email.client.view.html
@@ -16,6 +16,7 @@
 
           <div class="text-center form-group" ng-if="!confirmEmail.success">
 
+            <a ng-if="confirmEmail.email" href="mailto:{{ confirmEmail.email }}"><h4>{{ confirmEmail.email }}</h4></a>
             <p class="lead" ng-if="confirmEmail.signup">Confirm your email and make your profile visible to others.</p>
             <p class="lead" ng-if="!confirmEmail.signup">Confirm your email.</p>
 

--- a/modules/users/client/views/authentication/confirm-email.client.view.html
+++ b/modules/users/client/views/authentication/confirm-email.client.view.html
@@ -16,7 +16,7 @@
 
           <div class="text-center form-group" ng-if="!confirmEmail.success">
 
-            <a ng-if="confirmEmail.email" href="mailto:{{ confirmEmail.email }}"><h4>{{ confirmEmail.email }}</h4></a>
+            <h4 ng-if="::confirmEmail.email" ng-bind="::confirmEmail.email"></h4>
             <p class="lead" ng-if="confirmEmail.signup">Confirm your email and make your profile visible to others.</p>
             <p class="lead" ng-if="!confirmEmail.signup">Confirm your email.</p>
 


### PR DESCRIPTION
On confirm-email page it's not possible to determine user's email (as far as I know). So I decided to encode email into signup token. I generate 20 bytes of crypto-salt and consolidate it with user's email. Result buffer I encode into hex.
After that on confirm-email page I decode string, skip first 20 bytes and display the email.