### PR TITLE
#342 Suspended users

### DIFF
--- a/modules/core/server/controllers/errors.server.controller.js
+++ b/modules/core/server/controllers/errors.server.controller.js
@@ -20,6 +20,7 @@ exports.getErrorMessageByKey = function(key) {
     'unsupported-media-type': 'Unsupported Media Type.', // Status 415
     'bad-request': 'Bad request.', // Status 400
     'conflict': 'Conflict.', // Status 409
+    'suspended': 'Your account has been suspended.',
     'default': defaultErrorMessage
   };
 

--- a/modules/core/server/views/suspended.server.view.html
+++ b/modules/core/server/views/suspended.server.view.html
@@ -1,0 +1,28 @@
+{% extends 'layout.server.view.html' %}
+
+{% block header %}{% endblock %}
+
+{% block content %}
+  <section class="container container-fullscreen container-error board board-error">
+    <div class="middle-wrapper middle-wrapper-horizontal">
+      <div class="middle-content">
+
+        <div class="row">
+          <div class="col-md-6 col-md-offset-3 text-center" role="alert">
+            <h1>{{message}}</h1>
+            <br><br>
+            <a href="/rules" target="_top" class="btn btn-default btn-md">
+              Rules Of Trustroots
+            </a>
+            <a href="/contact" target="_top" class="btn btn-default btn-md">
+              Contact us
+            </a>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </section>
+{% endblock %}
+
+{% block footer %}{% endblock %}

--- a/modules/pages/client/views/faq-general.client.view.html
+++ b/modules/pages/client/views/faq-general.client.view.html
@@ -39,6 +39,11 @@
   The practical answer: it takes time to set up a forum and even more time to keep it spam-free. The less practical answer: In our long-term and short-term experience forum activity is not necessarily the best way to get to more real life interactions. In the long term we do want to provide a way to communicate on the site, but this will probably look more like the quick and easy way you can interact on Facebook or Diaspora than a full fledged forum.
 </div>
 
+<div class="faq-question" id="why-was-my-account-suspended">
+  <h3>Why was my account suspended?</h3>
+  See <a ui-sref="rules">rules of Trustroots</a> for details.
+</div>
+
 <div class="faq-question" id="how-can-i-contact-you">
   <h3>How can can I contact you?</h3>
   In plenty of public and private ways: <a ui-sref="support">drop us a message</a>, <a href="https://ideas.trustroots.org/">our blog</a>, <a href="https://github.com/Trustroots/trustroots/issues">GitHub</a>, <a href="https://twitter.com/trustroots">Twitter</a>, <a href="http://webchat.freenode.net/?channels=trustroots">IRC</a> and for private contacts, see <a ui-sref="team">the team</a> page.

--- a/modules/pages/client/views/faq.client.view.html
+++ b/modules/pages/client/views/faq.client.view.html
@@ -52,6 +52,9 @@
               <a ui-sref=".general({'#': 'why-is-there-no-forum'})" class="list-group-item">
                 Why is there no forum?
               </a>
+              <a ui-sref=".general({'#': 'why-was-my-account-suspended'})" class="list-group-item">
+                Why was my account suspended?
+              </a>
               <a ui-sref=".general({'#': 'how-can-i-contact-you'})" class="list-group-item">
                 How can can I contact you?
               </a>

--- a/modules/users/server/config/users.config.server.js
+++ b/modules/users/server/config/users.config.server.js
@@ -6,7 +6,8 @@
 var passport = require('passport'),
     User = require('mongoose').model('User'),
     path = require('path'),
-    config = require(path.resolve('./config/config'));
+    config = require(path.resolve('./config/config')),
+    usersSuspended = require(path.resolve('./modules/users/server/controllers/users-suspended.server.controller'));
 
 module.exports = function(app) {
   // Serialize sessions
@@ -31,4 +32,7 @@ module.exports = function(app) {
   // Add passport's middleware
   app.use(passport.initialize());
   app.use(passport.session());
+
+  // Handle logging out suspended users
+  app.use(usersSuspended.invalidateSuspendedSessions);
 };

--- a/modules/users/server/controllers/users-suspended.server.controller.js
+++ b/modules/users/server/controllers/users-suspended.server.controller.js
@@ -1,0 +1,51 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+var _ = require('lodash'),
+    path = require('path'),
+    errorHandler = require(path.resolve('./modules/core/server/controllers/errors.server.controller'));
+
+/**
+ * Handle invalidating sessions of suspended users
+ */
+exports.invalidateSuspendedSessions = function(req, res, next) {
+
+  // User is suspended
+  if (req.user && _.isArray(req.user.roles) && req.user.roles.indexOf('suspended') > -1) {
+
+    // Passport method for logging out user
+    req.logout();
+
+    // Express session middleware way of removing the session
+    // https://github.com/expressjs/session#sessiondestroycallback
+    return req.session.destroy(function() {
+
+      // A short one-liner
+      var suspendedMessage = errorHandler.getErrorMessageByKey('suspended');
+
+      // Do content negotiation and return a message
+      // https://expressjs.com/en/api.html#res.format
+      res.status(403).format({
+        // For HTML calls send "suspended" html view
+        'text/html': function() {
+          res.render('modules/core/server/views/suspended', {
+            message: suspendedMessage
+          });
+        },
+        // For API calls send "suspended" json message
+        'application/json': function() {
+          res.json({
+            message: suspendedMessage
+          });
+        }
+      });
+
+    });
+
+  }
+
+  // User isn't suspended, just continue
+  next();
+};

--- a/modules/users/server/models/user.server.model.js
+++ b/modules/users/server/models/user.server.model.js
@@ -197,7 +197,7 @@ var UserSchema = new Schema({
   roles: {
     type: [{
       type: String,
-      enum: ['user', 'admin']
+      enum: ['user', 'admin', 'suspended']
     }],
     default: ['user']
   },

--- a/modules/users/tests/server/user.server.model.tests.js
+++ b/modules/users/tests/server/user.server.model.tests.js
@@ -254,6 +254,69 @@ describe('User Model Unit Tests:', function() {
 
   });
 
+  describe('Roles Validation', function() {
+    it('should show error when trying to save with non-existing role', function(done) {
+      var _user = new User(user);
+
+      _user.roles = ['nope'];
+      _user.save(function(err) {
+        should.exist(err);
+        done();
+      });
+    });
+
+    it('should save without any roles', function(done) {
+      var _user = new User(user);
+
+      _user.roles = [];
+      _user.save(function(err) {
+        should.not.exist(err);
+        done();
+      });
+    });
+
+    it('should save with "user" role', function(done) {
+      var _user = new User(user);
+
+      _user.roles = ['user'];
+      _user.save(function(err) {
+        should.not.exist(err);
+        done();
+      });
+    });
+
+    it('should save with "admin" role', function(done) {
+      var _user = new User(user);
+
+      _user.roles = ['admin'];
+      _user.save(function(err) {
+        should.not.exist(err);
+        done();
+      });
+    });
+
+    it('should save with "suspended" role', function(done) {
+      var _user = new User(user);
+
+      _user.roles = ['suspended'];
+      _user.save(function(err) {
+        should.not.exist(err);
+        done();
+      });
+    });
+
+    it('should save with multiple roles', function(done) {
+      var _user = new User(user);
+
+      _user.roles = ['user', 'admin'];
+      _user.save(function(err) {
+        should.not.exist(err);
+        done();
+      });
+    });
+
+  });
+
   afterEach(function(done) {
     User.remove().exec(done);
   });


### PR DESCRIPTION
- Adds `suspended` user role
- Won’t let users with `suspended` role sign in
- Destroys active sessions of users with `suspended` role and causes
API endpoints return 403
- Redirects returning users with active sessions to “Your account has
been suspended.” page with links to rules and contact pages.
- Add FAQ about account suspension