### PR TITLE
Add site-wide announcements

### DIFF
--- a/config/env/default.js
+++ b/config/env/default.js
@@ -17,6 +17,15 @@ module.exports = {
     title: 'Trustroots',
     description: 'Travellers community for sharing, hosting and getting people together. We want a world that encourages trust and adventure.'
   },
+  // Appears on top of every page for authenticated users.
+  // There's no way turning them off permanently,
+  // so remember to keep them visible only limited times.
+  siteAnnouncement: {
+    enabled: false,
+    // Can contain HTML
+    // You can access user object like this: `{{app.user.displayName}}`
+    message: ''
+  },
   maxUploadSize: process.env.MAX_UPLOAD_SIZE || 10 * 1024 * 1024, // 10MB. Remember to change this to Nginx configs as well
   imageProcessor: 'graphicsmagick', // graphicsmagick|imagemagick
   uploadTmpDir: './tmp/',

--- a/config/env/local.sample.js
+++ b/config/env/local.sample.js
@@ -13,6 +13,18 @@
 
 module.exports = {
 
+  /*
+  // Appears on top of every page for authenticated users.
+  // There's no way turning them off permanently,
+  // so remember to keep them visible only limited times.
+  siteAnnouncement: {
+    enabled: true,
+    // Can contain HTML
+    // You can access user object like this: `{{app.user.displayName}}`
+    message: 'Hey {{app.user.displayName}}!'
+  },
+  */
+
   // Uncomment if you have installed InfluxDB and would like to store collected statistics
   /*
   influxdb: {

--- a/config/lib/express.js
+++ b/config/lib/express.js
@@ -43,6 +43,7 @@ module.exports.initLocalVariables = function (app) {
   app.locals.appSettings.https = config.https;
   app.locals.appSettings.maxUploadSize = config.maxUploadSize;
   app.locals.appSettings.profileMinimumLength = config.profileMinimumLength;
+  app.locals.siteAnnouncement = config.siteAnnouncement || { enabled: false };
 
   if (process.env.NODE_ENV !== 'production') {
     app.locals.jsFiles = _.concat(config.files.client.js, 'dist/uib-templates.js');

--- a/modules/core/client/less/global-variables.less
+++ b/modules/core/client/less/global-variables.less
@@ -48,6 +48,9 @@
 @link-color:                @brand-secondary;
 @link-hover-color:          darken(@link-color, 15%);
 
+// Site wide announcement header
+@site-announcement-height: 53px;
+
 // Notification badge directive
 @notification-badge-bg:     #d9534f;
 @notification-badge-text:   #fff;

--- a/modules/core/client/less/layout/site-announcement.less
+++ b/modules/core/client/less/layout/site-announcement.less
@@ -1,0 +1,22 @@
+/**
+ * Styles for side wide announcement header
+ *
+ * See also core's `header.less` and search module less for more.
+ */
+body.is-site-announcement-visible {
+  padding-top: @site-announcement-height;
+
+  #tr-header {
+    top: @site-announcement-height;
+  }
+}
+
+.site-announcement {
+  position: fixed;
+  z-index: @zindex-navbar-fixed;
+  height: @site-announcement-height;
+  top: 0;
+  left: 0;
+  right: 0;
+  margin: 0;
+}

--- a/modules/core/server/views/layout.server.view.html
+++ b/modules/core/server/views/layout.server.view.html
@@ -109,7 +109,10 @@
 </head>
 <body class="ng-cloak"
       tr-window-blur="app.onWindowBlur()"
-      tr-window-focus="app.onWindowFocus()">
+      tr-window-focus="app.onWindowFocus()"
+      {% if siteAnnouncement.enabled && siteAnnouncement.message !== '' %}
+        ng-class="{ 'is-site-announcement-visible': app.user && !app.isSiteAnnouncementClosed }"
+      {% endif %}>
 
   <div id="tr-wrap">
 
@@ -119,6 +122,18 @@
 
     {# Flash messages #}
     <mc-messages></mc-messages>
+
+    {# Site wide notifications #}
+    {# Enabled from `local.js` config #}
+    {% if siteAnnouncement.enabled && siteAnnouncement.message !== '' %}
+      <div class="alert alert-success site-announcement" ng-if="app.user && !app.isSiteAnnouncementClosed">
+        {{siteAnnouncement.message}}
+        <a class="close"
+           ng-click="app.isSiteAnnouncementClosed = true;"
+           data-dismiss="alert"
+           aria-hidden="true">×</a>
+      </div>
+    {% endif %}
 
     <article class="content" id="tr-main" role="main">
       {% block content %}{% endblock %}

--- a/modules/search/client/less/map.less
+++ b/modules/search/client/less/map.less
@@ -82,5 +82,13 @@
     }
     */
   }
+  // Push map down a bit when sitewide announcements are visible.
+  // See `modules/core/client/less/layout/site-announcement.less` for more.
+  body.is-site-announcement-visible {
+    .search-map-active-area,
+    .leaflet-container {
+      top: @navbar-height + @site-announcement-height;
+    }
+  }
 
 }

--- a/modules/search/client/less/sidebar.less
+++ b/modules/search/client/less/sidebar.less
@@ -35,6 +35,14 @@
   }
 }
 
+// Push sidebar down a bit when sitewide announcements are visible.
+// See `modules/core/client/less/layout/site-announcement.less` for more.
+body.is-site-announcement-visible {
+  .search-sidebar {
+    top: @navbar-height + @site-announcement-height;
+  }
+}
+
 // "Clear selections" button for filters
 .search-sidebar-filters-clear {
   float: right;


### PR DESCRIPTION
Ping @chmac 

Used trough configs:
```js
  // Appears on top of every page for authenticated users.
  // There's no way turning them off permanently,
  // so remember to keep them visible only limited times.
  siteAnnouncement: {
    enabled: true,
    // Can contain HTML
    // You can access user object like this: `{{app.user.displayName}}`
    message: 'hey {{app.user.displayName}}!'
  },
```