### PR TITLE
Fixes #348 Typing reply message scrolls down the existing messages

### DIFF
--- a/modules/messages/client/controllers/thread.client.controller.js
+++ b/modules/messages/client/controllers/thread.client.controller.js
@@ -291,7 +291,12 @@
 
         // $timeout ensures scroll happens only after DOM has finished rendering
         $timeout(function() {
-          $scope.$broadcast('threadScrollToBottom');
+          // changing event as scroll should happen not at
+          // every char type as person would be looking at
+          // scroll history, but once he sends the message
+
+          // $scope.$broadcast('threadScrollToBottom');
+          $scope.$broadcast('threadMessageSend');
         });
 
       }, function(errorResponse) {

--- a/modules/messages/client/directives/thread-dimensions.client.directive.js
+++ b/modules/messages/client/directives/thread-dimensions.client.directive.js
@@ -42,11 +42,13 @@
               elemThreadScrollTop = elemThread.scrollTop(),
               elemThreadSHeight = elemThread.prop('scrollHeight');
 
-          elemThread.on('mouseover', function() {
-            enableScroll();
-          });
+          elemThread.on('touchstart', enableScroll);
+          elemThread.on('mouseover', enableScroll);
 
-          elemReply.on('mouseover', function() {
+          elemReply.on('touchstart', checkNLock);
+          elemReply.on('mouseover', checkNLock);
+
+          function checkNLock() {
             // This condition can be tuned for how much page view can enable scroll
             // console.log(elemThreadCHeight + ',' + elemThreadScrollTop + '=' + elemThreadSHeight);
             if (elemThreadCHeight + elemThreadScrollTop === elemThreadSHeight) {
@@ -54,7 +56,7 @@
             } else {
               disableScroll();
             }
-          });
+          }
 
           if (onScrollTimeout) $timeout.cancel(onScrollTimeout);
           onScrollTimeout = $timeout(function() {
@@ -70,6 +72,8 @@
         function enableScroll() {
           scrollLock = false;
           elemThread.css({ overflow: 'auto' });
+          var elemReplyContent = angular.element('#message-reply-content');
+          elemReplyContent.blur();
         }
 
         /**


### PR DESCRIPTION
- newly added event threadMessageSend is broadcasted to handle scroll
- scroll enable / disable functions added
- behaviour is: if user seeing scrolled history, scroll is locked
- if user sends the message, scroll is unlocked and scroll happens
- used mouseover events
- tested on fresh install