### PR TITLE
Accept invitation codes +1/-3 days

### DIFF
--- a/modules/users/client/services/invitation.client.service.js
+++ b/modules/users/client/services/invitation.client.service.js
@@ -22,6 +22,12 @@
       return date;
     };
 
+    var setTomorrow = function(d) {
+      var date = new Date(d.getTime())
+      date.setDate(date.getDate() + 1);
+      return date;
+    };
+
     var setYesterday = function(d) {
       var date = new Date(d.getTime())
       date.setDate(date.getDate() - 1);
@@ -79,6 +85,7 @@
     var validateCode = function(inviteKey, now, code) {
       return moment(now).isSame(codeToDate(inviteKey, code), 'day') ||
         moment(now).isSame(setYesterday(codeToDate(inviteKey, code)), 'day') ||
+        moment(now).isSame(setTomorrow(codeToDate(inviteKey, code)), 'day') ||
         moment(now).isSame(setYesterdayTwo(codeToDate(inviteKey, code)), 'day');
     };
 

--- a/modules/users/client/services/invitation.client.service.js
+++ b/modules/users/client/services/invitation.client.service.js
@@ -14,10 +14,11 @@
     // will not work any more.
 
     var setMidnight = function(date) {
-      date.setUTCHours(0);
-      date.setUTCMinutes(0);
-      date.setSeconds(0);
-      date.setMilliseconds(0);
+      // It's crucial we set these by UTC because we use the timestamp at
+      // midnight as an integer to create a code. If each timezone generated a
+      // different timestamp for midnight, then each timezone would create a
+      // different code which would only work in the same timezone.
+      date.setUTCHours(0, 0, 0, 0); // Sets hours, minutes, seconds, ms
       return date;
     };
 

--- a/modules/users/client/services/invitation.client.service.js
+++ b/modules/users/client/services/invitation.client.service.js
@@ -73,13 +73,13 @@
 
     // Checks if a code is valid and returns boolean yes or no
     // `inviteKey` - should always be the same, an integer
-    // `today` - a date object, can be `new Date()`, time is ignored
+    // `now` - a date object, can be `new Date()`, time is ignored
     // `code` - a string representation of the invitation code
     // Returns boolean true if code is valid, false if not
-    var validateCode = function(inviteKey, today, code) {
-      today = setMidnight(today);
-      return moment(today).isSame(codeToDate(inviteKey, code), 'day') ||
-        moment(today).isSame(setYesterday(codeToDate(inviteKey, code)), 'day');
+    var validateCode = function(inviteKey, now, code) {
+      return moment(now).isSame(codeToDate(inviteKey, code), 'day') ||
+        moment(now).isSame(setYesterday(codeToDate(inviteKey, code)), 'day') ||
+        moment(now).isSame(setYesterdayTwo(codeToDate(inviteKey, code)), 'day');
     };
 
     // Return service

--- a/modules/users/client/services/invitation.client.service.js
+++ b/modules/users/client/services/invitation.client.service.js
@@ -37,7 +37,7 @@
 
     // Take a date object and return an integer
     var dayToInt = function(d) {
-      return d.getTime() / 1e3;
+      return Math.floor(d.getTime() / 1e3);
     };
 
     // Take an integer and return a date object

--- a/modules/users/client/services/invitation.client.service.js
+++ b/modules/users/client/services/invitation.client.service.js
@@ -23,20 +23,20 @@
     };
 
     var setTomorrow = function(d) {
-      var date = new Date(d.getTime())
+      var date = new Date(d.getTime());
       date.setDate(date.getDate() + 1);
       return date;
     };
 
     var setYesterday = function(d) {
-      var date = new Date(d.getTime())
+      var date = new Date(d.getTime());
       date.setDate(date.getDate() - 1);
       return date;
     };
 
     // Push the date 2 days back so it's the day before yesterday
     var setYesterdayTwo = function(d) {
-      var date = new Date(d.getTime())
+      var date = new Date(d.getTime());
       date.setDate(date.getDate() - 2);
       return date;
     };

--- a/modules/users/client/services/invitation.client.service.js
+++ b/modules/users/client/services/invitation.client.service.js
@@ -28,6 +28,13 @@
       return date;
     };
 
+    // Push the date 2 days back so it's the day before yesterday
+    var setYesterdayTwo = function(d) {
+      var date = new Date(d.getTime())
+      date.setDate(date.getDate() - 2);
+      return date;
+    };
+
     // Take a date object and return an integer
     var dayToInt = function(d) {
       return d.getTime() / 1e3;

--- a/modules/users/client/services/invitation.client.service.js
+++ b/modules/users/client/services/invitation.client.service.js
@@ -22,7 +22,8 @@
       return date;
     };
 
-    var setYesterday = function(date) {
+    var setYesterday = function(d) {
+      var date = new Date(d.getTime())
       date.setDate(date.getDate() - 1);
       return date;
     };


### PR DESCRIPTION
Pushed the acceptance window out so we accept today's code, yesterday's code, the day before yesterday's code, and tomorrow's code. Hopefully that kills any timezone related issues. Also introduced a minor tweak to set midnight UTC more consistently.

@simison As usual, haven't tested...

fixes #502