### PR TITLE
490 precomposed template contact info location

### DIFF
--- a/config/lib/express.js
+++ b/config/lib/express.js
@@ -49,6 +49,13 @@ module.exports.initLocalVariables = function (app) {
   app.locals.appSettings.fcmSenderId = config.fcm.senderId;
   app.locals.siteAnnouncement = config.siteAnnouncement || { enabled: false };
 
+  // Predefined to be localized
+  app.locals.appSettings.messages = {
+    msgCanHost: 'Yes, I can host!',
+    msgCannotHost: 'Sorry, I can\'t host',
+    msgWriteBack: 'Write back'
+  };
+
   if (process.env.NODE_ENV !== 'production') {
     app.locals.jsFiles = _.concat(config.files.client.js, 'dist/uib-templates.js');
     app.locals.cssFiles = _.map(config.files.client.css, function(file) { return file.replace('/client', ''); });

--- a/config/lib/express.js
+++ b/config/lib/express.js
@@ -51,6 +51,7 @@ module.exports.initLocalVariables = function (app) {
 
   // Predefined to be localized
   app.locals.appSettings.messages = {
+    enableTemplates: true,  // display user defined template options
     msgCanHost: 'Yes, I can host!',
     msgCannotHost: 'Sorry, I can\'t host',
     msgWriteBack: 'Write back'

--- a/modules/messages/client/controllers/thread.client.controller.js
+++ b/modules/messages/client/controllers/thread.client.controller.js
@@ -15,7 +15,7 @@
     .controller('MessagesThreadController', MessagesThreadController);
 
   /* @ngInject */
-  function MessagesThreadController($rootScope, $scope, $stateParams, $state, $timeout, $filter, $analytics, Authentication, Messages, MessagesRead, messageCenterService, locker, userTo) {
+  function MessagesThreadController($rootScope, $scope, $stateParams, $state, $timeout, $filter, $analytics, Authentication, Messages, MessagesRead, messageCenterService, locker, userTo, OffersByService) {
 
     // Go back to inbox on these cases
     // - No recepient defined
@@ -52,6 +52,8 @@
     vm.messageRead = messageRead;
     vm.hideQuickReplyPanel = hideQuickReplyPanel;
     vm.editorContentChanged = editorContentChanged;
+    vm.templatesEnabled = true;
+    vm.sendTemplate = sendTemplate;
     vm.content = '';
 
     activate();
@@ -119,6 +121,37 @@
       });
 
     }
+
+    /** @function sendTemplate(templateName)
+     * Send a message template, may be all sending of all user defined
+     * templates can be done via a single point & single data structure
+     */
+
+    function sendTemplate(templateName) {
+      if (! vm.templatesEnabled) {
+        return;
+      }
+
+      OffersByService
+        .get({ 'userId': Authentication.user._id })
+        .$promise
+        .then(function(offer) {
+          var templates = offer.templates;
+          if (!templates) {
+            return;
+          }
+          var template = templates[templateName];
+          if (template) {
+            sendMessage(template);
+          }
+        })
+        .catch(function() {
+          // In case any thing goes wrong we keep quite and let users chat
+          // console.log('offer:' + template + 'for:' + Authentication.user._id);
+          // messageCenterService.add('danger', 'Sorry, something went wrong. Please try again.');
+        });
+    }
+
 
     /**
      * When contents at the editor change, update layout

--- a/modules/messages/client/directives/thread-dimensions.client.directive.js
+++ b/modules/messages/client/directives/thread-dimensions.client.directive.js
@@ -86,11 +86,19 @@
           // container has 15px padding on both sides when window is bigger than screen-sm-max (768px)
           var elemContainerPadding = ($window.innerWidth < 768) ? -15 : 30;
 
+          var elemQuickReply = angular.element('#message-quick-reply');
+
+          var combinedHeight = elemReplyHeight + (elemQuickReply.height());
+
+          elemQuickReply.css({
+            bottom: combinedHeight
+          });
+
           elemThread.css({
             // container has 15px padding on both sides when window is bigger than screen-sm-max (768px)
             width: elemContainerWidth - elemContainerPadding,
             // Bottom part of the message thread should touch top part of textarea
-            bottom: elemReplyHeight
+            bottom: combinedHeight + (combinedHeight / 8)
           });
 
           // Reply area has always padding 30 on the right

--- a/modules/messages/client/directives/thread-dimensions.client.directive.js
+++ b/modules/messages/client/directives/thread-dimensions.client.directive.js
@@ -88,7 +88,7 @@
 
           var elemQuickReply = angular.element('#message-quick-reply');
 
-          var combinedHeight = elemReplyHeight + (elemQuickReply.height());
+          var combinedHeight = elemReplyHeight + (elemReplyHeight / 3);
 
           elemQuickReply.css({
             bottom: combinedHeight
@@ -98,7 +98,7 @@
             // container has 15px padding on both sides when window is bigger than screen-sm-max (768px)
             width: elemContainerWidth - elemContainerPadding,
             // Bottom part of the message thread should touch top part of textarea
-            bottom: combinedHeight + (combinedHeight / 8)
+            bottom: combinedHeight + elemQuickReply.height()
           });
 
           // Reply area has always padding 30 on the right

--- a/modules/messages/client/less/thread.less
+++ b/modules/messages/client/less/thread.less
@@ -139,6 +139,21 @@
   }
 }
 
+#message-quick-reply {
+  position: fixed;
+  width: 90%;
+}
+
+#message-quick-reply .btn {
+  font-size: 0.8em;
+  padding: 3px;
+}
+
+#message-quick-reply.ng-hide {
+  transition: 0.2s linear all;
+  opacity: 1;
+}   
+
 // Reply box
 #message-reply {
   position: fixed;

--- a/modules/messages/client/views/thread.client.view.html
+++ b/modules/messages/client/views/thread.client.view.html
@@ -107,15 +107,18 @@
 
       <!-- quickreply -->
       <div class="btn-toolbar" id="message-quick-reply" ng-hide="thread.hideQuickReplyPanel">
-          <button class="btn btn-success icon-ok" ng-click="thread.sendMessage('<b><i>'+app.appSettings.messages.msgCanHost+'</i></b>');">
+        <div class="input-group">
+          <button class="btn btn-success icon-ok" ng-click="thread.sendMessage('<b><i>'+app.appSettings.messages.msgCanHost+'</i></b>');thread.sendTemplate('directions');">
             {{app.appSettings.messages.msgCanHost}}
           </button>
-          <button class="btn btn-danger icon-minus-squared-alt" ng-click="thread.sendMessage('<b><i>'+app.appSettings.messages.msgCannotHost+'</i></b>');">
-            {{app.appSettings.messages.msgCannotHost}}
-          </button>
-          <button class="btn btn-info icon-reply" ng-click="thread.hideQuickReplyPanel=true;">
-            {{app.appSettings.messages.msgWriteBack}}
-          </button>
+          <div ng-show={{app.appSettings.messages.enableTemplates}}><small>Send <a href="/offer" target="_blank">Directions:</a></small><input type="checkbox" checked ng-model="thread.templatesEnabled" /></div>
+        </div>
+        <button class="btn btn-danger icon-minus-squared-alt" ng-click="thread.sendMessage('<b><i>'+app.appSettings.messages.msgCannotHost+'</i></b>');">
+          {{app.appSettings.messages.msgCannotHost}}
+        </button>
+        <button class="btn btn-info icon-reply" ng-click="thread.hideQuickReplyPanel=true;">
+          {{app.appSettings.messages.msgWriteBack}}
+        </button>
       </div>
       <!-- quickreply -->
 

--- a/modules/messages/client/views/thread.client.view.html
+++ b/modules/messages/client/views/thread.client.view.html
@@ -105,7 +105,22 @@
       </threads>
       <!-- /Thread -->
 
+      <!-- quickreply -->
+      <div class="btn-toolbar" id="message-quick-reply" ng-hide="thread.hideQuickReplyPanel">
+          <button class="btn btn-success icon-ok" ng-click="thread.sendMessage('<b><i>'+app.appSettings.messages.msgCanHost+'</i></b>');">
+            {{app.appSettings.messages.msgCanHost}}
+          </button>
+          <button class="btn btn-danger icon-minus-squared-alt" ng-click="thread.sendMessage('<b><i>'+app.appSettings.messages.msgCannotHost+'</i></b>');">
+            {{app.appSettings.messages.msgCannotHost}}
+          </button>
+          <button class="btn btn-info icon-reply" ng-click="thread.hideQuickReplyPanel=true;">
+            {{app.appSettings.messages.msgWriteBack}}
+          </button>
+      </div>
+      <!-- quickreply -->
+
       <!-- Reply -->
+      <div>
       <form id="message-reply"
             name="messageForm"
             class="form-horizontal"
@@ -146,6 +161,7 @@
           </div>
         </div><!-- /.row -->
       </form>
+      </div>
       <!-- /Reply -->
 
     </div><!-- /.col-* -->

--- a/modules/offers/client/controllers/offers-edit.client.controller.js
+++ b/modules/offers/client/controllers/offers-edit.client.controller.js
@@ -107,6 +107,7 @@
         status: vm.offer.status,
         description: vm.offer.description,
         noOfferDescription: vm.offer.noOfferDescription,
+        templates: vm.offer.templates,  // user defined templates like directions
         location: [parseFloat(vm.mapCenter.lat), parseFloat(vm.mapCenter.lng)],
         maxGuests: parseInt(vm.offer.maxGuests, 10)
       });

--- a/modules/offers/client/views/offers-edit.client.view.html
+++ b/modules/offers/client/views/offers-edit.client.view.html
@@ -56,6 +56,17 @@
         </div>
       </div>
 
+      <!-- Directions to Host & Contact especially for quick accept  -->
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h4>Contact & Directions: How to reach you (Non-Public)</h4>
+          <h5>You will have to explicity share this via chat on acceptance</h5>
+        </div>
+        <div class="panel-body">
+          <div class="offer-description" ng-class="{'is-not-empty': offer.templates.directions.length}" ng-hide="!offersEdit.offer" ng-model="offersEdit.offer.templates.directions" tr-editor tr-editor-options="::app.editorOptions" data-placeholder="at least 1.Contact Info 2.Address 3.Landmarks 4.Transportation..."></div>
+        </div>
+      </div>
+
       <!-- Location -->
       <div class="panel panel-default offer-panel-map">
 

--- a/modules/offers/server/controllers/offers.server.controller.js
+++ b/modules/offers/server/controllers/offers.server.controller.js
@@ -20,6 +20,7 @@ var publicOfferFields = [
   '_id',
   'status',
   'description',
+  'templates',          // user defined templates, all in one object ?
   'noOfferDescription',
   'maxGuests',
   'location'
@@ -120,7 +121,7 @@ exports.create = function(req, res) {
   offer.locationFuzzy = fuzzyLocation(offer.location);
 
   // Sanitize contents coming from wysiwyg editors
-  ['description', 'noOfferDescription'].forEach(function(key) {
+  ['description', 'noOfferDescription', 'templates.directions'].forEach(function(key) {
     if (offer[key] && !textProcessor.isEmpty(offer[key])) {
       // Allow some HTML
       offer[key] = textProcessor.html(offer[key]);
@@ -354,6 +355,7 @@ exports.offerByUserId = function(req, res, next, userId) {
     // Sanitize each outgoing offer's contents
     offer.description = sanitizeHtml(offer.description, textProcessor.sanitizeOptions);
     offer.noOfferDescription = sanitizeHtml(offer.noOfferDescription, textProcessor.sanitizeOptions);
+    offer.templates.directions = sanitizeHtml(offer.templates.directions, textProcessor.sanitizeOptions);
 
     // Make sure we return accurate location only for offer owner,
     // others will see pre generated fuzzy location
@@ -439,6 +441,7 @@ exports.offerById = function(req, res, next, offerId) {
       // Sanitize each outgoing offer's contents
       offer.description = sanitizeHtml(offer.description, textProcessor.sanitizeOptions);
       offer.noOfferDescription = sanitizeHtml(offer.noOfferDescription, textProcessor.sanitizeOptions);
+      offer.templates.directions = sanitizeHtml(offer.templates.directions, textProcessor.sanitizeOptions);
 
       // Make sure we return accurate location only for offer owner,
       // others will see pre generated fuzzy location

--- a/modules/offers/server/models/offer.server.model.js
+++ b/modules/offers/server/models/offer.server.model.js
@@ -32,6 +32,11 @@ var OfferSchema = new Schema({
     max: 99,
     default: 1
   },
+  templates: {
+    type: Object,
+    default: { 'directions': '' },
+    trim: true
+  },
   // Actual location user has marked
   location: {
     type: [Number]


### PR DESCRIPTION
Fixes #490 Precomposed template contact info/location message to share with guests
    -Adds a little check box under Yes,I can host, button in quick-reply panel
    -User template is stored in offers, under Hosting Status
    -Adds a function to send template
    -Requires #422 (committed as part of this too)
    -The quick reply panel does not self hide, may be the behaviour can be discussed and finalised