### PR TITLE
Search users: API

### DIFF
--- a/config/env/default.js
+++ b/config/env/default.js
@@ -108,6 +108,8 @@ module.exports = {
     unreadMessageReminders: [{ minutes: 10 }, { hours: 24 }],
     // after what delay to stop sending further unread message reminders
     unreadMessageRemindersTooLate: { days: 14 },
+    // how many users should we return from search at maximum
+    userSearchLimit: 10,
     // Time intervals between welcome sequence emails
     welcomeSequence: {
       first: { minutes: 0 },

--- a/modules/users/server/controllers/users.profile.server.controller.js
+++ b/modules/users/server/controllers/users.profile.server.controller.js
@@ -1468,3 +1468,19 @@ function isUserMemberOfTribe(user, tribeId) {
     return membership.tribe.equals(tribeId);
   }));
 }
+
+/*
+ * This middleware sends response with an array of found users
+ * We assume that req.query.search exists
+ */
+exports.search = function (req, res, next) {
+  if (!_.has(req.query, 'search')) {
+    return next();
+  }
+  var queryString = req.query.search;
+
+  User.find({ username: new RegExp('^' + queryString) }).exec(function (err, users) {
+    if (err) return next(err);
+    return res.send(users);
+  });
+};

--- a/modules/users/server/controllers/users.profile.server.controller.js
+++ b/modules/users/server/controllers/users.profile.server.controller.js
@@ -1482,7 +1482,7 @@ exports.search = function (req, res, next) {
 
   // validate the query string
   if (req.query.search.length < 3) {
-    var errorMessage = errorHandler.getErrorMessageByKey('bad-request');
+    var errorMessage = errorService.getErrorMessageByKey('bad-request');
     return res.status(400).send({
       message: errorMessage,
       detail: 'Query string should be at least 3 characters long.'

--- a/modules/users/server/controllers/users.profile.server.controller.js
+++ b/modules/users/server/controllers/users.profile.server.controller.js
@@ -1482,7 +1482,11 @@ exports.search = function (req, res, next) {
 
   // validate the query string
   if (req.query.search.length < 3) {
-    return res.status(400).end();
+    var errorMessage = errorHandler.getErrorMessageByKey('bad-request');
+    return res.status(400).send({
+      message: errorMessage,
+      detail: 'Query string should be at least 3 characters long.'
+    });
   }
 
 
@@ -1507,7 +1511,6 @@ exports.search = function (req, res, next) {
     ] })
     // select only the right profile properties
     .select(exports.userMiniProfileFields + ' -_id')
-    // todo what to choose for sorting?
     .sort({ username: 1 })
     // limit the amount of found users (config)
     .limit(config.limits.userSearchLimit)

--- a/modules/users/server/models/user.server.model.js
+++ b/modules/users/server/models/user.server.model.js
@@ -349,4 +349,6 @@ UserSchema.methods.authenticate = function (password) {
  */
 UserSchema.plugin(uniqueValidation);
 
+UserSchema.index({ username: 'text', firstName: 'text', lastName: 'text' });
+
 mongoose.model('User', UserSchema);

--- a/modules/users/server/policies/users.server.policy.js
+++ b/modules/users/server/policies/users.server.policy.js
@@ -45,7 +45,7 @@ exports.invokeRolesPolicies = function () {
     roles: ['user'],
     allows: [{
       resources: '/api/users',
-      permissions: ['put', 'delete']
+      permissions: ['get', 'put', 'delete']
     }, {
       resources: '/api/users/remove/:token',
       permissions: ['delete']

--- a/modules/users/server/routes/users.server.routes.js
+++ b/modules/users/server/routes/users.server.routes.js
@@ -12,6 +12,7 @@ module.exports = function (app) {
 
   // Setting up the users profile api
   app.route('/api/users').all(usersPolicy.isAllowed)
+    .get(userProfile.search)
     .delete(userProfile.initializeRemoveProfile)
     .put(userProfile.update);
 

--- a/modules/users/tests/server/search-users.server.routes.tests.js
+++ b/modules/users/tests/server/search-users.server.routes.tests.js
@@ -14,8 +14,7 @@ var request = require('supertest'),
 
 describe('Search users: GET /users?search=string', function () {
 
-  var agent,
-      sandbox;
+  var agent;
 
   var limit = 9;
 
@@ -34,13 +33,11 @@ describe('Search users: GET /users?search=string', function () {
   });
 
   beforeEach(function () {
-    sandbox = sinon.sandbox.create();
-
-    sandbox.stub(config.limits, 'userSearchLimit').value(limit);
+    sinon.stub(config.limits, 'userSearchLimit').value(limit);
   });
 
   afterEach(function () {
-    sandbox.restore();
+    sinon.restore();
   });
 
 

--- a/modules/users/tests/server/search-users.server.routes.tests.js
+++ b/modules/users/tests/server/search-users.server.routes.tests.js
@@ -422,8 +422,9 @@ describe('Search users: GET /users?search=string', function () {
       it('[query string is less than 3 characters long] respond with 400', function (done) {
         agent.get('/api/users?search=aa')
           .expect(400)
-          .end(function (err) {
-            // @TODO test the error message
+          .end(function (err, res) {
+            should(res.body.message).eql('Bad request.');
+            should(res.body.detail).eql('Query string should be at least 3 characters long.');
             done(err);
           });
       });

--- a/modules/users/tests/server/search-users.server.routes.tests.js
+++ b/modules/users/tests/server/search-users.server.routes.tests.js
@@ -10,7 +10,7 @@ var request = require('supertest'),
     User = mongoose.model('User'),
     express = require(path.resolve('./config/lib/express')),
     config = require(path.resolve('./config/config')),
-    userHandler = require(path.resolve('./modules/users/server/controllers/users.server.controller'));
+    userHandler = require(path.resolve('./modules/users/server/controllers/users.profile.server.controller'));
 
 describe('Search users: GET /users?search=string', function () {
 
@@ -20,9 +20,9 @@ describe('Search users: GET /users?search=string', function () {
   var limit = 9;
 
   // initialize the testing environment
-  before(function() {
+  before(function () {
     // Get application
-    var app = express.init(mongoose);
+    var app = express.init(mongoose.connection);
     agent = request.agent(app);
   });
 

--- a/modules/users/tests/server/search-users.server.routes.tests.js
+++ b/modules/users/tests/server/search-users.server.routes.tests.js
@@ -1,0 +1,130 @@
+var request = require('supertest'),
+    async = require('async'),
+    path = require('path'),
+    mongoose = require('mongoose'),
+    should = require('should'),
+    User = mongoose.model('User'),
+    express = require(path.resolve('./config/lib/express'));
+
+describe('Search users: GET /users?search=string', function () {
+
+  var agent;
+
+  // initialize the testing environment
+  before(function() {
+    // Get application
+    var app = express.init(mongoose);
+    agent = request.agent(app);
+  });
+
+  // clear the database
+  afterEach(function (done) {
+    async.each([User], function (collection, cb) {
+      collection.remove().exec(cb);
+    }, done);
+  });
+
+
+  function createUsers(users, callback) {
+    var createdUsers = [];
+    async.eachOfSeries(users, function (user, index, cb) {
+      var createdUser = new User({
+        username: user.username || 'user' + index,
+        firstName: user.firstName || 'firstName' + index,
+        lastName: user.lastName || 'lastName' + index,
+        get email() { return this.username + '@example.com'; },
+        displayName: 'Full Name',
+        get emailTemporary() { return this.email; },
+        emailToken: 'initial email token',
+        get displayUsername() { return this.username; },
+        password: user.password || '******password',
+        provider: 'local'
+      });
+
+      createdUsers.push(createdUser);
+      createdUser.save(cb);
+    }, function (err) {
+      callback(err, createdUsers);
+    });
+  }
+
+
+  context('not logged in', function () {
+    it('Forbidden 403');
+  });
+
+  context('logged in', function () {
+
+    var loggedUser;
+
+    // create logged user
+    beforeEach(function (done) {
+      createUsers([{ username: 'loggedUser', password: 'somepassword' }], function (err, users) {
+        loggedUser = users[0];
+
+        done(err);
+      });
+    });
+
+    // sign in
+    beforeEach(function (done) {
+      agent.post('/api/auth/signin')
+        .send({ username: loggedUser.username, password: 'somepassword' })
+        .expect(200)
+        .end(done);
+    });
+
+    // sign out
+    afterEach(function (done) {
+      agent.get('/api/auth/signout')
+        .expect(302)
+        .end(done);
+    });
+
+    context('valid request', function () {
+      it('[some usernames matched] return array of users', function (done) {
+        async.waterfall([
+
+          // create some users
+          function (cb) {
+            createUsers([
+              { username: 'asdf' },
+              { username: 'asdfg' },
+              { username: 'asdia' },
+              { username: 'hasdfg' }
+            ], cb);
+          },
+
+          // search
+          function (users, cb) {
+            agent.get('/api/users?search=asd')
+              .expect(200)
+              .end(function (err, response) {
+                cb(err, response.body);
+              });
+          },
+
+          // check that we found the users starting with asd
+          function (foundUsers, cb) {
+
+            should(foundUsers).length(3);
+
+            cb();
+          }
+        ], done);
+      });
+      it('[some given names matched] return array of users');
+      it('[some family names matched] return array of users');
+      it('[none matched] return empty array');
+      it('the user data should have fields from miniProfile');
+      it('[many users matched] limit the amount (5-10, config)');
+      it('search is case insensitive');
+      it('return only active users');
+    });
+
+    context('invalid request', function () {
+      it('[query string is less than 3 characters long] respond with 400');
+      it('[query string contains invalid characters] respond with 400');
+    });
+  });
+});

--- a/modules/users/tests/server/search-users.server.routes.tests.js
+++ b/modules/users/tests/server/search-users.server.routes.tests.js
@@ -25,6 +25,11 @@ describe('Search users: GET /users?search=string', function () {
     agent = request.agent(app);
   });
 
+  // rebuild indexes before tests
+  before(function (done) {
+    User.ensureIndexes(done);
+  });
+
   // clear the database
   afterEach(function (done) {
     async.each([User], function (collection, cb) {
@@ -103,7 +108,7 @@ describe('Search users: GET /users?search=string', function () {
     });
 
     context('valid request', function () {
-      it('[some usernames matched] return array of users', function (done) {
+      it('[a username matched] return array of users', function (done) {
         async.waterfall([
 
           // create some users
@@ -118,7 +123,7 @@ describe('Search users: GET /users?search=string', function () {
 
           // search
           function (users, cb) {
-            agent.get('/api/users?search=asd')
+            agent.get('/api/users?search=asdia')
               .expect(200)
               .end(function (err, response) {
                 cb(err, response.body);
@@ -128,7 +133,7 @@ describe('Search users: GET /users?search=string', function () {
           // check that we found the users
           function (foundUsers, cb) {
 
-            should(foundUsers).length(3);
+            should(foundUsers).length(1);
 
             cb();
           }
@@ -144,9 +149,9 @@ describe('Search users: GET /users?search=string', function () {
               { firstName: 'qwer' },
               { firstName: 'qwera' },
               { firstName: 'qwery' },
-              { firstName: 'qwert' },
+              { firstName: 'qwer' },
               { firstName: 'qwe' },
-              { firstName: 'sqweruyo' }
+              { firstName: 'sqwero' }
             ], cb);
           },
 
@@ -162,7 +167,7 @@ describe('Search users: GET /users?search=string', function () {
           // check that we found the users
           function (foundUsers, cb) {
 
-            should(foundUsers).length(4);
+            should(foundUsers).length(2);
 
             cb();
           }
@@ -177,11 +182,11 @@ describe('Search users: GET /users?search=string', function () {
             createUsers([
               { lastName: 'zxcvbna' },
               { lastName: 'zxcvbnrya' },
-              { lastName: 'zxcvboa' },
+              { lastName: 'zxcvb' },
               { lastName: 'zxcvbny' },
               { lastName: 'zxcvb' },
               { lastName: 'zxcvba' },
-              { lastName: 'xcvz' },
+              { lastName: 'zxcvz' },
               { lastName: 'asdia' },
               { lastName: 'hasdfg' }
             ], cb);
@@ -199,7 +204,7 @@ describe('Search users: GET /users?search=string', function () {
           // check that we found the users
           function (foundUsers, cb) {
 
-            should(foundUsers).length(6);
+            should(foundUsers).length(2);
 
             cb();
           }
@@ -217,14 +222,14 @@ describe('Search users: GET /users?search=string', function () {
               { firstName: 'jAcob', lastName: 'alic' },
               { firstName: 'jaCob', lastName: 'alid' },
               { firstName: 'jacob', lastName: 'aliE' },
-              { firstName: 'jacob', lastName: 'alIf' },
-              { firstName: 'jacob', lastName: 'alg' }
+              { firstName: 'jacob', lastName: 'alIA' },
+              { firstName: 'jaco', lastName: 'alg' }
             ], cb);
           },
 
           // search
           function (users, cb) {
-            agent.get('/api/users?search=jacob+aLi')
+            agent.get('/api/users?search=jacob+aLia')
               .expect(200)
               .end(function (err, response) {
                 cb(err, response.body);
@@ -274,13 +279,13 @@ describe('Search users: GET /users?search=string', function () {
         ], done);
       });
 
-      it('the user data should have only fields from miniProfile', function (done) {
+      it('the user data should have only fields from miniProfile, and score', function (done) {
         async.waterfall([
 
           // create some users
           function (cb) {
             createUsers([
-              { username: 'aaaaaaa' }
+              { username: 'aaa' }
             ], cb);
           },
 
@@ -303,7 +308,7 @@ describe('Search users: GET /users?search=string', function () {
 
             var unexpectedFields = _.difference(actualFields, expectedFields);
 
-            should(unexpectedFields).length(0);
+            should(unexpectedFields).eql(['score']);
 
             cb();
           }
@@ -316,24 +321,24 @@ describe('Search users: GET /users?search=string', function () {
           // create some users
           function (cb) {
             createUsers([
-              { username: 'aaaaaaaa' },
-              { firstName: 'aaaaaaa' },
-              { lastName: 'aaaaaaa' },
-              { username: 'aaaaaaa' },
-              { username: 'aaaaaaaaab' },
-              { username: 'aaaaaaaba' },
-              { firstName: 'aaaaaaa' },
-              { lastName: 'aaaaaaac' },
-              { firstName: 'aaaaaaa' },
-              { lastName: 'aaaaaaa' },
-              { firstName: 'aaaaaaa' },
-              { lastName: 'aaaaaaa' }
+              { username: 'aaaaaa' },
+              { firstName: 'aaaaaa' },
+              { lastName: 'aaaaaa' },
+              { lastName: 'aaaaaa' },
+              { firstName: 'aAaAaa' },
+              { lastName: 'aaaaaa' },
+              { firstName: 'aaaaaa' },
+              { lastName: 'aaaaaa' },
+              { firstName: 'aaaaaa' },
+              { lastName: 'aaaaaa' },
+              { firstName: 'aaaaaa' },
+              { lastName: 'aaaaaa' }
             ], cb);
           },
 
           // search
           function (users, cb) {
-            agent.get('/api/users?search=aaa')
+            agent.get('/api/users?search=aaaaaa')
               .expect(200)
               .end(function (err, response) {
                 cb(err, response.body);
@@ -356,16 +361,16 @@ describe('Search users: GET /users?search=string', function () {
           // create some users
           function (cb) {
             createUsers([
-              { username: 'aaabcdef' },
-              { firstName: 'aAabCd' },
-              { lastName: 'aaABCc' },
+              { username: 'abcdef' },
+              { firstName: 'abCdef' },
+              { lastName: 'ABCdEF' },
               { username: 'aabc' }
             ], cb);
           },
 
           // search
           function (users, cb) {
-            agent.get('/api/users?search=aaaBc')
+            agent.get('/api/users?search=abcdEf')
               .expect(200)
               .end(function (err, response) {
                 cb(err, response.body);
@@ -388,16 +393,17 @@ describe('Search users: GET /users?search=string', function () {
           // create some users
           function (cb) {
             createUsers([
-              { username: 'aaabcdef', public: true },
+              { username: 'aabcdef', public: true },
               { firstName: 'aAabCd', public: false },
               { lastName: 'aaABCc', public: false },
-              { username: 'aabc', public: true } // this one is not matched
+              { lastName: 'aaABCc', public: true }, // this one is not matched
+              { firstName: 'aabCDef', lastName: 'aAbcdef', public: true }
             ], cb);
           },
 
           // search
           function (users, cb) {
-            agent.get('/api/users?search=aaaBc')
+            agent.get('/api/users?search=aabcdef')
               .expect(200)
               .end(function (err, response) {
                 cb(err, response.body);
@@ -407,7 +413,7 @@ describe('Search users: GET /users?search=string', function () {
           // check that we found the users
           function (foundUsers, cb) {
 
-            should(foundUsers).length(1);
+            should(foundUsers).length(2);
 
             cb();
           }


### PR DESCRIPTION
Backend API part for _"searching members you already know"_ -feature #530

The endpoint is `GET /api/users?search=[searchString]`, where replace `[searchString]`.

The endpoint will support search by full names, (given and family) and full usernames. The support for partial search (_search as you type_) will be dropped.