### PR TITLE
Add user info to message thread mobile view

### DIFF
--- a/modules/messages/client/less/thread.less
+++ b/modules/messages/client/less/thread.less
@@ -16,11 +16,11 @@
 
   @media (min-width: @screen-xs-min) {
     .content-empty {
-      position: absolute;
-      bottom: 50%;
-      margin-top: -65px;
-      left: 0;
-      right: 0;
+      // position: absolute;
+      // bottom: 50%;
+      // margin-top: -65px;
+      // left: 0;
+      // right: 0;
     }
   }
 

--- a/modules/messages/client/views/thread.client.view.html
+++ b/modules/messages/client/views/thread.client.view.html
@@ -17,6 +17,21 @@
       <!-- Thread -->
       <threads id="messages-thread" moremessages="thread.moreMessages()">
 
+        <!-- User profile mobile view -->
+        <div class="message">
+          <div class="col-xs-12 col-sm-11">
+            <div class="message-recipient panel panel-default visible-xs">
+              <a class="panel-body" ui-sref="profile.about({username: thread.userTo.username})">
+                <div tr-avatar data-size="32" data-link="false" data-user="::thread.userTo"></div>
+                <h4>
+                  {{ thread.userTo.displayName }}
+                </h4>
+                <small class="text-muted">@{{ thread.userTo.displayUsername || thread.userTo.username }}</small>
+              </a>
+            </div>
+          </div>
+        </div>
+
         <!-- Pagination error -->
         <div class="divider divider-first" ng-if="thread.messageHandler.resolved === false && thread.messageHandler.nextPage">
           <div class="panel panel-danger">

--- a/modules/search/client/less/sidebar.less
+++ b/modules/search/client/less/sidebar.less
@@ -92,7 +92,7 @@ body.is-site-announcement-visible {
   }
 }
 
-.search-result {
+.search-result, .message-recipient {
   user-select: none;
   position: relative;
   cursor: pointer;


### PR DESCRIPTION
I'd like to expose some information about the person you're about to write to in the mobile view of message threads:

![message-thread-mobile-after](https://user-images.githubusercontent.com/1589186/28541884-e0cc4008-70ba-11e7-8061-60774daae9fa.jpg)

The other views show the other person's name, but it's hidden in mobile and quite inconvenient.

Not sure about the design but somehow getting their name there would be excellent!