### PR TITLE
doesn't work with node 8

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,7 +6,7 @@ _These instructions are for installing locally. If you'd like to have containeri
 ## Prerequisites
 
 Make sure you have installed all these prerequisites:
-* [Node.js](https://nodejs.org/en/download/) v6 or v8 and the NPM package manager (`node --version && npm --version`). You can run multiple Node versions using [NVM](https://github.com/creationix/nvm).
+* [Node.js](https://nodejs.org/en/download/) v6 and the NPM package manager (`node --version && npm --version`). You can run multiple Node versions using [NVM](https://github.com/creationix/nvm).
 * [MongoDB](http://www.mongodb.org/downloads) v3 (`mongod --version`).
 * [GraphicsMagick](http://www.graphicsmagick.org/). If you prefer [ImageMagick](http://www.imagemagick.org/) instead, change `imageProcessor` setting from `./configs/env/local.js` (see install step 2) to `imagemagic`. In Mac OS X, you can simply use [Homebrew](http://mxcl.github.io/homebrew/) and do:
 ```


### PR DESCRIPTION
Running `npm start` with node at latest couple versions of 8 (including the latest, 8.2.1) gives me a variety of compilation errors, so I'm removing the option from the install guide!