### PR TITLE
English grammar fix

### DIFF
--- a/modules/core/client/directives/tr-flashcards.client.directive.js
+++ b/modules/core/client/directives/tr-flashcards.client.directive.js
@@ -34,7 +34,7 @@
           title: 'Tell a little bit about yourself',
           content: 'You\'re much more likely to get a positive response if you have written a bit about yourself.'
         }, {
-          title: 'Explain them why you are choosing them',
+          title: 'Explain to them why you are choosing them',
           content: '...explaining that you are interested in meeting them, not just looking for free accommodation.'
         }, {
           title: 'Tell your host why you\'re on a trip',

--- a/modules/pages/client/views/guide.client.view.html
+++ b/modules/pages/client/views/guide.client.view.html
@@ -19,7 +19,7 @@
 
       <br>
 
-      <h3>Explain them why you are choosing them</h3>
+      <h3>Explain to them why you are choosing them</h3>
       <p class="lead">...explaining that you are interested in meeting them, not just looking for free accommodation.</p>
 
       <br>


### PR DESCRIPTION
I hear *\*explain them* frequently across Europe - but you never hear it in Britain or USA. :)