### PR TITLE
Update engine requirements (Node.js, NPM and MongoDB)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ node_js:
   - 9
 matrix:
   fast_finish: true
-  allow_failures:
-    - node_js: 9
 # https://docs.travis-ci.com/user/reference/overview/#Virtualisation-Environment-vs-Operating-System
 dist: trusty
 # NodeJS v4+ requires gcc 4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: node_js
 node_js:
-  - 6
   - 8
+  - 9
+matrix:
+  fast_finish: true
+  allow_failures:
+    - node_js: 9
+# https://docs.travis-ci.com/user/reference/overview/#Virtualisation-Environment-vs-Operating-System
 dist: trusty
 # NodeJS v4+ requires gcc 4.8
 # https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements
@@ -17,7 +22,7 @@ addons:
     - google-chrome
     - ubuntu-toolchain-r-test
     - mongodb-upstart
-    - mongodb-3.2-precise
+    - mongodb-3.6-precise
     packages:
     - g++-4.8
     - gcc-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ addons:
     - google-chrome
     - ubuntu-toolchain-r-test
     - mongodb-upstart
-    - mongodb-3.6-precise
+    - mongodb-3.4-precise
     packages:
     - g++-4.8
     - gcc-4.8

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,8 +6,8 @@ _These instructions are for installing locally. If you'd like to have containeri
 ## Prerequisites
 
 Make sure you have installed all these prerequisites:
-* [Node.js](https://nodejs.org/en/download/) v6 or v8 and the NPM package manager (`node --version && npm --version`). You can run multiple Node versions using [NVM](https://github.com/creationix/nvm).
-* [MongoDB](http://www.mongodb.org/downloads) v3 (`mongod --version`).
+* [Node.js](https://nodejs.org/en/download/) v8 and the NPM v5 (`node --version && npm --version`). You can run multiple Node versions using [NVM](https://github.com/creationix/nvm).
+* [MongoDB](http://www.mongodb.org/downloads) v3.6 (`mongod --version`).
 * [GraphicsMagick](http://www.graphicsmagick.org/). If you prefer [ImageMagick](http://www.imagemagick.org/) instead, change `imageProcessor` setting from `./configs/env/local.js` (see install step 2) to `imagemagic`. In Mac OS X, you can simply use [Homebrew](http://mxcl.github.io/homebrew/) and do:
 ```
 brew install graphicsmagick

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,8 +6,8 @@ _These instructions are for installing locally. If you'd like to have containeri
 ## Prerequisites
 
 Make sure you have installed all these prerequisites:
-* [Node.js](https://nodejs.org/en/download/) v8 and the NPM v5 (`node --version && npm --version`). You can run multiple Node versions using [NVM](https://github.com/creationix/nvm).
-* [MongoDB](http://www.mongodb.org/downloads) v3.6 (`mongod --version`).
+* [Node.js](https://nodejs.org/en/download/) v8+ and the NPM v5+ (`node --version && npm --version`). You can run multiple Node versions using [NVM](https://github.com/creationix/nvm).
+* [MongoDB](http://www.mongodb.org/downloads) v3.4+ (`mongod --version`).
 * [GraphicsMagick](http://www.graphicsmagick.org/). If you prefer [ImageMagick](http://www.imagemagick.org/) instead, change `imageProcessor` setting from `./configs/env/local.js` (see install step 2) to `imagemagic`. In Mac OS X, you can simply use [Homebrew](http://mxcl.github.io/homebrew/) and do:
 ```
 brew install graphicsmagick

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "url": "https://github.com/Trustroots/trustroots"
   },
   "engines": {
-    "node": ">=6.0.0",
-    "npm": ">=3.0.0"
+    "node": ">=8.0.0",
+    "npm": ">=5.0.0"
   },
   "browserslist": [
     "last 2 versions",


### PR DESCRIPTION
- Node.js requirement from v6 to v8
- MongoDB from 3.2 to 3.6
- NPM from v3 to v5
- Start running CI tests for Node.js v9 but allow failures