### PR TITLE
Fix cold npm start

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "> 1%"
   ],
   "scripts": {
-    "prestart": "npm run install-if-no-modules && check-node-version --package",
+    "prestart": "npm run install-if-no-modules && ./node_modules/.bin/check-node-version --package",
     "install-if-no-modules": "if [ ! -d node_modules ]; then npm install --quiet; fi",
     "start": "concurrently --raw --kill-others --kill-others-on-fail 'gulp' 'npm run start:worker' 'maildev' 'npm run agendash'",
     "start:docker": "npm run prestart && concurrently --raw --kill-others --kill-others-on-fail 'gulp --skipBower' 'npm run start:worker'",


### PR DESCRIPTION
Fixes:
```
❯ npm start                                                                                                                                                       (git)-[master]

> trustroots@0.3.3 prestart /Users/guaka/code/trustroots
> npm run install-if-no-modules && check-node-version --package


> trustroots@0.3.3 install-if-no-modules /Users/guaka/code/trustroots
> if [ ! -d node_modules ]; then npm install --quiet; fi

sh: check-node-version: command not found
npm ERR! file sh
npm ERR! code ELIFECYCLE
npm ERR! errno ENOENT
npm ERR! syscall spawn
npm ERR! trustroots@0.3.3 prestart: `npm run install-if-no-modules && check-node-version --package`
npm ERR! spawn ENOENT
npm ERR!
npm ERR! Failed at the trustroots@0.3.3 prestart script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/guaka/.npm/_logs/2018-06-05T12_14_43_720Z-debug.log
```