### PR TITLE
Update Engines for supported Node.js versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/Trustroots/trustroots"
   },
   "engines": {
-    "node": ">=8.0.0",
+    "node": "^8.0.0",
     "npm": ">=5.0.0"
   },
   "browserslist": [


### PR DESCRIPTION
Throws error on Node.js 10 when `npm start`'ing, since the app does not support it yet.

Helps with https://github.com/Trustroots/trustroots/issues/618