### PR TITLE
Remove `nsp` check from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ addons:
     - mongodb-org-shell
 before_install:
   - gem update --system
-  - npm install nsp -g
 before_script:
   - mongo --version
   - mongod --version
@@ -42,8 +41,6 @@ before_script:
   - 'sh -e /etc/init.d/xvfb start'
   - sleep 3 # give xvfb some time to start
 
-after_script:
-  - nsp check
 notifications:
   slack:
     secure: XRMYG9Hf+bJjMSHHXN0XeGT4ZhSP+oCHBUWmjBwxO0p+VORBOEZvlh/2OvxingFuzLGOXFeOPr1g91G+OgiCGR6GxaDpf680lEjk8ESTJ4oECv0aO2NQEZWYR4peiLRtBmJZTCSsKXDY21nrDHiKOaMQyPJqbzkIrTBMnK/YJpg=


### PR DESCRIPTION
Since npm 6+ has built in security audit features, we don't need this anymore.