### PR TITLE
Fix gulp watch error

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -177,7 +177,7 @@ gulp.task('watch', function (done) {
         defaultAssets.server.migrations
       ]
     ),
-    'lint'
+    gulp.series('lint')
   );
 
   // Watch and generate app files


### PR DESCRIPTION
Attempts to fix error:
```
Error: watching server.js,config/**/*.js,modules/*/server/**/*.js,worker.js,gulpfile.js,migrations/*.js: watch task has to be a function (optionally generated by using gulp.parallel or gulp.series)
    at Gulp.watch (~/trustroots/node_modules/gulp/index.js:28:11)
    at ~/trustroots/gulpfile.js:171:8
    at taskWrapper (~/trustroots/node_modules/undertaker/lib/set-task.js:13:15)
    at bound (domain.js:396:14)
    at runBound (domain.js:409:12)
    at asyncRunner (~/trustroots/node_modules/async-done/index.js:55:18)
    at process._tickCallback (internal/process/next_tick.js:61:11)
```

FYI @guaka 

Fixes https://github.com/Trustroots/trustroots/issues/623