### PR TITLE
Add a test to check MongoDB version compatibility

### DIFF
--- a/config/env/development.js
+++ b/config/env/development.js
@@ -21,7 +21,9 @@ module.exports = {
       // pass: ''
     },
     // Mongoose debug mode
-    debug: true
+    debug: true,
+    // Check for MongoDB version compatibility on start
+    checkCompatibility: true
   },
   app: {
     title: 'Trustroots Development version',

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -21,8 +21,9 @@ module.exports = {
       // pass: ''
     },
     // Mongoose debug mode
-    debug: false
-
+    debug: false,
+    // Check for MongoDB version compatibility on start
+    checkCompatibility: false
   },
   domain: process.env.DOMAIN || 'www.trustroots.org'
 };

--- a/config/env/test.js
+++ b/config/env/test.js
@@ -21,7 +21,9 @@ module.exports = {
       // pass: ''
     },
     // Mongoose debug mode
-    debug: false
+    debug: false,
+    // Check for MongoDB version compatibility on start
+    checkCompatibility: false
   },
   maxUploadSize: 10000, // =10kb in bytes. Set ridiculously small just for tests
   port: 3001,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "engines": {
     "node": ">=8.0.0 <11",
-    "npm": ">=5.0.0"
+    "npm": ">=5.0.0",
+    "mongodb": "~3.4"
   },
   "browserslist": [
     "last 2 versions",


### PR DESCRIPTION
Related to making dev setup easier https://github.com/Trustroots/trustroots/issues/618

Previously the app would just silently fail with wrong versions.

While at it, refactors mongoose connection to be more clear.

Resolves https://github.com/Trustroots/trustroots/issues/624