### PR TITLE
Fix showing messages from deleted users

### DIFF
--- a/modules/messages/client/components/InboxThread.js
+++ b/modules/messages/client/components/InboxThread.js
@@ -18,7 +18,7 @@ export default function InboxThread({ user, thread }) {
         !read ? 'threadlist-thread-unread' : ''
       }`}
     >
-      <a href={`/messages/${otherUser.username}`}>
+      <a href={`/messages/${otherUser.username}?userId=${otherUser._id}`}>
         <div className="media">
           <div className="media-left">
             <Avatar user={otherUser} size={32} link={false} />

--- a/modules/messages/client/components/Thread.component.js
+++ b/modules/messages/client/components/Thread.component.js
@@ -301,7 +301,7 @@ export default function Thread({ user, profileMinimumLength }) {
             </ThreadContainer>
           )}
         </div>
-        {otherUser && !isExtraSmall && (
+        {otherUser && !isExtraSmall && !removed && (
           <div className="col-sm-3 text-center">
             <Monkeybox user={otherUser} otherUser={user} />
             {messages.length > 0 && (

--- a/modules/messages/client/components/Thread.component.js
+++ b/modules/messages/client/components/Thread.component.js
@@ -300,6 +300,15 @@ export default function Thread({ user, profileMinimumLength }) {
                   onSend={content => sendMessage(content)}
                 />
               )}
+              {removed && (
+                <div className="panel panel-default">
+                  <div className="panel-body">
+                    <em className="text-danger">
+                      {t('Member is not available anymore.')}
+                    </em>
+                  </div>
+                </div>
+              )}
             </ThreadContainer>
           )}
         </div>

--- a/modules/messages/client/components/Thread.component.js
+++ b/modules/messages/client/components/Thread.component.js
@@ -104,6 +104,8 @@ function Loading() {
 }
 
 export default function Thread({ user, profileMinimumLength }) {
+  const { t } = useTranslation('messages');
+
   if (!user.public) {
     return (
       <section className="container-spacer">
@@ -162,7 +164,7 @@ export default function Thread({ user, profileMinimumLength }) {
   function createFakeUserObject(userId) {
     return {
       _id: userId,
-      displayName: 'Unknown User',
+      displayName: t('Unknown member'),
       username: null,
       member: [],
       languages: [],

--- a/modules/messages/client/components/Thread.component.js
+++ b/modules/messages/client/components/Thread.component.js
@@ -119,6 +119,8 @@ export default function Thread({ user, profileMinimumLength }) {
     return null; // important to return null to indicate "nothing to render"
   }
 
+  const chatWithUnknownUser = username === 'undefined';
+
   const [nextParams, setNextParams] = useState(null);
   const [isFetching, setIsFetching] = useState(false);
   const [isFetchingMore, setIsFetchingMore] = useState(false);
@@ -135,7 +137,8 @@ export default function Thread({ user, profileMinimumLength }) {
   const userHasReplied = Boolean(
     messages.find(message => message.userFrom._id === user._id),
   );
-  const showReply = messages.length > 0 || !hasEmptyProfile;
+  const showReply =
+    (messages.length > 0 || !hasEmptyProfile) && !chatWithUnknownUser;
   const showQuickReply = showReply && !userHasReplied;
 
   const isExtraSmall = useMediaQuery({ maxWidth: 768 - 1 });
@@ -189,7 +192,7 @@ export default function Thread({ user, profileMinimumLength }) {
         a.created.localeCompare(b.created),
       );
       // TODO should be done at the back-end?
-      if (username === 'undefined') {
+      if (chatWithUnknownUser) {
         const filledMessages = messages.map(message => {
           if (!message.userTo) {
             message.userTo = { _id: otherUser._id };

--- a/modules/messages/client/components/ThreadMessage.js
+++ b/modules/messages/client/components/ThreadMessage.js
@@ -70,22 +70,26 @@ export default function ThreadMessage({ message, user }) {
     return otherUser._id === user._id;
   }
 
+  const deletedUser = !message.userFrom.username;
+
   return (
     <MessageContainer message={message}>
       <div className="message-main">
         <div className="message-meta">
           {isMe(message.userFrom) ? (
             <span>{t('You')}</span>
-          ) : (
+          ) : !deletedUser ? (
             <a href={`/profile/${message.userFrom.username}`}>
               {message.userFrom.displayName}
             </a>
+          ) : (
+            <span>Unknown User</span>
           )}
           —
           <TimeAgo date={new Date(message.created)} />
         </div>
         <div className="panel panel-default">
-          <Avatar user={message.userFrom} size={24} />
+          <Avatar user={message.userFrom} size={24} link={!deletedUser} />
           <div
             className="panel-body"
             dangerouslySetInnerHTML={{ __html: message.content }}
@@ -93,7 +97,7 @@ export default function ThreadMessage({ message, user }) {
         </div>
       </div>
       <div className="message-author">
-        <Avatar user={message.userFrom} size={32} />
+        <Avatar user={message.userFrom} size={32} link={!deletedUser} />
       </div>
     </MessageContainer>
   );

--- a/modules/messages/client/components/ThreadMessage.js
+++ b/modules/messages/client/components/ThreadMessage.js
@@ -83,7 +83,7 @@ export default function ThreadMessage({ message, user }) {
               {message.userFrom.displayName}
             </a>
           ) : (
-            <span>Unknown User</span>
+            <span>{t('Unknown member')}</span>
           )}
           —
           <TimeAgo date={new Date(message.created)} />

--- a/modules/messages/client/components/ThreadMessages.js
+++ b/modules/messages/client/components/ThreadMessages.js
@@ -30,7 +30,7 @@ export default function ThreadMessages({
   const isExtraSmall = useMediaQuery({ maxWidth: 768 - 1 });
   return (
     <InfiniteMessages component={MessagesContainer} onFetchMore={onFetchMore}>
-      {isExtraSmall && (
+      {isExtraSmall && otherUser.username && (
         <div className="message">
           <div className="message-recipient panel panel-default">
             <a className="panel-body" href={`/profile/${otherUser.username}`}>

--- a/modules/messages/client/config/messages.client.routes.js
+++ b/modules/messages/client/config/messages.client.routes.js
@@ -13,7 +13,7 @@ function MessagesRoutes($stateProvider) {
       },
     })
     .state('messageThread', {
-      url: '/messages/:username',
+      url: '/messages/:username?userId',
       template:
         '<thread user="app.user" profileMinimumLength="app.appSettings.profileMinimumLength"></thread>',
       requiresAuth: true,

--- a/modules/messages/server/controllers/messages.server.controller.js
+++ b/modules/messages/server/controllers/messages.server.controller.js
@@ -74,59 +74,93 @@ function sanitizeMessages(messages) {
 exports.sanitizeMessages = sanitizeMessages;
 
 /**
+ * Fill `userFrom` or `userTo` with deleted user's ID
+ *
+ * If user is deleted, the object from `User` collection is gone.
+ * `Thread.paginate()` attempts to populate it but failing to do so,
+ * leaves `userFrom` or `userTo` as `null` instead of just keeping
+ * the original document `_id` which would still be useful at the frontend.
+ * Until we refactor our code not to use `mongoose-paginate`, this helper
+ * will backfill the IDs. Cumbersome and not optimal, but there are not that
+ * many deleted profiles that this would be a significant issue.
+ *
+ * @param {Object} Thread
+ * @return {Object} Thread with possibly mutated `thread.userFrom` / `thread.userTo`
+ */
+function fillDeletedProfiles(threads, callback) {
+  if (!threads || !threads.length) {
+    return callback(null, []);
+  }
+
+  async.mapSeries(
+    threads,
+    function (thread, done) {
+      if (thread.userTo && thread.userFrom) {
+        return done(null, thread);
+      }
+
+      // Check which field is `null` — only one of them can
+      const field = !thread.userTo ? 'userTo' : 'userFrom';
+
+      Thread.findById(thread._id, field, function (err, newThread) {
+        if (!err && newThread) {
+          thread[field] = {
+            _id: newThread[field],
+          };
+        }
+        done(null, thread);
+      });
+    },
+    callback,
+  );
+}
+
+/**
  * Sanitize threads
+ *
  * @param {Array} threads - list of threads to go trough
  * @param {ObjectId} authenticatedUserId - ID of currently authenticated user
  * @returns {Array}
  */
-function sanitizeThreads(threads, authenticatedUserId) {
+function sanitizeThreads(threads, authenticatedUserId, callback) {
   if (!threads || !threads.length) {
-    return [];
+    return callback(null, []);
   }
 
-  // Sanitize each outgoing thread
-  const threadsCleaned = [];
+  async.mapSeries(
+    threads,
+    function (thread, done) {
+      // Threads need just excerpt
+      thread = thread.toObject();
 
-  threads.forEach(function (thread) {
-    // Threads need just excerpt
-    thread = thread.toObject();
+      // Clean message content from html + clean all whitespace + shorten
+      if (thread.message) {
+        thread.message.excerpt = thread.message.content
+          ? textService
+              .plainText(thread.message.content, true)
+              .substring(0, 100)
+          : '…';
+        delete thread.message.content;
+      } else {
+        // Ensure this works even if messages couldn't be found for some reason
+        thread.message = {
+          excerpt: '…',
+        };
+      }
+      // If latest message in the thread was from current user, show
+      // it as read - sender obviously read his/her own message
+      if (
+        thread.userFrom &&
+        thread.userFrom._id &&
+        thread.userFrom._id.toString() === authenticatedUserId.toString()
+      ) {
+        thread.read = true;
+      }
 
-    // Clean message content from html + clean all whitespace + shorten
-    if (thread.message) {
-      thread.message.excerpt = thread.message.content
-        ? textService.plainText(thread.message.content, true).substring(0, 100)
-        : '…';
-      delete thread.message.content;
-    } else {
-      // Ensure this works even if messages couldn't be found for some reason
-      thread.message = {
-        excerpt: '…',
-      };
-    }
-
-    // If latest message in the thread was from current user, show
-    // it as read - sender obviously read his/her own message
-    if (
-      thread.userFrom &&
-      thread.userFrom._id &&
-      thread.userFrom._id.toString() === authenticatedUserId.toString()
-    ) {
-      thread.read = true;
-    }
-
-    // If users weren't populated, they were removed.
-    // Don't return thread at all at this point.
-    //
-    // @todo:
-    // Return thread but with placeholder user and old user's ID
-    // With ID we could fetch the message thread — now all we could
-    // show is this line at inbox but not actual messages
-    if (thread.userTo && thread.userFrom) {
-      threadsCleaned.push(thread);
-    }
-  });
-
-  return threadsCleaned;
+      done(null, thread);
+    },
+    callback,
+  );
 }
 
 /**
@@ -165,10 +199,17 @@ exports.inbox = function (req, res) {
       limit: req.query.limit || 20,
       sort: '-updated',
       select: threadFields,
-      populate: {
-        path: 'userFrom userTo message',
-        select: 'content ' + userProfile.userMiniProfileFields,
-      },
+      populate: [
+        {
+          path: 'message',
+          select: 'content',
+        },
+        {
+          path: 'userFrom userTo',
+          select: userProfile.userMiniProfileFields,
+          model: 'User',
+        },
+      ],
     },
     function (err, data) {
       if (err) {
@@ -176,12 +217,22 @@ exports.inbox = function (req, res) {
           message: errorService.getErrorMessage(err),
         });
       } else {
-        const threads = sanitizeThreads(data.docs, req.user._id);
-
         // Pass pagination data to construct link header
         setLinkHeader(req, res, data.pages);
 
-        res.json(threads);
+        // Sanitize and return threads
+        sanitizeThreads(data.docs, req.user._id, function (err, threads) {
+          // If user is deleted, the object from `User` collection is gone.
+          // `Thread.paginate()` attempts to populate it but failing to do so,
+          // leaves `userFrom` or `userTo` as `null` instead of just keeping
+          // the original document `_id` which would still be useful at the frontend.
+          // Until we refactor our code not to use `mongoose-paginate`, this helper
+          // will backfill the IDs. Cumbersome and not optimal, but there are not that
+          // many deleted profiles that this would be a significant issue.
+          fillDeletedProfiles(threads, function (err, threads) {
+            res.json(threads || []);
+          });
+        });
       }
     },
   );

--- a/modules/messages/server/controllers/messages.server.controller.js
+++ b/modules/messages/server/controllers/messages.server.controller.js
@@ -512,34 +512,41 @@ exports.threadByUser = function (req, res, next, userId) {
     });
   }
 
-  // Only moderator and admin roles can read messages from banned users. For others they stay hidden.
-  const publicityLimit =
-    req.user.roles.includes('moderator') || req.user.roles.includes('admin')
-      ? {}
-      : {
-          public: true,
-          roles: { $nin: ['suspended', 'shadowban'] },
-        };
+  // TODO do we want to allow to see the messages from suspended or banned users
+  // in order to make them "read"?
+
+  // // Only moderator and admin roles can read messages from banned users. For others they stay hidden.
+  // const publicityLimit =
+  //   req.user.roles.includes('moderator') || req.user.roles.includes('admin')
+  //     ? {}
+  //     : {
+  //         public: true,
+  //         roles: { $nin: ['suspended', 'shadowban'] },
+  //       };
 
   async.waterfall(
     [
-      // Check that other user is legitimate:
-      // - Has to be confirmed their email (hence be public)
-      // - Not suspended profile
-      function (done) {
-        User.findOne({
-          _id: userId,
-          ...publicityLimit,
-        }).exec(function (err, receiver) {
-          // If we were unable to find the receiver, return the error and stop here
-          if (err || !receiver) {
-            return res.status(404).send({
-              message: 'Member does not exist.',
-            });
-          }
-          done();
-        });
-      },
+      // TODO commented out just to make it work.
+      // We probably want to still return 404, if the user existed by didn't
+      // have conversation with logged-in user?
+
+      // // Check that other user is legitimate:
+      // // - Has to be confirmed their email (hence be public)
+      // // - Not suspended profile
+      // function (done) {
+      //   User.findOne({
+      //     _id: userId,
+      //     ...publicityLimit,
+      //   }).exec(function (err, receiver) {
+      //     // If we were unable to find the receiver, return the error and stop here
+      //     if (err || !receiver) {
+      //       return res.status(404).send({
+      //         message: 'Member does not exist.',
+      //       });
+      //     }
+      //     done();
+      //   });
+      // },
 
       // Find messages
       function (done) {

--- a/modules/messages/server/controllers/messages.server.controller.js
+++ b/modules/messages/server/controllers/messages.server.controller.js
@@ -600,6 +600,7 @@ exports.threadByUser = function (req, res, next, userId) {
 
         // If latest message in the thread was to current user, mark thread read
         if (
+          messages[0].userTo &&
           messages[0].userTo._id &&
           req.user._id.equals(messages[0].userTo._id)
         ) {

--- a/modules/messages/tests/server/message.server.routes.tests.js
+++ b/modules/messages/tests/server/message.server.routes.tests.js
@@ -207,6 +207,28 @@ describe('Message CRUD tests', function () {
     });
   });
 
+  it('should be able to read messages from user with role "shadowban"', function (done) {
+    userTo.roles = ['user', 'shadowban'];
+
+    userTo.save(function (saveErr) {
+      should.not.exist(saveErr);
+
+      agent
+        .post('/api/auth/signin')
+        .send(credentials)
+        .expect(200)
+        .end(function (signinErr) {
+          should.not.exist(signinErr);
+
+          // Get a list of messages
+          agent
+            .get('/api/messages/' + userToId)
+            .expect(200)
+            .end(done);
+        });
+    });
+  });
+
   it('should not be able to send messages to user with role "shadowban"', function (done) {
     userTo.roles = ['user', 'shadowban'];
 
@@ -226,127 +248,29 @@ describe('Message CRUD tests', function () {
     });
   });
 
-  it('should be able to read messages from user with role "shadowban" when with role "admin"', function (done) {
-    userTo.roles = ['user', 'shadowban'];
-    userFrom.roles = ['user', 'admin'];
+  ['admin', 'moderator'].forEach(role => {
+    it(`should be able to send messages to user with role "shadowban" when with role "${role}"`, function (done) {
+      userTo.roles = ['user', 'shadowban'];
+      userFrom.roles = ['user', role];
 
-    userFrom.save(function (saveErr) {
-      should.not.exist(saveErr);
-
-      userTo.save(function (saveErr) {
+      userFrom.save(function (saveErr) {
         should.not.exist(saveErr);
 
-        agent
-          .post('/api/auth/signin')
-          .send(credentials)
-          .expect(200)
-          .end(function (signinErr) {
-            should.not.exist(signinErr);
+        userTo.save(function (saveErr) {
+          should.not.exist(saveErr);
 
-            // Get a list of messages
-            agent
-              .get('/api/messages/' + userToId)
-              .expect(200)
-              .end(done);
-          });
-      });
-    });
-  });
-
-  it('should be able to send messages to user with role "shadowban" when with role "admin"', function (done) {
-    userTo.roles = ['user', 'shadowban'];
-    userFrom.roles = ['user', 'admin'];
-
-    userFrom.save(function (saveErr) {
-      should.not.exist(saveErr);
-
-      userTo.save(function (saveErr) {
-        should.not.exist(saveErr);
-
-        agent
-          .post('/api/auth/signin')
-          .send(credentials)
-          .expect(200)
-          .end(function (signinErr) {
-            should.not.exist(signinErr);
-
-            // Save a new message
-            agent.post('/api/messages').send(message).expect(200).end(done);
-          });
-      });
-    });
-  });
-
-  it('should be able to read messages from user with role "shadowban" when with role "moderator"', function (done) {
-    userTo.roles = ['user', 'shadowban'];
-    userFrom.roles = ['user', 'moderator'];
-
-    userFrom.save(function (saveErr) {
-      should.not.exist(saveErr);
-
-      userTo.save(function (saveErr) {
-        should.not.exist(saveErr);
-
-        agent
-          .post('/api/auth/signin')
-          .send(credentials)
-          .expect(200)
-          .end(function (signinErr) {
-            should.not.exist(signinErr);
-
-            // Get a list of messages
-            agent
-              .get('/api/messages/' + userToId)
-              .expect(200)
-              .end(done);
-          });
-      });
-    });
-  });
-
-  it('should be able to send messages to user with role "shadowban" when with role "moderator"', function (done) {
-    userTo.roles = ['user', 'shadowban'];
-    userFrom.roles = ['user', 'moderator'];
-
-    userFrom.save(function (saveErr) {
-      should.not.exist(saveErr);
-
-      userTo.save(function (saveErr) {
-        should.not.exist(saveErr);
-
-        agent
-          .post('/api/auth/signin')
-          .send(credentials)
-          .expect(200)
-          .end(function (signinErr) {
-            should.not.exist(signinErr);
-
-            // Save a new message
-            agent.post('/api/messages').send(message).expect(200).end(done);
-          });
-      });
-    });
-  });
-
-  it('should not be able to read messages from user with role "shadowban"', function (done) {
-    userTo.roles = ['user', 'shadowban'];
-
-    userTo.save(function (saveErr) {
-      should.not.exist(saveErr);
-
-      agent
-        .post('/api/auth/signin')
-        .send(credentials)
-        .expect(200)
-        .end(function (signinErr) {
-          should.not.exist(signinErr);
-
-          // Get a list of messages
           agent
-            .get('/api/messages/' + userToId)
-            .expect(404)
-            .end(done);
+            .post('/api/auth/signin')
+            .send(credentials)
+            .expect(200)
+            .end(function (signinErr) {
+              should.not.exist(signinErr);
+
+              // Save a new message
+              agent.post('/api/messages').send(message).expect(200).end(done);
+            });
         });
+      });
     });
   });
 


### PR DESCRIPTION
Resolves https://github.com/Trustroots/trustroots/issues/596

Allow reading messages from deleted users by:
- Passing user `_id` from the API
- Opening message thread with that id instead of username
- Loading messages with that _id even when `userFrom` does not resolve to any user _(still broken)_

Todo:
- [x] Fix frontend, might need some refactoring
- [x] Update tests

### Testing

- Create three users and send messages from one to two others
- Delete one of the user's profile
- See if you can still open the message thread
- Ensure for other users, `?userId=` bit doesn't appear in the URLs
- No JS errors in the console when looking at inbox and threads