### PR TITLE
Search: add last-seen filter

### DIFF
--- a/modules/offers/tests/server/offer.server.routes.tests.js
+++ b/modules/offers/tests/server/offer.server.routes.tests.js
@@ -1102,7 +1102,6 @@ describe('Offer CRUD tests', function () {
   });
 
   afterEach(function (done) {
-    // Uggggly pyramid revenge!
     User.remove().exec(function () {
       Tribe.remove().exec(function () {
         Offer.remove().exec(done);

--- a/modules/search/client/controllers/search.client.controller.js
+++ b/modules/search/client/controllers/search.client.controller.js
@@ -24,6 +24,8 @@
     vm.onPlaceSearch = onPlaceSearch;
     vm.openSearchPlaceInput = openSearchPlaceInput;
     vm.onLanguageFiltersChange = onLanguageFiltersChange;
+    vm.onSeenFilterChange = onSeenFilterChange;
+    vm.onlineInPast6Months = vm.filters.seen && vm.filters.seen.months === 6;
     vm.sidebarTab = 'filters';
 
     // Visibility toggle for search place input on small screens
@@ -103,6 +105,22 @@
       $timeout(function () {
         // Save new value to cache
         FiltersService.set('languages', vm.filters.languages || []);
+
+        onFiltersUpdated();
+      });
+    }
+
+    /**
+     * Fired for changes at seen filter
+     */
+    function onSeenFilterChange() {
+      vm.filters.seen.months = vm.onlineInPast6Months ? 6 : 24;
+
+      // `vm.filters.seen` is still out of sync at this point,
+      // but in next cycle after `$timeout` we have updated version.
+      $timeout(function () {
+        // Save new value to cache
+        FiltersService.set('seen', vm.filters.seen);
 
         onFiltersUpdated();
       });

--- a/modules/search/client/services/filters.client.service.js
+++ b/modules/search/client/services/filters.client.service.js
@@ -15,7 +15,10 @@
     var defaultFilters = {
       tribes: [],
       types: [],
-      languages: []
+      languages: [],
+      seen: {
+        months: 24
+      }
     };
 
     // Make cache id unique for this user

--- a/modules/search/client/views/search-sidebar-filters.client.view.html
+++ b/modules/search/client/views/search-sidebar-filters.client.view.html
@@ -32,6 +32,19 @@
 
   <hr class="hr-gray hr-tight">
 
+  <!-- Online recently filter (aka "seen") -->
+  <p>
+    <label tr-switch>
+      <input type="checkbox"
+             ng-model="search.onlineInPast6Months"
+             ng-change="search.onSeenFilterChange()">
+      Online in the past 6 months
+    </label>
+  </p>
+  <!-- /Online recently filter (aka "seen") -->
+
+  <hr class="hr-gray hr-tight">
+
   <!-- Language filter -->
   <h4 id="filter-languages">Spoken languages</h4>
   <div tr-languages="search.filters.languages"


### PR DESCRIPTION
Adds a simple _"Online in the past 6 months"_  toggle to search filters.

By default sends _"online in the past 24 months"_ filter in every API request to hide members who didn't login in the past 2 years.

Resolves #639