### PR TITLE
Revert "minimal upgrade to mongoose v5"

### DIFF
--- a/config/lib/app.js
+++ b/config/lib/app.js
@@ -13,10 +13,10 @@ mongoose.loadModels();
 
 module.exports.init = function init(callback) {
 
-  mongoose.connect(function (connection) {
+  mongoose.connect(function (db) {
     // Initialize express
-    var app = express.init(connection);
-    if (callback) callback(app, connection, config);
+    var app = express.init(db);
+    if (callback) callback(app, db, config);
   });
 };
 

--- a/config/lib/express.js
+++ b/config/lib/express.js
@@ -168,7 +168,7 @@ module.exports.initViewEngine = function (app) {
 /**
  * Configure Express session
  */
-module.exports.initSession = function (app, connection) {
+module.exports.initSession = function (app, db) {
   // Express MongoDB session storage
   // https://www.npmjs.com/package/express-session
   app.use(session({
@@ -189,7 +189,7 @@ module.exports.initSession = function (app, connection) {
       maxAge: 2419200000 // (in milliseconds) 28 days
     },
     store: new MongoStore({
-      mongooseConnection: connection,
+      mongooseConnection: db.connection,
       collection: config.sessionCollection
     })
   }));
@@ -523,7 +523,7 @@ module.exports.initErrorRoutes = function (app) {
 /**
  * Initialize the Express application
  */
-module.exports.init = function (connection) {
+module.exports.init = function (db) {
   // Initialize express app
   var app = express();
 
@@ -543,7 +543,7 @@ module.exports.init = function (connection) {
   this.initModulesClientRoutes(app);
 
   // Initialize Express session
-  this.initSession(app, connection);
+  this.initSession(app, db);
 
   // Initialize Modules configuration
   this.initModulesConfiguration(app);

--- a/config/lib/mongoose.js
+++ b/config/lib/mongoose.js
@@ -43,10 +43,12 @@ module.exports.connect = function (callback) {
     }
   };
 
+  var db;
+
   async.waterfall([
     // Connect
     function (done) {
-      mongoose.connect(config.db.uri, mongoConnectionOptions, function (err) {
+      db = mongoose.connect(config.db.uri, mongoConnectionOptions, function (err) {
         if (err) {
           console.error(chalk.red('Could not connect to MongoDB!'));
           console.error(err);
@@ -82,7 +84,7 @@ module.exports.connect = function (callback) {
   ],
   function () {
     if (callback) {
-      callback(mongoose.connection);
+      callback(db);
     }
   });
 };

--- a/modules/contacts/tests/server/contact.server.model.tests.js
+++ b/modules/contacts/tests/server/contact.server.model.tests.js
@@ -45,13 +45,13 @@ describe('Contact Model Unit Tests:', function () {
     });
 
     // Create users
-    user1.save(function () {
+    user1.save(function (user1Err, user1Res) {
 
-      user1Id = user1._id;
+      user1Id = user1Res._id;
 
-      user2.save(function () {
+      user2.save(function (user2Err, user2Res) {
 
-        user2Id = user2._id;
+        user2Id = user2Res._id;
 
         // Create connection between users
         contact = new Contact({

--- a/modules/contacts/tests/server/contact.server.routes.tests.js
+++ b/modules/contacts/tests/server/contact.server.routes.tests.js
@@ -39,7 +39,7 @@ describe('Contact CRUD tests', function () {
 
   before(function (done) {
     // Get application
-    app = express.init(mongoose.connection);
+    app = express.init(mongoose);
     agent = request.agent(app);
 
     done();

--- a/modules/core/tests/server/core.server.config.tests.js
+++ b/modules/core/tests/server/core.server.config.tests.js
@@ -27,7 +27,7 @@ describe('Configuration Tests:', function () {
 
     beforeEach(function (done) {
       // Get application
-      app = express.init(mongoose.connection);
+      app = express.init(mongoose);
       agent = request.agent(app);
       done();
     });
@@ -105,7 +105,7 @@ describe('Configuration Tests:', function () {
               }
 
               // The user we just created should be exposed
-              res.text.should.match(new RegExp('user = \\{.*"_id":"' + userId + '"'));
+              res.text.should.containEql('user = {"_id":"' + userId + '",');
 
               return done();
             });
@@ -152,7 +152,7 @@ describe('Configuration Tests:', function () {
                 }
 
                 // The user we just created should be exposed
-                res.text.should.match(new RegExp('user = \\{.*"_id":"' + userId + '"'));
+                res.text.should.containEql('user = {"_id":"' + userId + '",');
 
                 Tribe.remove().exec(done);
               });
@@ -175,7 +175,7 @@ describe('Configuration Tests:', function () {
         process.env.NODE_ENV = env;
 
         // Get application
-        app = express.init(mongoose.connection);
+        app = express.init(mongoose);
         agent = request.agent(app);
 
         // Get rendered layout

--- a/modules/core/tests/server/core.server.routes.tests.js
+++ b/modules/core/tests/server/core.server.routes.tests.js
@@ -33,7 +33,7 @@ describe('Core CRUD tests', function () {
 
   before(function (done) {
     // Get application
-    app = express.init(mongoose.connection);
+    app = express.init(mongoose);
     agent = request.agent(app);
 
     done();

--- a/modules/core/tests/server/jobs/send-push-message.server.job.tests.js
+++ b/modules/core/tests/server/jobs/send-push-message.server.job.tests.js
@@ -235,8 +235,7 @@ describe('job: send push message', function () {
           var tokens = updatedUser.pushRegistration.map(function (reg) {
             return reg.token;
           });
-          // we need to convert CoreMongooseArray to Array
-          Array.from(tokens).should.deepEqual(['123', '456']);
+          tokens.should.deepEqual(['123', '456']);
 
           done();
         });

--- a/modules/messages/tests/server/message-stat.server.routes.tests.js
+++ b/modules/messages/tests/server/message-stat.server.routes.tests.js
@@ -21,7 +21,7 @@ describe('Display Message Statistics in User Route', function () {
 
   before(function (done) {
     // Get application
-    var app = express.init(mongoose.connection);
+    var app = express.init(mongoose);
     agent = request.agent(app);
 
     done();

--- a/modules/messages/tests/server/message.server.routes.tests.js
+++ b/modules/messages/tests/server/message.server.routes.tests.js
@@ -32,7 +32,7 @@ describe('Message CRUD tests', function () {
 
   before(function (done) {
     // Get application
-    app = express.init(mongoose.connection);
+    app = express.init(mongoose);
     agent = request.agent(app);
 
     done();

--- a/modules/offers/tests/server/offer.server.routes.tests.js
+++ b/modules/offers/tests/server/offer.server.routes.tests.js
@@ -77,7 +77,7 @@ describe('Offer CRUD tests', function () {
 
   before(function (done) {
     // Get application
-    app = express.init(mongoose.connection);
+    app = express.init(mongoose);
     agent = request.agent(app);
 
     done();

--- a/modules/references-thread/tests/server/reference-thread.server.routes.tests.js
+++ b/modules/references-thread/tests/server/reference-thread.server.routes.tests.js
@@ -38,7 +38,7 @@ describe('Reference Thread CRUD tests', function () {
 
   before(function (done) {
     // Get application
-    app = express.init(mongoose.connection);
+    app = express.init(mongoose);
     agent = request.agent(app);
 
     done();

--- a/modules/sparkpost/tests/server/sparkpost.server.routes.tests.js
+++ b/modules/sparkpost/tests/server/sparkpost.server.routes.tests.js
@@ -22,7 +22,7 @@ describe('Sparkpost CRUD tests', function () {
 
     before(function (done) {
       // Get application
-      app = express.init(mongoose.connection);
+      app = express.init(mongoose);
       agent = request.agent(app);
 
       // Sparkpost webhook event example

--- a/modules/statistics/tests/server/statistics.server.routes.tests.js
+++ b/modules/statistics/tests/server/statistics.server.routes.tests.js
@@ -26,7 +26,7 @@ describe('Statistics CRUD tests', function () {
 
   before(function () {
     // Get application
-    app = express.init(mongoose.connection);
+    app = express.init(mongoose);
     agent = request.agent(app);
   });
 

--- a/modules/support/tests/server/support.server.routes.tests.js
+++ b/modules/support/tests/server/support.server.routes.tests.js
@@ -23,7 +23,7 @@ describe('Support CRUD tests', function () {
 
   before(function (done) {
     // Get application
-    app = express.init(mongoose.connection);
+    app = express.init(mongoose);
     agent = request.agent(app);
 
     done();

--- a/modules/tribes/tests/server/tribes.server.routes.test.js
+++ b/modules/tribes/tests/server/tribes.server.routes.test.js
@@ -28,7 +28,7 @@ describe('Tribe CRUD tests', function () {
 
   before(function (done) {
     // Get application
-    app = express.init(mongoose.connection);
+    app = express.init(mongoose);
     agent = request.agent(app);
 
     done();

--- a/modules/users/tests/server/user-invite.server.routes.tests.js
+++ b/modules/users/tests/server/user-invite.server.routes.tests.js
@@ -25,7 +25,7 @@ describe('User invites CRUD tests', function () {
 
   before(function (done) {
     // Get application
-    app = express.init(mongoose.connection);
+    app = express.init(mongoose);
     agent = request.agent(app);
 
     done();

--- a/modules/users/tests/server/user-lastseen.server.tests.js
+++ b/modules/users/tests/server/user-lastseen.server.tests.js
@@ -23,7 +23,7 @@ describe('User last seen CRUD tests', function () {
 
   before(function (done) {
     // Get application
-    app = express.init(mongoose.connection);
+    app = express.init(mongoose);
     agent = request.agent(app);
 
     done();

--- a/modules/users/tests/server/user-password.server.routes.tests.js
+++ b/modules/users/tests/server/user-password.server.routes.tests.js
@@ -23,7 +23,7 @@ describe('User password CRUD tests', function () {
 
   before(function (done) {
     // Get application
-    app = express.init(mongoose.connection);
+    app = express.init(mongoose);
     agent = request.agent(app);
 
     done();

--- a/modules/users/tests/server/user-profile.server.routes.tests.js
+++ b/modules/users/tests/server/user-profile.server.routes.tests.js
@@ -27,7 +27,7 @@ describe('User profile CRUD tests', function () {
 
   before(function (done) {
     // Get application
-    app = express.init(mongoose.connection);
+    app = express.init(mongoose);
     agent = request.agent(app);
 
     done();

--- a/modules/users/tests/server/user-removal.server.routes.tests.js
+++ b/modules/users/tests/server/user-removal.server.routes.tests.js
@@ -38,7 +38,7 @@ describe('User removal CRUD tests', function () {
 
   before(function (done) {
     // Get application
-    app = express.init(mongoose.connection);
+    app = express.init(mongoose);
     agent = request.agent(app);
 
     done();

--- a/modules/users/tests/server/user-signup-validate.server.routes.tests.js
+++ b/modules/users/tests/server/user-signup-validate.server.routes.tests.js
@@ -58,7 +58,7 @@ describe('User signup validation CRUD tests', function () {
 
   before(function (done) {
     // Get application
-    app = express.init(mongoose.connection);
+    app = express.init(mongoose);
     agent = request.agent(app);
 
     done();

--- a/modules/users/tests/server/user-signup.server.routes.tests.js
+++ b/modules/users/tests/server/user-signup.server.routes.tests.js
@@ -29,7 +29,7 @@ describe('User signup and authentication CRUD tests', function () {
 
   before(function (done) {
     // Get application
-    app = express.init(mongoose.connection);
+    app = express.init(mongoose);
     agent = request.agent(app);
 
     done();

--- a/modules/users/tests/server/user-tribe.server.routes.tests.js
+++ b/modules/users/tests/server/user-tribe.server.routes.tests.js
@@ -24,7 +24,7 @@ describe('User tribe memberships CRUD tests', function () {
 
   before(function (done) {
     // Get application
-    app = express.init(mongoose.connection);
+    app = express.init(mongoose);
     agent = request.agent(app);
 
     done();

--- a/package-lock.json
+++ b/package-lock.json
@@ -891,9 +891,9 @@
       "dev": true
     },
     "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
+      "integrity": "sha1-AkpVFylTCIV/FPkfEQb8O1VfRGs="
     },
     "body-parser": {
       "version": "1.18.3",
@@ -3882,8 +3882,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "optional": true
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
           "version": "1.1.1",
@@ -3934,8 +3933,7 @@
         "balanced-match": {
           "version": "0.4.2",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-          "optional": true
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
@@ -3950,7 +3948,6 @@
           "version": "0.0.9",
           "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
           "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-          "optional": true,
           "requires": {
             "inherits": "~2.0.0"
           }
@@ -3959,7 +3956,6 @@
           "version": "2.10.1",
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -3968,7 +3964,6 @@
           "version": "1.1.7",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
           "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
-          "optional": true,
           "requires": {
             "balanced-match": "^0.4.1",
             "concat-map": "0.0.1"
@@ -3977,8 +3972,7 @@
         "buffer-shims": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-          "optional": true
+          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
         },
         "caseless": {
           "version": "0.12.0",
@@ -3995,14 +3989,12 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "optional": true
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "combined-stream": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-          "optional": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
@@ -4010,20 +4002,17 @@
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "optional": true
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "optional": true
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-          "optional": true
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "cryptiles": {
           "version": "2.0.5",
@@ -4069,8 +4058,7 @@
         "delayed-stream": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-          "optional": true
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
         },
         "delegates": {
           "version": "1.0.0",
@@ -4096,8 +4084,7 @@
         "extsprintf": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-          "optional": true
+          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -4119,14 +4106,12 @@
         "fs.realpath": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-          "optional": true
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "fstream": {
           "version": "1.0.11",
           "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
           "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "inherits": "~2.0.0",
@@ -4182,7 +4167,6 @@
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -4195,8 +4179,7 @@
         "graceful-fs": {
           "version": "4.1.11",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "optional": true
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
         },
         "har-schema": {
           "version": "1.0.5",
@@ -4235,8 +4218,7 @@
         "hoek": {
           "version": "2.16.3",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "optional": true
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
         },
         "http-signature": {
           "version": "1.1.1",
@@ -4253,7 +4235,6 @@
           "version": "1.0.6",
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "optional": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -4274,7 +4255,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4288,8 +4268,7 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "optional": true
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "isstream": {
           "version": "0.1.2",
@@ -4362,14 +4341,12 @@
         "mime-db": {
           "version": "1.27.0",
           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
-          "optional": true
+          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
         },
         "mime-types": {
           "version": "2.1.15",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
           "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-          "optional": true,
           "requires": {
             "mime-db": "~1.27.0"
           }
@@ -4378,7 +4355,6 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4386,14 +4362,12 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "optional": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "mkdirp": {
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4446,8 +4420,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "optional": true
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -4494,8 +4467,7 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-          "optional": true
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "performance-now": {
           "version": "0.2.0",
@@ -4506,8 +4478,7 @@
         "process-nextick-args": {
           "version": "1.0.7",
           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "optional": true
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
         },
         "punycode": {
           "version": "1.4.1",
@@ -4545,7 +4516,6 @@
           "version": "2.2.9",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
           "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
-          "optional": true,
           "requires": {
             "buffer-shims": "~1.0.0",
             "core-util-is": "~1.0.0",
@@ -4590,7 +4560,6 @@
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
           "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-          "optional": true,
           "requires": {
             "glob": "^7.0.5"
           }
@@ -4598,8 +4567,7 @@
         "safe-buffer": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
-          "optional": true
+          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
         },
         "semver": {
           "version": "5.3.0",
@@ -4657,7 +4625,6 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4668,7 +4635,6 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
           "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -4683,7 +4649,6 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4698,7 +4663,6 @@
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
           "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-          "optional": true,
           "requires": {
             "block-stream": "*",
             "fstream": "^1.0.2",
@@ -4754,8 +4718,7 @@
         "util-deprecate": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-          "optional": true
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "uuid": {
           "version": "3.0.1",
@@ -6817,6 +6780,11 @@
         "parse-passwd": "^1.0.0"
       }
     },
+    "hooks-fixed": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-2.0.0.tgz",
+      "integrity": "sha1-oB2JTVKsf2WZu7H2PfycQR33DLo="
+    },
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
@@ -7545,9 +7513,9 @@
       "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo="
     },
     "kareem": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.2.1.tgz",
-      "integrity": "sha512-xpDFy8OxkFM+vK6pXy6JmH92ibeEFUuDWzas5M9L7MzVmHW3jzwAHxodCPV/BYkf4A31bVDLyonrMfp9RXb/oA=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-1.4.1.tgz",
+      "integrity": "sha1-7XYgAET6BB7zK02oJh4lU/EXNTE="
     },
     "karma": {
       "version": "1.7.1",
@@ -8513,11 +8481,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
       "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
-    },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.includes": {
       "version": "4.3.0",
@@ -10061,59 +10024,50 @@
       }
     },
     "mongoose": {
-      "version": "5.2.9",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.2.9.tgz",
-      "integrity": "sha512-PqXYKtXq5VPJDf7pUuCfTjN5MVEE0Dyia+YrqkI/FU8kk7YmZbGIedbvw7HHn+EKFSD2N137djhbH0NJ7FNA5Q==",
+      "version": "4.9.10",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-4.9.10.tgz",
+      "integrity": "sha1-PjWWPhq3KydamYWCuusm6PIC0uM=",
       "requires": {
-        "async": "2.6.1",
-        "bson": "~1.0.5",
-        "kareem": "2.2.1",
-        "lodash.get": "4.4.2",
-        "mongodb": "3.1.3",
-        "mongodb-core": "3.1.2",
-        "mongoose-legacy-pluralize": "1.0.2",
-        "mpath": "0.4.1",
-        "mquery": "3.1.2",
-        "ms": "2.0.0",
+        "async": "2.1.4",
+        "bson": "~1.0.4",
+        "hooks-fixed": "2.0.0",
+        "kareem": "1.4.1",
+        "mongodb": "2.2.26",
+        "mpath": "0.2.1",
+        "mpromise": "0.5.5",
+        "mquery": "2.3.0",
+        "ms": "0.7.2",
+        "muri": "1.2.1",
         "regexp-clone": "0.0.1",
-        "safe-buffer": "5.1.2",
         "sliced": "1.0.1"
       },
       "dependencies": {
-        "mongodb": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.3.tgz",
-          "integrity": "sha512-hfzI54/fe+604w5gP+i9aJ5GGVxnquxZ09ZN1cyLTbpnBfDRpj78lN59SBdDRkF1VNTzmM2KcgDWhHHDHcsJxw==",
+        "async": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
+          "integrity": "sha1-LSFgx3iAMuTdbL4lAvH5osj2zeQ=",
           "requires": {
-            "mongodb-core": "3.1.2"
+            "lodash": "^4.14.0"
+          }
+        },
+        "mongodb": {
+          "version": "2.2.26",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.26.tgz",
+          "integrity": "sha1-G9UMVXwnfJjhoF2jjJg5xJIrA0o=",
+          "requires": {
+            "es6-promise": "3.2.1",
+            "mongodb-core": "2.1.10",
+            "readable-stream": "2.2.7"
           }
         },
         "mongodb-core": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.1.2.tgz",
-          "integrity": "sha512-R2XxGzsmhlUeOK2jKATj1TWn3q3qNcJpKrSh0rhaBSHxJmV7WZ+ikjocdY8VdJxUkKqOxM8rxMqOAEzeJ3p1ww==",
+          "version": "2.1.10",
+          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.10.tgz",
+          "integrity": "sha1-6ykGgdGW0zRqSSFhqi6gkF5jFRs=",
           "requires": {
-            "bson": "^1.1.0",
-            "require_optional": "^1.0.1",
-            "saslprep": "^1.0.0"
-          },
-          "dependencies": {
-            "bson": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.0.tgz",
-              "integrity": "sha512-9Aeai9TacfNtWXOYarkFJRW2CWo+dRon+fuLZYJmvLV3+MiUp0bEI6IAZfXEIg7/Pl/7IWlLaDnhzTsD81etQA=="
-            }
+            "bson": "~1.0.4",
+            "require_optional": "~1.0.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
     },
@@ -10139,11 +10093,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/mongoose-integer/-/mongoose-integer-0.1.1.tgz",
       "integrity": "sha1-f9OP12T85YiK5YvcR3sCFZxKDfg="
-    },
-    "mongoose-legacy-pluralize": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
-      "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ=="
     },
     "mongoose-paginate": {
       "version": "5.0.3",
@@ -10203,26 +10152,50 @@
       }
     },
     "mpath": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.4.1.tgz",
-      "integrity": "sha512-NNY/MpBkALb9jJmjpBlIi6GRoLveLUM0pJzgbp9vY9F7IQEb/HREC/nxrixechcQwd1NevOhJnWWV8QQQRE+OA=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.2.1.tgz",
+      "integrity": "sha1-Ok6Ck1mAHeljCcJ6ay4QLon56W4="
+    },
+    "mpromise": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mpromise/-/mpromise-0.5.5.tgz",
+      "integrity": "sha1-9bJCWddjrMIlewoMjG2Gb9UXMuY="
     },
     "mquery": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.1.2.tgz",
-      "integrity": "sha512-rBo2+eShI/Ko/GFzXMvJvYjzeLRW3P7E4NllAGRyNO90Xw5awo5RI3zCqzuJWe1NSvdL7cGu3RPLuGjZ1TmnmA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-2.3.0.tgz",
+      "integrity": "sha1-PRcXrYlY0MmeQuokYaEJ8+Xz5Fg=",
       "requires": {
-        "bluebird": "3.5.1",
-        "debug": "3.1.0",
+        "bluebird": "2.10.2",
+        "debug": "2.2.0",
         "regexp-clone": "0.0.1",
-        "sliced": "1.0.1"
+        "sliced": "0.0.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "requires": {
+            "ms": "0.7.1"
+          }
+        },
+        "ms": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+        },
+        "sliced": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
+          "integrity": "sha1-XtwETKTrb3gW1Qui/GPiXY/kcH8="
+        }
       }
     },
     "ms": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-      "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-      "dev": true
+      "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
     },
     "multer": {
       "version": "1.3.1",
@@ -10238,6 +10211,11 @@
         "type-is": "^1.6.4",
         "xtend": "^4.0.0"
       }
+    },
+    "muri": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/muri/-/muri-1.2.1.tgz",
+      "integrity": "sha1-7H6lzmympSPrGrNbrNpfqBbJqjw="
     },
     "mute-stdout": {
       "version": "1.0.0",
@@ -11669,13 +11647,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -11688,13 +11664,11 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
@@ -11801,8 +11775,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -11812,7 +11785,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -11825,7 +11797,6 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -11925,8 +11896,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -13683,12 +13653,6 @@
         "srcset": "^1.0.0",
         "xtend": "^4.0.0"
       }
-    },
-    "saslprep": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.1.tgz",
-      "integrity": "sha512-ntN6SbE3hRqd45PKKadRPgA+xHPWg5lPSj2JWJdJvjTwXDDfkPVtXWvP8jJojvnm+rAsZ2b299C5NwZqq818EA==",
-      "optional": true
     },
     "semver": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "engines": {
     "node": ">=8.0.0 <11",
     "npm": ">=5.0.0",
-    "mongodb": ">=3.6 <=4.0"
+    "mongodb": "~3.4"
   },
   "browserslist": [
     "last 2 versions",
@@ -111,7 +111,7 @@
     "mmmagic": "~0.5.0",
     "moment": "~2.22.2",
     "mongodb": "~2.2.36",
-    "mongoose": "^5.2.9",
+    "mongoose": "~4.9.10",
     "mongoose-beautiful-unique-validation": "~5.1.1",
     "mongoose-integer": "~0.1.1",
     "mongoose-paginate": "5.0.3",


### PR DESCRIPTION
Reverts Trustroots/trustroots#634

Seems like we still need some changes in worker scripts, I found this from logs:
```
Mongoose: users.find({ roles: { '$elemMatch': { '$ne': 'suspended' } }, welcomeSequenceSent: { '$lt': new Date("Sun, 12 Aug 2018 19:29:12 GMT") }, welcomeSequenceStep: 2, public: true }, { limit: 50, fields: {} })
(node:27573) UnhandledPromiseRejectionWarning: MongoError: The 'cursor' option is required, except for aggregate with the explain argument
    at Function.MongoError.create (/Users/mikael/Documents/trustroots/node_modules/mongoose/node_modules/mongodb-core/lib/error.js:31:11)
    at /Users/mikael/Documents/trustroots/node_modules/mongoose/node_modules/mongodb-core/lib/connection/pool.js:489:72
    at authenticateStragglers (/Users/mikael/Documents/trustroots/node_modules/mongoose/node_modules/mongodb-core/lib/connection/pool.js:435:16)
    at Connection.messageHandler (/Users/mikael/Documents/trustroots/node_modules/mongoose/node_modules/mongodb-core/lib/connection/pool.js:469:5)
    at Socket.<anonymous> (/Users/mikael/Documents/trustroots/node_modules/mongoose/node_modules/mongodb-core/lib/connection/connection.js:321:22)
    at Socket.emit (events.js:182:13)
    at addChunk (_stream_readable.js:283:12)
    at readableAddChunk (_stream_readable.js:264:11)
    at Socket.Readable.push (_stream_readable.js:219:10)
    at TCP.onread (net.js:639:20)
(node:27573) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:27573) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
[Worker] Agenda job [welcome sequence first] 59b0fd4bf0bad605b73f1636 finished.
[Worker] Agenda job [check unread messages] 59b0fd4bf0bad605b73f162c failed with [The 'cursor' option is required, except for aggregate with the explain argument]  failCount:2
```

FYI @mrkvon 