### PR TITLE
Fix statistics collecting daily hosting offer stats

### DIFF
--- a/modules/statistics/server/jobs/daily-statistics.server.job.js
+++ b/modules/statistics/server/jobs/daily-statistics.server.job.js
@@ -75,15 +75,15 @@ module.exports = function (job, agendaDone) {
         }
 
         // Write numbers to stats
-        async.eachSeries(hostOfferCounts, function (offerCount, doneStatus) {
+        async.eachOfSeries(hostOfferCounts, function (offerCount, offerStatus, doneStatus) {
           writeDailyStat({
             namespace: 'offers',
             values: {
-              count: parseInt(offerCount.count, 10)
+              count: parseInt(offerCount, 10)
             },
             tags: {
               type: 'host',
-              status: String(offerCount._id) // `yes|maybe|no`
+              status: String(offerStatus) // `yes|maybe|no`
             }
           }, doneStatus);
         }, done);


### PR DESCRIPTION
Fixes https://github.com/Trustroots/trustroots/issues/676

Results from the DB query were like: `{ yes: 1, maybe: 2, no: 3 }` so we had to iterate them in different way than other stats which are mostly arrays.