### PR TITLE
Reset margin for paragraphs in messages

### DIFF
--- a/modules/messages/client/less/thread.less
+++ b/modules/messages/client/less/thread.less
@@ -99,6 +99,10 @@
     }
   }
 
+  .panel-body p {
+    margin: auto;
+  }
+
   // "Yes, I can host!" messages
   &[ng-data-hosting="yes"] {
     .panel-body {


### PR DESCRIPTION
This is a proposed solution for issue https://github.com/Trustroots/trustroots/issues/641

The "new line" style is caused by a global style assigned to `<p>` element

Preview:
![screenshot from 2018-10-03 17-16-00](https://user-images.githubusercontent.com/4799048/46420350-20f3b400-c730-11e8-96d4-21e4ef7063b0.png)
