### PR TITLE
Create a reference (API)

### DIFF
--- a/config/env/default.js
+++ b/config/env/default.js
@@ -93,6 +93,8 @@ module.exports = {
     // How long we should wait before trying to reactivate "no" hosts?
     // Moment.js `duration` object literal http://momentjs.com/docs/#/durations/
     timeToReactivateHosts: { days: 90 },
+    // How long should user have for replying a reference before it becomes public?
+    timeToReplyReference: { days: 14 },
     // How long should we wait to update user's seen field since the last update
     timeToUpdateLastSeenUser: { minutes: 5 },
     // when to send reminders about unread messages (since the last unread message was sent)

--- a/config/env/default.js
+++ b/config/env/default.js
@@ -18,6 +18,16 @@ module.exports = {
     description: 'Travellers community for sharing, hosting and getting people together. We want a world that encourages trust and adventure.'
   },
 
+  // Feature flags
+  featureFlags: {
+    // enable references at all?
+    reference: false
+    // Tribe endorsements for user references
+    // referenceTribeEndorsements: false,
+    // Free text feedback in references
+    // referenceFreetextFeedback: false
+  },
+
   // Is site invitation only?
   invitations: {
     enabled: false,

--- a/config/env/default.js
+++ b/config/env/default.js
@@ -20,12 +20,8 @@ module.exports = {
 
   // Feature flags
   featureFlags: {
-    // enable references at all?
+    // enable references?
     reference: false
-    // Tribe endorsements for user references
-    // referenceTribeEndorsements: false,
-    // Free text feedback in references
-    // referenceFreetextFeedback: false
   },
 
   // Is site invitation only?

--- a/config/env/test.js
+++ b/config/env/test.js
@@ -11,6 +11,15 @@
  */
 
 module.exports = {
+  // Feature flags
+  featureFlags: {
+    // enable references at all?
+    reference: true
+    // Tribe endorsements for user references
+    // referenceTribeEndorsements: false,
+    // Free text feedback in references
+    // referenceFreetextFeedback: false
+  },
   db: {
     uri: 'mongodb://' + (process.env.DB_1_PORT_27017_TCP_ADDR || 'localhost') + '/trustroots-test',
     options: {

--- a/config/env/test.js
+++ b/config/env/test.js
@@ -13,12 +13,8 @@
 module.exports = {
   // Feature flags
   featureFlags: {
-    // enable references at all?
+    // enable references?
     reference: true
-    // Tribe endorsements for user references
-    // referenceTribeEndorsements: false,
-    // Free text feedback in references
-    // referenceFreetextFeedback: false
   },
   db: {
     uri: 'mongodb://' + (process.env.DB_1_PORT_27017_TCP_ADDR || 'localhost') + '/trustroots-test',

--- a/config/lib/worker.js
+++ b/config/lib/worker.js
@@ -77,6 +77,12 @@ exports.start = function (options, callback) {
       require(path.resolve('./modules/users/server/jobs/user-welcome-sequence-third.server.job'))
     );
 
+    agenda.define(
+      'publish old unpublished references',
+      { lockLifetime: 10000, concurrency: 1 },
+      require(path.resolve('./modules/references/server/jobs/references-publish.server.job'))
+    );
+
     // Schedule job(s)
 
     agenda.every('5 minutes', 'check unread messages');
@@ -86,6 +92,7 @@ exports.start = function (options, callback) {
     agenda.every('15 minutes', 'welcome sequence first');
     agenda.every('60 minutes', 'welcome sequence second');
     agenda.every('60 minutes', 'welcome sequence third');
+    agenda.every('23 minutes', 'publish old unpublished references');
 
     // Start worker
 

--- a/modules/core/server/services/email.server.service.js
+++ b/modules/core/server/services/email.server.service.js
@@ -410,6 +410,21 @@ exports.sendReferenceNotificationFirst = function (userFrom, userTo, callback) {
 };
 
 /**
+ * Reference Notification (Second reference between users)
+ */
+exports.sendReferenceNotificationSecond = function (userFrom, userTo, reference, callback) {
+
+  var params = exports.addEmailBaseTemplateParams({
+    subject: 'New reference from ' + userFrom.username,
+    email: userTo.email,
+    seeReferencesUrl: url + '/profile/' + userTo.username + '/references',
+    recommend: reference.recommend
+  });
+
+  exports.renderEmailAndSend('reference-notification-second', params, callback);
+};
+
+/**
  * Add several parameters to be used to render transactional emails
  * These variables are used by email base template:
  * `modules/core/server/views/email-templates/email.server.view.html`

--- a/modules/core/server/services/email.server.service.js
+++ b/modules/core/server/services/email.server.service.js
@@ -396,6 +396,20 @@ exports.sendWelcomeSequenceThird = function (user, callback) {
 };
 
 /**
+ * Reference Notification (First between users)
+ */
+exports.sendReferenceNotificationFirst = function (userFrom, userTo, callback) {
+
+  var params = exports.addEmailBaseTemplateParams({
+    subject: 'New reference from ' + userFrom.username,
+    email: userTo.email,
+    giveReferenceUrl: url + '/profile/' + userFrom.username + '/references/new'
+  });
+
+  exports.renderEmailAndSend('reference-notification-first', params, callback);
+};
+
+/**
  * Add several parameters to be used to render transactional emails
  * These variables are used by email base template:
  * `modules/core/server/views/email-templates/email.server.view.html`

--- a/modules/core/server/services/push.server.service.js
+++ b/modules/core/server/services/push.server.service.js
@@ -85,6 +85,35 @@ exports.notifyMessagesUnread = function (userFrom, userTo, data, callback) {
   exports.sendUserNotification(userTo, notification, callback);
 };
 
+/**
+ * Send a push notification about a new reference, to the receiver of the reference
+ * @param {User} userFrom - user who gave the reference
+ * @param {User} userTo - user who received the reference
+ * @param {Object} data - notification config
+ * @param {boolean} data.isFirst - is it the first reference between users?
+ */
+exports.notifyNewReference = function (userFrom, userTo, data, callback) {
+  var giveReferenceUrl = url + '/profile/' + userFrom.username + '/references/new';
+  var readReferencesUrl = url + '/profile/' + userTo.username + '/references';
+
+  // When the reference is first, reply reference can be given.
+  // Otherwise both references are public now and can be seen.
+  var actionText = (data.isFirst) ? 'Give a reference back.' : 'You can see it.';
+  var actionUrl = (data.isFirst) ? giveReferenceUrl : readReferencesUrl;
+
+  var notification = {
+    title: 'Trustroots',
+    body: userFrom.username + ' gave you a new reference. ' + actionText,
+    click_action: analyticsHandler.appendUTMParams(actionUrl, {
+      source: 'push-notification',
+      medium: 'fcm',
+      campaign: 'new-reference',
+      content: 'reply-to' // @TODO what are the correct parameters here? What do they mean?
+    })
+  };
+  exports.sendUserNotification(userTo, notification, callback);
+};
+
 exports.sendUserNotification = function (user, notification, callback) {
 
   var data = {

--- a/modules/core/server/views/email-templates-text/reference-notification-first.server.view.html
+++ b/modules/core/server/views/email-templates-text/reference-notification-first.server.view.html
@@ -1,0 +1,6 @@
+{% extends './email.server.view.html' %}
+
+{% block content %}
+give the reference, too: {{giveReferenceUrl}}
+And give more explanation about time limit etc.
+{% endblock content %}

--- a/modules/core/server/views/email-templates-text/reference-notification-second.server.view.html
+++ b/modules/core/server/views/email-templates-text/reference-notification-second.server.view.html
@@ -1,0 +1,7 @@
+{% extends './email.server.view.html' %}
+
+{% block content %}
+see my own references: {{seeReferencesUrl}}
+the recommendation was {{recommend}}
+and we can show other reference data, too.
+{% endblock content %}

--- a/modules/core/server/views/email-templates/reference-notification-first.server.view.html
+++ b/modules/core/server/views/email-templates/reference-notification-first.server.view.html
@@ -1,0 +1,5 @@
+{% extends './email.server.view.html' %}
+
+{% block content %}
+<a href="{{giveReferenceUrl}}">give a reference</a>
+{% endblock content %}

--- a/modules/core/server/views/email-templates/reference-notification-second.server.view.html
+++ b/modules/core/server/views/email-templates/reference-notification-second.server.view.html
@@ -1,0 +1,7 @@
+{% extends './email.server.view.html' %}
+
+{% block content %}
+<a href="{{seeReferencesUrl}}">see my references</a>
+the recommendation was {{recommend}} <!-- yes, no, unknown -->
+and we can show other reference data, too.
+{% endblock content %}

--- a/modules/core/tests/server/worker.tests.js
+++ b/modules/core/tests/server/worker.tests.js
@@ -175,7 +175,7 @@ describe('Worker tests', function () {
   });
 
   it('defines right number of repeating jobs', function () {
-    scheduledJobs.length.should.equal(7);
+    scheduledJobs.length.should.equal(8);
   });
 
   it('only schedules defined jobs', function () {

--- a/modules/references/server/controllers/reference.server.controller.js
+++ b/modules/references/server/controllers/reference.server.controller.js
@@ -58,6 +58,17 @@ function create(req, res, next) {
     // save the reference...
     function saveNewReference(otherReference, cb) {
 
+      // ... when the other reference is public, this one can only have value of recommend: yes ...
+      if (otherReference && otherReference.public && req.body.recommend !== 'yes') {
+        return cb({
+          status: 400,
+          body: {
+            errType: 'bad-request',
+            detail: 'Only a positive recommendation is allowed in response to a public reference.'
+          }
+        });
+      }
+
       // ...and make it public if it is a reference reply
       var reference = new Reference(_.merge(req.body, { userFrom: req.user._id, public: !!otherReference }));
 

--- a/modules/references/server/controllers/reference.server.controller.js
+++ b/modules/references/server/controllers/reference.server.controller.js
@@ -1,0 +1,7 @@
+function create(req, res) {
+  return res.status(201).json({});
+}
+
+module.exports = {
+  create: create
+};

--- a/modules/references/server/controllers/reference.server.controller.js
+++ b/modules/references/server/controllers/reference.server.controller.js
@@ -1,11 +1,22 @@
+'use strict';
+
 var mongoose = require('mongoose'),
     _ = require('lodash'),
+    path = require('path'),
+    errorService = require(path.resolve('./modules/core/server/services/error.server.service')),
     Reference = mongoose.model('Reference');
 
 function create(req, res) {
   var reference = new Reference(_.merge(req.body, { userFrom: req.user._id }));
 
   reference.save(function (err, savedReference) {
+    var isConflict = err && err.errors && err.errors.userFrom && err.errors.userTo &&
+      err.errors.userFrom.kind === 'unique' && err.errors.userTo.kind === 'unique';
+
+    if (isConflict) {
+      return res.status(409).json({ message: errorService.getErrorMessageByKey('conflict') });
+    }
+
     return res.status(201).json({
       userFrom: savedReference.userFrom,
       userTo: savedReference.userTo,

--- a/modules/references/server/controllers/reference.server.controller.js
+++ b/modules/references/server/controllers/reference.server.controller.js
@@ -150,17 +150,23 @@ function create(req, res, next) {
       if (otherReference && !otherReference.public) {
         otherReference.set({ public: true });
         return otherReference.save(function (err) {
-          return cb(err, savedReference);
+          return cb(err, savedReference, otherReference);
         });
       }
 
-      return cb(null, savedReference);
+      return cb(null, savedReference, otherReference);
     },
     // send email notification
-    function (savedReference, cb) {
-      emailService.sendReferenceNotificationFirst(req.user, userTo, function (err) {
-        return cb(err, savedReference);
-      });
+    function (savedReference, otherReference, cb) {
+      if (!otherReference) {
+        return emailService.sendReferenceNotificationFirst(req.user, userTo, function (err) {
+          cb(err, savedReference);
+        });
+      } else {
+        return emailService.sendReferenceNotificationSecond(req.user, userTo, savedReference, function (err) {
+          cb(err, savedReference);
+        });
+      }
     },
     // finally, respond
     function (savedReference, cb) {

--- a/modules/references/server/controllers/reference.server.controller.js
+++ b/modules/references/server/controllers/reference.server.controller.js
@@ -7,6 +7,15 @@ var mongoose = require('mongoose'),
     Reference = mongoose.model('Reference');
 
 function create(req, res) {
+
+  // Can't create a reference to oneself
+  if (req.user._id.toString() === req.body.userTo) {
+    return res.status(400).json({
+      message: errorService.getErrorMessageByKey('bad-request'),
+      detail: 'Reference to self.'
+    });
+  }
+
   var reference = new Reference(_.merge(req.body, { userFrom: req.user._id }));
 
   reference.save(function (err, savedReference) {

--- a/modules/references/server/controllers/reference.server.controller.js
+++ b/modules/references/server/controllers/reference.server.controller.js
@@ -1,5 +1,23 @@
+var mongoose = require('mongoose'),
+    _ = require('lodash'),
+    Reference = mongoose.model('Reference');
+
 function create(req, res) {
-  return res.status(201).json({});
+  var reference = new Reference(_.merge(req.body, { userFrom: req.user._id }));
+
+  reference.save(function (err, savedReference) {
+    return res.status(201).json({
+      userFrom: savedReference.userFrom,
+      userTo: savedReference.userTo,
+      recommend: savedReference.recommend,
+      created: savedReference.created.getTime(),
+      met: savedReference.met,
+      hostedMe: savedReference.hostedMe,
+      hostedThem: savedReference.hostedThem,
+      id: savedReference._id,
+      public: savedReference.public
+    });
+  });
 }
 
 module.exports = {

--- a/modules/references/server/controllers/reference.server.controller.js
+++ b/modules/references/server/controllers/reference.server.controller.js
@@ -25,7 +25,7 @@ function validateCreate(req) {
   }
 
   // Some interaction must have happened
-  var isInteraction = req.body.met || req.body.hostedMe || req.body.hostedThem;
+  var isInteraction = req.body.interactions && (req.body.interactions.met || req.body.interactions.hostedMe || req.body.interactions.hostedThem);
   if (!isInteraction) {
     valid = false;
     details.push('No interaction.');
@@ -39,7 +39,7 @@ function validateCreate(req) {
 
   // Values of interactions must be boolean
   ['met', 'hostedMe', 'hostedThem'].forEach(function (interaction) {
-    if (req.body.hasOwnProperty(interaction) && typeof req.body[interaction] !== 'boolean') {
+    if (req.body.interactions && req.body.interactions.hasOwnProperty(interaction) && typeof req.body.interactions[interaction] !== 'boolean') {
       valid = false;
       details.push('Value of \'' + interaction + '\' should be a boolean.');
     }
@@ -55,10 +55,13 @@ function validateCreate(req) {
   }
 
   // No unexpected fields
-  var allowedFields = ['userTo', 'met', 'hostedMe', 'hostedThem', 'recommend'];
+  var allowedFields = ['userTo', 'interactions', 'recommend'];
   var fields = Object.keys(req.body);
   var unexpectedFields = _.difference(fields, allowedFields);
-  if (unexpectedFields.length > 0) {
+  var allowedInteractions = ['met', 'hostedMe', 'hostedThem'];
+  var interactions = Object.keys(req.body.interactions || {});
+  var unexpectedInteractions = _.difference(interactions, allowedInteractions);
+  if (unexpectedFields.length > 0 || unexpectedInteractions.length > 0) {
     valid = false;
     details.push('Unexpected fields.');
   }
@@ -191,9 +194,11 @@ exports.create = function (req, res, next) {
           userTo: savedReference.userTo,
           recommend: savedReference.recommend,
           created: savedReference.created.getTime(),
-          met: savedReference.met,
-          hostedMe: savedReference.hostedMe,
-          hostedThem: savedReference.hostedThem,
+          interactions: {
+            met: savedReference.interactions.met,
+            hostedMe: savedReference.interactions.hostedMe,
+            hostedThem: savedReference.interactions.hostedThem
+          },
           id: savedReference._id,
           public: savedReference.public
         }

--- a/modules/references/server/jobs/references-publish.server.job.js
+++ b/modules/references/server/jobs/references-publish.server.job.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var path = require('path'),
+    mongoose = require('mongoose'),
+    moment = require('moment'),
+    config = require(path.resolve('./config/config')),
+    Reference = mongoose.model('Reference');
+
+/**
+ * Find all references that are older than timeToReply Reference and non-public.
+ * Make them public.
+ * @TODO (maybe) Notify the affected users that a reference for them was published.
+ */
+module.exports = function (job, agendaDone) {
+  Reference.updateMany({
+    created: { $lt: moment().subtract(config.limits.timeToReplyReference) },
+    public: false
+  }, { public: true }).exec(agendaDone);
+};

--- a/modules/references/server/models/reference.server.model.js
+++ b/modules/references/server/models/reference.server.model.js
@@ -13,7 +13,7 @@ var mongoose = require('mongoose'),
 var ReferenceSchema = new Schema({
   created: {
     type: Date,
-    default: Date.now,
+    default: function () { return Date.now(); }, // Date.now is wrapped for sinon.useFakeTimers()
     required: true
   },
   /*
@@ -24,7 +24,7 @@ var ReferenceSchema = new Schema({
   */
   public: {
     type: Boolean,
-    default: true,
+    default: false,
     required: true
   },
   userFrom: {
@@ -42,12 +42,12 @@ var ReferenceSchema = new Schema({
     default: false,
     required: true
   },
-  hosted_me: {
+  hostedMe: {
     type: Boolean,
     default: false,
     required: true
   },
-  hosted_them: {
+  hostedThem: {
     type: Boolean,
     default: false,
     required: true

--- a/modules/references/server/models/reference.server.model.js
+++ b/modules/references/server/models/reference.server.model.js
@@ -1,0 +1,79 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+var mongoose = require('mongoose'),
+    uniqueValidation = require('mongoose-beautiful-unique-validation'),
+    Schema = mongoose.Schema;
+
+/**
+ * ReferenceUser Schema
+ */
+var ReferenceSchema = new Schema({
+  created: {
+    type: Date,
+    default: Date.now,
+    required: true
+  },
+  /*
+  modified: {
+    type: Date,
+    default: Date.now
+  },
+  */
+  public: {
+    type: Boolean,
+    default: true,
+    required: true
+  },
+  userFrom: {
+    type: Schema.ObjectId,
+    ref: 'User',
+    required: true
+  },
+  userTo: {
+    type: Schema.ObjectId,
+    ref: 'User',
+    required: true
+  },
+  met: {
+    type: Boolean,
+    default: false,
+    required: true
+  },
+  hosted_me: {
+    type: Boolean,
+    default: false,
+    required: true
+  },
+  hosted_them: {
+    type: Boolean,
+    default: false,
+    required: true
+  },
+  recommend: {
+    type: String,
+    enum: ['yes', 'no', 'unknown'],
+    default: 'unknown',
+    required: true
+  }/* ,
+  feedbackPublic: {
+    type: String,
+    trim: true
+  },
+  feedbackPrivate: {
+    type: String,
+    trim: true
+  }
+  */
+});
+
+/**
+ * Indexing
+ */
+ReferenceSchema.plugin(uniqueValidation);
+ReferenceSchema.index({ userFrom: 1, userTo: 1, public: 1, created: 1 });
+ReferenceSchema.index({ userFrom: 1, userTo: 1 }, { unique: true });
+
+mongoose.model('Reference', ReferenceSchema);

--- a/modules/references/server/models/reference.server.model.js
+++ b/modules/references/server/models/reference.server.model.js
@@ -37,20 +37,22 @@ var ReferenceSchema = new Schema({
     ref: 'User',
     required: true
   },
-  met: {
-    type: Boolean,
-    default: false,
-    required: true
-  },
-  hostedMe: {
-    type: Boolean,
-    default: false,
-    required: true
-  },
-  hostedThem: {
-    type: Boolean,
-    default: false,
-    required: true
+  interactions: {
+    met: {
+      type: Boolean,
+      default: false,
+      required: true
+    },
+    hostedMe: {
+      type: Boolean,
+      default: false,
+      required: true
+    },
+    hostedThem: {
+      type: Boolean,
+      default: false,
+      required: true
+    }
   },
   recommend: {
     type: String,

--- a/modules/references/server/policies/references.server.policy.js
+++ b/modules/references/server/policies/references.server.policy.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var acl = require('acl'),
+    path = require('path'),
+    errorService = require(path.resolve('./modules/core/server/services/error.server.service'));
+
+acl = new acl(new acl.memoryBackend());
+
+exports.invokeRolesPolicies = function () {
+  acl.allow([{
+    roles: ['user', 'admin'],
+    allows: [{
+      resources: '/api/references',
+      permissions: ['post']
+    }]
+  }]);
+};
+
+exports.isAllowed = function (req, res, next) {
+
+  var roles = (req.user && req.user.roles) ? req.user.roles : ['guest'];
+
+  acl.areAnyRolesAllowed(roles, req.route.path, req.method.toLowerCase(), function (err, isAllowed) {
+    if (err) {
+
+    } else {
+      if (isAllowed && req.user.public) {
+        // Access granted! Invoke next middleware
+        return next();
+      }
+
+      return res.status(403).json({
+        message: errorService.getErrorMessageByKey('forbidden')
+      });
+    }
+  });
+};

--- a/modules/references/server/routes/reference.server.routes.js
+++ b/modules/references/server/routes/reference.server.routes.js
@@ -1,9 +1,13 @@
 'use strict';
 
-var referencePolicy = require('../policies/references.server.policy'),
+var path = require('path'),
+    config = require(path.resolve('./config/config')),
+    referencePolicy = require('../policies/references.server.policy'),
     referenceThread = require('../controllers/reference.server.controller');
 
 module.exports = function (app) {
-  app.route('/api/references').all(referencePolicy.isAllowed)
-    .post(referenceThread.create);
+  if (config.featureFlags.reference) {
+    app.route('/api/references').all(referencePolicy.isAllowed)
+      .post(referenceThread.create);
+  }
 };

--- a/modules/references/server/routes/reference.server.routes.js
+++ b/modules/references/server/routes/reference.server.routes.js
@@ -3,11 +3,11 @@
 var path = require('path'),
     config = require(path.resolve('./config/config')),
     referencePolicy = require('../policies/references.server.policy'),
-    referenceThread = require('../controllers/reference.server.controller');
+    references = require('../controllers/reference.server.controller');
 
 module.exports = function (app) {
   if (config.featureFlags.reference) {
     app.route('/api/references').all(referencePolicy.isAllowed)
-      .post(referenceThread.create);
+      .post(references.create);
   }
 };

--- a/modules/references/server/routes/reference.server.routes.js
+++ b/modules/references/server/routes/reference.server.routes.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var referencePolicy = require('../policies/references.server.policy'),
+    referenceThread = require('../controllers/reference.server.controller');
+
+module.exports = function (app) {
+  app.route('/api/references').all(referencePolicy.isAllowed)
+    .post(referenceThread.create);
+};

--- a/modules/references/tests/server/reference-create.server.routes.tests.js
+++ b/modules/references/tests/server/reference-create.server.routes.tests.js
@@ -209,10 +209,10 @@ describe('Create a reference', function () {
         });
 
 
-        it('[duplicate reference between these people] 409 Conflict');
-        it('[sending a reference to self] 400');
-        it('[sending a reference to nonexistent user] 404');
-        it('[sending a reference to non-public user]');
+        it('[duplicate reference (the same (from, to) combination)] 409 Conflict');
+        it('[creating a reference for self] 400');
+        it('[creating a reference for nonexistent user] 404');
+        it('[creating a reference for non-public user]');
       });
 
       context('initial reference', function () {

--- a/modules/references/tests/server/reference-create.server.routes.tests.js
+++ b/modules/references/tests/server/reference-create.server.routes.tests.js
@@ -1,0 +1,54 @@
+describe('Create a reference', function () {
+
+  // user can leave a reference to anyone
+  //  - types of interaction
+  //  - recommend
+  //  - from whom
+  //  - to whom
+  // POST /references
+  // reference can't be modified or removed
+  // email notification will be sent to the receiver of the reference
+  // the receiver has some time to give a reference, too.
+  // after this time the only accepted answers are yes/ignore.
+  // after the given time or after both left reference, both references become public
+
+  context('logged in', function () {
+    context('valid request', function () {
+
+      context('every reference', function () {
+        it('respond with 201 Created and the new reference in body');
+        it('save reference to database with proper fields');
+        it('[duplicate reference between these people] 409 Conflict');
+        it('[sending a reference to self] 400');
+        it('[sending a reference to nonexistent user] 404');
+      });
+
+      context('initial reference', function () {
+        it('the reference is private');
+        it('send email notification to target user');
+      });
+
+      context('reply reference', function () {
+        it('[late] only positive recommendation is allowed');
+        it('set both references as public');
+        it('send email notification (maybe)');
+      });
+    });
+
+    context('invalid request', function () {
+      it('[invalid value in interaction types] 400');
+      it('[invalid recommendation] 400');
+      it('[invalid receiver id] 400');
+      it('[missing fields] 400');
+      it('[unexpected fields] 400');
+    });
+  });
+
+  context('logged in as non-public user', function () {
+    it('403');
+  });
+
+  context('not logged in', function () {
+    it('403');
+  });
+});

--- a/modules/references/tests/server/reference-create.server.routes.tests.js
+++ b/modules/references/tests/server/reference-create.server.routes.tests.js
@@ -9,6 +9,18 @@ var // should = require('should'),
 
 describe('Create a reference', function () {
 
+  // user can leave a reference to anyone
+  //  - types of interaction
+  //  - recommend
+  //  - from whom
+  //  - to whom
+  // POST /references
+  // reference can't be modified or removed
+  // email notification will be sent to the receiver of the reference
+  // the receiver has some time to give a reference, too.
+  // after this time the only accepted answers are yes/ignore.
+  // after the given time or after both left reference, both references become public
+
   var user1,
       user2,
       user3Nonpublic;
@@ -52,18 +64,6 @@ describe('Create a reference', function () {
     provider: 'local'
   };
 
-  // user can leave a reference to anyone
-  //  - types of interaction
-  //  - recommend
-  //  - from whom
-  //  - to whom
-  // POST /references
-  // reference can't be modified or removed
-  // email notification will be sent to the receiver of the reference
-  // the receiver has some time to give a reference, too.
-  // after this time the only accepted answers are yes/ignore.
-  // after the given time or after both left reference, both references become public
-  //
   beforeEach(function (done) {
 
     user1 = new User(_user1);

--- a/modules/references/tests/server/reference-create.server.routes.tests.js
+++ b/modules/references/tests/server/reference-create.server.routes.tests.js
@@ -271,8 +271,55 @@ describe('Create a reference', function () {
             });
         });
 
-        it('[creating a reference for nonexistent user] 404');
-        it('[creating a reference for non-public user] 404');
+        it('[creating a reference for nonexistent user] 404', function (done) {
+          agent.post('/api/references')
+            .send({
+              userTo: '0'.repeat(24), // nonexistent user id
+              met: false,
+              hostedMe: true,
+              hostedThem: false,
+              recommend: 'no'
+            })
+            .expect(404)
+            .end(function (err, response) {
+              if (err) return done(err);
+
+              try {
+                should(response.body).match({
+                  message: 'Not found.',
+                  detail: 'User not found.'
+                });
+                return done();
+              } catch (e) {
+                return done(e);
+              }
+            });
+        });
+
+        it('[creating a reference for non-public user] 404', function (done) {
+          agent.post('/api/references')
+            .send({
+              userTo: user3Nonpublic._id, // non-public user id
+              met: false,
+              hostedMe: true,
+              hostedThem: false,
+              recommend: 'no'
+            })
+            .expect(404)
+            .end(function (err, response) {
+              if (err) return done(err);
+
+              try {
+                should(response.body).match({
+                  message: 'Not found.',
+                  detail: 'User not found.'
+                });
+                return done();
+              } catch (e) {
+                return done(e);
+              }
+            });
+        });
       });
 
       context('initial reference', function () {

--- a/modules/references/tests/server/reference-create.server.routes.tests.js
+++ b/modules/references/tests/server/reference-create.server.routes.tests.js
@@ -264,7 +264,7 @@ describe('Create a reference', function () {
               try {
                 should(response.body).match({
                   message: 'Bad request.',
-                  detail: 'Reference to self.'
+                  details: ['Reference to self.']
                 });
                 return done();
               } catch (e) {
@@ -471,7 +471,7 @@ describe('Create a reference', function () {
                   try {
                     should(response).have.propertyByPath('body').match({
                       message: 'Bad request.',
-                      detail: 'Only a positive recommendation is allowed in response to a public reference.'
+                      details: ['Only a positive recommendation is allowed in response to a public reference.']
                     });
                     return cb();
                   } catch (e) {
@@ -504,12 +504,146 @@ describe('Create a reference', function () {
     });
 
     context('invalid request', function () {
-      it('[invalid value in interaction types] 400');
-      it('[invalid recommendation] 400');
-      it('[invalid receiver id] 400');
-      it('[missing fields] 400');
-      it('[unexpected fields] 400');
-      it('[all interaction types false] 400');
+      it('[invalid value in interaction types] 400', function (done) {
+        agent.post('/api/references')
+          .send({
+            userTo: user2._id,
+            met: 'met',
+            hostedMe: false,
+            recommend: 'unknown'
+          })
+          .expect(400)
+          .end(function (err, response) {
+            if (err) return done(err);
+
+            try {
+              should(response.body).match({
+                message: 'Bad request.',
+                details: ['Value of \'met\' should be a boolean.']
+              });
+              return done();
+            } catch (e) {
+              return done(e);
+            }
+          });
+      });
+
+      it('[invalid recommendation] 400', function (done) {
+        agent.post('/api/references')
+          .send({
+            userTo: user2._id,
+            met: true,
+            hostedMe: false,
+            recommend: 'invalid'
+          })
+          .expect(400)
+          .end(function (err, response) {
+            if (err) return done(err);
+
+            try {
+              should(response.body).match({
+                message: 'Bad request.',
+                details: ['Invalid recommendation.']
+              });
+              return done();
+            } catch (e) {
+              return done(e);
+            }
+          });
+      });
+
+      it('[invalid userTo] 400', function (done) {
+        agent.post('/api/references')
+          .send({
+            userTo: 'hello',
+            hostedMe: true,
+            recommend: 'yes'
+          })
+          .expect(400)
+          .end(function (err, response) {
+            if (err) return done(err);
+
+            try {
+              should(response.body).match({
+                message: 'Bad request.',
+                details: ['Value of userTo must be a user id.']
+              });
+              return done();
+            } catch (e) {
+              return done(e);
+            }
+          });
+      });
+
+      it('[missing userTo] 400', function (done) {
+        agent.post('/api/references')
+          .send({
+            hostedMe: true,
+            recommend: 'yes'
+          })
+          .expect(400)
+          .end(function (err, response) {
+            if (err) return done(err);
+
+            try {
+              should(response.body).match({
+                message: 'Bad request.',
+                details: ['Missing userTo.']
+              });
+              return done();
+            } catch (e) {
+              return done(e);
+            }
+          });
+      });
+
+      it('[unexpected fields] 400', function (done) {
+        agent.post('/api/references')
+          .send({
+            userTo: user2._id,
+            hostedMe: true,
+            recommend: 'yes',
+            foo: 'bar'
+          })
+          .expect(400)
+          .end(function (err, response) {
+            if (err) return done(err);
+
+            try {
+              should(response.body).match({
+                message: 'Bad request.',
+                details: ['Unexpected fields.']
+              });
+              return done();
+            } catch (e) {
+              return done(e);
+            }
+          });
+      });
+
+      it('[all interaction types false or missing] 400', function (done) {
+        agent.post('/api/references')
+          .send({
+            userTo: user2._id,
+            met: false,
+            hostedMe: false,
+            recommend: 'yes'
+          })
+          .expect(400)
+          .end(function (err, response) {
+            if (err) return done(err);
+
+            try {
+              should(response.body).match({
+                message: 'Bad request.',
+                details: ['No interaction.']
+              });
+              return done();
+            } catch (e) {
+              return done(e);
+            }
+          });
+      });
     });
   });
 

--- a/modules/references/tests/server/reference-create.server.routes.tests.js
+++ b/modules/references/tests/server/reference-create.server.routes.tests.js
@@ -25,7 +25,7 @@ describe('Create a reference', function () {
   // after this time the only accepted answers are yes/ignore.
   // after the given time or after both left reference, both references become public
 
-  // we'll catch email notifications
+  // we'll catch email and push notifications
   var jobs = testutils.catchJobs();
 
   var user1,
@@ -85,13 +85,9 @@ describe('Create a reference', function () {
     user2 = new User(_user2);
     user3Nonpublic = new User(_user3Nonpublic);
 
-    user1.save(function (err) {
-      if (err) return done(err);
-      return user2.save(function (err) {
-        if (err) return done(err);
-        return user3Nonpublic.save(done);
-      });
-    });
+    async.eachSeries([user1, user2, user3Nonpublic], function (user, cb) {
+      user.save(cb);
+    }, done);
   });
 
   afterEach(function (done) {
@@ -430,8 +426,9 @@ describe('Create a reference', function () {
                 should(job.data.userId).equal(user2._id.toString());
                 should(job.data.notification.title).equal('Trustroots');
                 // @TODO design the notification text
-                should(job.data.notification.body).equal(user1.username + ' gave you a new reference. Give a reference back.');
-                job.data.notification.click_action.should
+                should(job.data.notification.body)
+                  .equal(user1.username + ' gave you a new reference. Give a reference back.');
+                should(job.data.notification.click_action)
                   .containEql('/profile/' + user1.username + '/references/new');
 
                 return done();
@@ -673,8 +670,9 @@ describe('Create a reference', function () {
                     should(job.data.userId).equal(user2._id.toString());
                     should(job.data.notification.title).equal('Trustroots');
                     // @TODO design the notification text
-                    should(job.data.notification.body).equal(user1.username + ' gave you a new reference. You can see it.');
-                    job.data.notification.click_action.should
+                    should(job.data.notification.body)
+                      .equal(user1.username + ' gave you a new reference. You can see it.');
+                    should(job.data.notification.click_action)
                       .containEql('/profile/' + user2.username + '/references');
 
                     return cb();

--- a/modules/references/tests/server/reference-create.server.routes.tests.js
+++ b/modules/references/tests/server/reference-create.server.routes.tests.js
@@ -1,4 +1,56 @@
+'use strict';
+
+var // should = require('should'),
+    request = require('supertest'),
+    path = require('path'),
+    mongoose = require('mongoose'),
+    User = mongoose.model('User'),
+    express = require(path.resolve('./config/lib/express'));
+
 describe('Create a reference', function () {
+
+  var user1,
+      user2,
+      user3Nonpublic;
+
+  var app = express.init(mongoose.connection);
+  var agent = request.agent(app);
+
+  var _user1 = {
+    public: true,
+    firstName: 'Full',
+    lastName: 'Name',
+    displayName: 'Full Name',
+    email: 'user1@example.com',
+    username: 'user1',
+    displayUsername: 'user1',
+    password: 'correcthorsebatterystaples',
+    provider: 'local'
+  };
+
+  var _user2 = {
+    public: true,
+    firstName: 'Full2',
+    lastName: 'Name2',
+    displayName: 'Full2 Name2',
+    email: 'user2@example.com',
+    username: 'user2',
+    displayUsername: 'user2',
+    password: 'correcthorsebatterystaples',
+    provider: 'local'
+  };
+
+  var _user3Nonpublic = {
+    public: false,
+    firstName: 'Full3',
+    lastName: 'Name3',
+    displayName: 'Full3 Name3',
+    email: 'user3@example.com',
+    username: 'user3',
+    displayUsername: 'user3',
+    password: 'correcthorsebatterystaples',
+    provider: 'local'
+  };
 
   // user can leave a reference to anyone
   //  - types of interaction
@@ -11,16 +63,83 @@ describe('Create a reference', function () {
   // the receiver has some time to give a reference, too.
   // after this time the only accepted answers are yes/ignore.
   // after the given time or after both left reference, both references become public
+  //
+  beforeEach(function (done) {
+
+    user1 = new User(_user1);
+    user2 = new User(_user2);
+    user3Nonpublic = new User(_user3Nonpublic);
+
+    user1.save(function (err) {
+      if (err) return done(err);
+      return user2.save(function (err) {
+        if (err) return done(err);
+        return user3Nonpublic.save(done);
+      });
+    });
+  });
+
+  afterEach(function (done) {
+    User.remove().exec(done);
+  });
+
+  /**
+   * @TODO this can be refactored. Sign in may be moved to some test utils
+   *
+   *
+   */
+  function signIn(credentials, agent) {
+    return function (done) {
+      agent.post('/api/auth/signin')
+        .send(credentials)
+        .expect(200)
+        .end(done);
+    };
+  }
+
+  /**
+   *
+   *
+   */
+  function signOut(agent) {
+    return function (done) {
+      agent.get('/api/auth/signout')
+        .expect(302)
+        .end(done);
+    };
+  }
 
   context('logged in', function () {
-    context('valid request', function () {
+    // Sign in and sign out
+    beforeEach(signIn({ username: _user1.username, password: _user1.password }, agent));
+    afterEach(signOut(agent));
 
+    context('valid request', function () {
       context('every reference', function () {
-        it('respond with 201 Created and the new reference in body');
+
+        it('respond with 201 Created and the new reference in body', function (done) {
+          agent.post('/api/references')
+            .send({
+
+            })
+            .expect(201)
+            .end(function (err, res) {
+              if (err) {
+                return done(err);
+              }
+
+              res;
+              // @TODO unfinished test!!
+
+              return done();
+            });
+        });
+
         it('save reference to database with proper fields');
         it('[duplicate reference between these people] 409 Conflict');
         it('[sending a reference to self] 400');
         it('[sending a reference to nonexistent user] 404');
+        it('[sending a reference to non-public user]');
       });
 
       context('initial reference', function () {
@@ -45,10 +164,40 @@ describe('Create a reference', function () {
   });
 
   context('logged in as non-public user', function () {
-    it('403');
+    // Sign in and sign out
+    beforeEach(signIn({ username: _user3Nonpublic.username, password: _user3Nonpublic.password }, agent));
+    afterEach(signOut(agent));
+
+    it('403', function (done) {
+      agent.post('/api/references')
+        .send({
+
+        })
+        .expect(403)
+        .end(function (err) {
+          if (err) {
+            return done(err);
+          }
+
+          return done();
+        });
+    });
   });
 
   context('not logged in', function () {
-    it('403');
+    it('403', function (done) {
+      agent.post('/api/references')
+        .send({
+
+        })
+        .expect(403)
+        .end(function (err) {
+          if (err) {
+            return done(err);
+          }
+
+          return done();
+        });
+    });
   });
 });

--- a/modules/references/tests/server/reference-create.server.routes.tests.js
+++ b/modules/references/tests/server/reference-create.server.routes.tests.js
@@ -136,9 +136,11 @@ describe('Create a reference', function () {
           agent.post('/api/references')
             .send({
               userTo: user2._id,
-              met: true,
-              hostedMe: true,
-              hostedThem: true,
+              interactions: {
+                met: true,
+                hostedMe: true,
+                hostedThem: true
+              },
               recommend: 'yes'
             })
             .expect(201)
@@ -152,9 +154,11 @@ describe('Create a reference', function () {
                 userFrom: user1._id.toString(),
                 userTo: user2._id.toString(),
                 created: Date.now(),
-                met: true,
-                hostedMe: true,
-                hostedThem: true,
+                interactions: {
+                  met: true,
+                  hostedMe: true,
+                  hostedThem: true
+                },
                 recommend: 'yes'
               });
 
@@ -183,9 +187,11 @@ describe('Create a reference', function () {
               agent.post('/api/references')
                 .send({
                   userTo: user2._id,
-                  met: true,
-                  hostedMe: true,
-                  hostedThem: true,
+                  interactions: {
+                    met: true,
+                    hostedMe: true,
+                    hostedThem: true
+                  },
                   recommend: 'yes'
                 })
                 .expect(201)
@@ -202,7 +208,12 @@ describe('Create a reference', function () {
                 should(references).have.length(1);
                 should(references[0]).match({
                   userFrom: user1._id,
-                  userTo: user2._id
+                  userTo: user2._id,
+                  interactions: {
+                    met: true,
+                    hostedMe: true,
+                    hostedThem: true
+                  }
                 });
                 cb();
               } catch (e) {
@@ -220,9 +231,11 @@ describe('Create a reference', function () {
               agent.post('/api/references')
                 .send({
                   userTo: user2._id,
-                  met: true,
-                  hostedMe: true,
-                  hostedThem: true,
+                  interactions: {
+                    met: true,
+                    hostedMe: true,
+                    hostedThem: true
+                  },
                   recommend: 'yes'
                 })
                 .expect(201)
@@ -235,9 +248,11 @@ describe('Create a reference', function () {
               agent.post('/api/references')
                 .send({
                   userTo: user2._id,
-                  met: false,
-                  hostedMe: true,
-                  hostedThem: false,
+                  interactions: {
+                    met: false,
+                    hostedMe: true,
+                    hostedThem: false
+                  },
                   recommend: 'no'
                 })
                 .expect(409)
@@ -252,9 +267,11 @@ describe('Create a reference', function () {
           agent.post('/api/references')
             .send({
               userTo: user1._id, // the same user as logged in user
-              met: false,
-              hostedMe: true,
-              hostedThem: false,
+              interactions: {
+                met: false,
+                hostedMe: true,
+                hostedThem: false
+              },
               recommend: 'no'
             })
             .expect(400)
@@ -277,9 +294,11 @@ describe('Create a reference', function () {
           agent.post('/api/references')
             .send({
               userTo: '0'.repeat(24), // nonexistent user id
-              met: false,
-              hostedMe: true,
-              hostedThem: false,
+              interactions: {
+                met: false,
+                hostedMe: true,
+                hostedThem: false
+              },
               recommend: 'no'
             })
             .expect(404)
@@ -302,9 +321,11 @@ describe('Create a reference', function () {
           agent.post('/api/references')
             .send({
               userTo: user3Nonpublic._id, // non-public user id
-              met: false,
-              hostedMe: true,
-              hostedThem: false,
+              interactions: {
+                met: false,
+                hostedMe: true,
+                hostedThem: false
+              },
               recommend: 'no'
             })
             .expect(404)
@@ -332,9 +353,11 @@ describe('Create a reference', function () {
               agent.post('/api/references')
                 .send({
                   userTo: user2._id,
-                  met: true,
-                  hostedMe: true,
-                  hostedThem: true,
+                  interactions: {
+                    met: true,
+                    hostedMe: true,
+                    hostedThem: true
+                  },
                   recommend: 'yes'
                 })
                 .expect(201)
@@ -375,9 +398,11 @@ describe('Create a reference', function () {
           agent.post('/api/references')
             .send({
               userTo: user2._id,
-              met: true,
-              hostedMe: true,
-              hostedThem: true,
+              interactions: {
+                met: true,
+                hostedMe: true,
+                hostedThem: true
+              },
               recommend: 'yes'
             })
             .expect(201)
@@ -409,9 +434,11 @@ describe('Create a reference', function () {
           agent.post('/api/references')
             .send({
               userTo: user2._id,
-              met: true,
-              hostedMe: true,
-              hostedThem: true,
+              interactions: {
+                met: true,
+                hostedMe: true,
+                hostedThem: true
+              },
               recommend: 'yes'
             })
             .expect(201)
@@ -462,9 +489,11 @@ describe('Create a reference', function () {
               agent.post('/api/references')
                 .send({
                   userTo: user2._id,
-                  met: true,
-                  hostedMe: true,
-                  hostedThem: true,
+                  interactions: {
+                    met: true,
+                    hostedMe: true,
+                    hostedThem: true
+                  },
                   recommend: 'yes'
                 })
                 .expect(201)
@@ -529,9 +558,11 @@ describe('Create a reference', function () {
               agent.post('/api/references')
                 .send({
                   userTo: user2._id,
-                  met: true,
-                  hostedMe: true,
-                  hostedThem: true,
+                  interactions: {
+                    met: true,
+                    hostedMe: true,
+                    hostedThem: true
+                  },
                   recommend: 'no'
                 })
                 .expect(400)
@@ -555,9 +586,11 @@ describe('Create a reference', function () {
               agent.post('/api/references')
                 .send({
                   userTo: user2._id,
-                  met: true,
-                  hostedMe: true,
-                  hostedThem: true,
+                  interactions: {
+                    met: true,
+                    hostedMe: true,
+                    hostedThem: true
+                  },
                   recommend: 'yes'
                 })
                 .expect(201)
@@ -593,9 +626,11 @@ describe('Create a reference', function () {
               agent.post('/api/references')
                 .send({
                   userTo: user2._id,
-                  met: true,
-                  hostedMe: true,
-                  hostedThem: true,
+                  interactions: {
+                    met: true,
+                    hostedMe: true,
+                    hostedThem: true
+                  },
                   recommend: 'yes'
                 })
                 .expect(201)
@@ -641,7 +676,9 @@ describe('Create a reference', function () {
               var reference = new Reference({
                 userFrom: user2._id,
                 userTo: user1._id,
-                met: true,
+                interaction: {
+                  met: true
+                },
                 recommend: 'no'
               });
 
@@ -653,9 +690,11 @@ describe('Create a reference', function () {
               agent.post('/api/references')
                 .send({
                   userTo: user2._id,
-                  met: true,
-                  hostedMe: true,
-                  hostedThem: true,
+                  interactions: {
+                    met: true,
+                    hostedMe: true,
+                    hostedThem: true
+                  },
                   recommend: 'yes'
                 })
                 .expect(201)
@@ -692,8 +731,10 @@ describe('Create a reference', function () {
         agent.post('/api/references')
           .send({
             userTo: user2._id,
-            met: 'met',
-            hostedMe: false,
+            interactions: {
+              met: 'met',
+              hostedMe: false
+            },
             recommend: 'unknown'
           })
           .expect(400)
@@ -716,8 +757,10 @@ describe('Create a reference', function () {
         agent.post('/api/references')
           .send({
             userTo: user2._id,
-            met: true,
-            hostedMe: false,
+            interactions: {
+              met: true,
+              hostedMe: false
+            },
             recommend: 'invalid'
           })
           .expect(400)
@@ -740,7 +783,9 @@ describe('Create a reference', function () {
         agent.post('/api/references')
           .send({
             userTo: 'hello',
-            hostedMe: true,
+            interactions: {
+              hostedMe: true
+            },
             recommend: 'yes'
           })
           .expect(400)
@@ -762,7 +807,9 @@ describe('Create a reference', function () {
       it('[missing userTo] 400', function (done) {
         agent.post('/api/references')
           .send({
-            hostedMe: true,
+            interactions: {
+              hostedMe: true
+            },
             recommend: 'yes'
           })
           .expect(400)
@@ -785,7 +832,9 @@ describe('Create a reference', function () {
         agent.post('/api/references')
           .send({
             userTo: user2._id,
-            hostedMe: true,
+            interactions: {
+              hostedMe: true
+            },
             recommend: 'yes',
             foo: 'bar'
           })
@@ -810,7 +859,9 @@ describe('Create a reference', function () {
           .send({
             userTo: user2._id,
             met: false,
-            hostedMe: false,
+            interactions: {
+              hostedMe: false
+            },
             recommend: 'yes'
           })
           .expect(400)

--- a/modules/references/tests/server/reference-create.server.routes.tests.js
+++ b/modules/references/tests/server/reference-create.server.routes.tests.js
@@ -276,12 +276,14 @@ describe('Create a reference', function () {
             })
             .expect(400)
             .end(function (err, response) {
-              if (err) done(err);
+              if (err) return done(err);
 
               try {
                 should(response.body).match({
                   message: 'Bad request.',
-                  details: ['Reference to self.']
+                  details: {
+                    userTo: 'self'
+                  }
                 });
                 return done();
               } catch (e) {
@@ -744,7 +746,11 @@ describe('Create a reference', function () {
             try {
               should(response.body).match({
                 message: 'Bad request.',
-                details: ['Value of \'met\' should be a boolean.']
+                details: {
+                  interactions: {
+                    met: 'boolean expected'
+                  }
+                }
               });
               return done();
             } catch (e) {
@@ -770,7 +776,9 @@ describe('Create a reference', function () {
             try {
               should(response.body).match({
                 message: 'Bad request.',
-                details: ['Invalid recommendation.']
+                details: {
+                  recommend: 'one of \'yes\', \'no\', \'unknown\' expected'
+                }
               });
               return done();
             } catch (e) {
@@ -795,7 +803,9 @@ describe('Create a reference', function () {
             try {
               should(response.body).match({
                 message: 'Bad request.',
-                details: ['Value of userTo must be a user id.']
+                details: {
+                  userTo: 'userId expected'
+                }
               });
               return done();
             } catch (e) {
@@ -819,7 +829,9 @@ describe('Create a reference', function () {
             try {
               should(response.body).match({
                 message: 'Bad request.',
-                details: ['Missing userTo.']
+                details: {
+                  userTo: 'missing'
+                }
               });
               return done();
             } catch (e) {
@@ -845,7 +857,9 @@ describe('Create a reference', function () {
             try {
               should(response.body).match({
                 message: 'Bad request.',
-                details: ['Unexpected fields.']
+                details: {
+                  fields: 'unexpected'
+                }
               });
               return done();
             } catch (e) {
@@ -871,7 +885,11 @@ describe('Create a reference', function () {
             try {
               should(response.body).match({
                 message: 'Bad request.',
-                details: ['No interaction.']
+                details: {
+                  interactions: {
+                    any: 'missing'
+                  }
+                }
               });
               return done();
             } catch (e) {

--- a/modules/references/tests/server/reference.server.jobs.tests.js
+++ b/modules/references/tests/server/reference.server.jobs.tests.js
@@ -1,4 +1,115 @@
+'use strict';
+
+var async = require('async'),
+    crypto = require('crypto'),
+    moment = require('moment'),
+    mongoose = require('mongoose'),
+    path = require('path'),
+    should = require('should'),
+    sinon = require('sinon'),
+    config = require(path.resolve('./config/config')),
+    jobPublishReference = require('../../server/jobs/references-publish.server.job'),
+    Reference = mongoose.model('Reference');
+
 describe('Job: Set reference to public after a given period of time', function () {
-  it('non-public references older than a given period of time become public');
-  it('newer non-public references are unaffected');
+
+  // fake Date
+  // stub config.limits.timeToReplyReference with custom test value
+  beforeEach(function () {
+    sinon.useFakeTimers({ now: new Date('2018-10-12 11:33:21.312'), toFake: ['Date'] });
+    sinon.stub(config.limits, 'timeToReplyReference').value({ days: 7 });
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  // delete references after each test
+  afterEach(function (done) {
+    Reference.deleteMany({}).exec(done);
+  });
+
+  function generateRandomId() {
+    var result = crypto.randomBytes(12).toString('hex');
+    // padding with 0 to 24 characters
+    result = '0'.repeat(24 - result.length) + result;
+    return result;
+  }
+
+  function generateRandomBoolean() {
+    return !!Math.floor(2 * Math.random());
+  }
+
+  function generateRandomRecommend() {
+    return ['yes', 'no', 'unknown'][Math.floor(3 * Math.random())];
+  }
+
+  var referenceData = {
+    get userFrom() { return generateRandomId(); },
+    get userTo() { return generateRandomId(); },
+    // here we don't care if all interactions are false
+    get met() { return generateRandomBoolean(); },
+    get hostedMe() { return generateRandomBoolean(); },
+    get hostedThem() { return generateRandomBoolean(); },
+    get recommend() { return generateRandomRecommend(); }
+  };
+
+  function createReferences(count, done) {
+    var references = [];
+
+    for (var i = 0; i < count; ++i) {
+      references.push(new Reference(referenceData));
+    }
+    async.eachSeries(references, function (reference, cb) { reference.save(cb); }, done);
+  }
+
+  function countPublicReferences(done) {
+    return Reference.find({ public: true }).exec(function (err, resp) {
+      return done(err, resp.length);
+    });
+  }
+
+  function waitWithCallback(duration, done) {
+    sinon.clock.tick(moment.duration(duration).asMilliseconds());
+    return done();
+  }
+
+  function runJobAndExpectPublicReferences(expectedCount, done) {
+    jobPublishReference(null, function (errJob) {
+      if (errJob) return done(errJob);
+
+      countPublicReferences(function (err, actualCount) {
+        if (err) return done(err);
+
+        try {
+          should(actualCount).eql(expectedCount);
+          return done();
+        } catch (e) {
+          return done(e);
+        }
+      });
+
+    });
+  }
+
+  it('non-public references older than a given period of time become public', function (done) {
+    return async.waterfall([
+      // create some non-public references
+      createReferences.bind(this, 7),
+      // wait for some time less than the given period
+      waitWithCallback.bind(this, { days: 3 }),
+      // create some more references
+      createReferences.bind(this, 4),
+      // run the job and see that all the references are private
+      runJobAndExpectPublicReferences.bind(this, 0),
+      // wait so the older references can become public
+      waitWithCallback.bind(this, { days: 4, seconds: 1 }),
+      // run the job and see that the older references are public now
+      runJobAndExpectPublicReferences.bind(this, 7),
+      // wait longer
+      waitWithCallback.bind(this, { days: 3 }),
+      // run the job and see that all the references are public now
+      runJobAndExpectPublicReferences.bind(this, 11)
+    ], done);
+  });
 });

--- a/modules/references/tests/server/reference.server.jobs.tests.js
+++ b/modules/references/tests/server/reference.server.jobs.tests.js
@@ -1,0 +1,4 @@
+describe('Job: Set reference to public after a given period of time', function () {
+  it('non-public references older than a given period of time become public');
+  it('newer non-public references are unaffected');
+});

--- a/modules/references/tests/server/reference.server.jobs.tests.js
+++ b/modules/references/tests/server/reference.server.jobs.tests.js
@@ -49,9 +49,11 @@ describe('Job: Set reference to public after a given period of time', function (
       userFrom: generateRandomId(),
       userTo: generateRandomId(),
       // here we don't care if all interactions are false
-      met: generateRandomBoolean(),
-      hostedMe: generateRandomBoolean(),
-      hostedThem: generateRandomBoolean(),
+      interactions: {
+        met: generateRandomBoolean(),
+        hostedMe: generateRandomBoolean(),
+        hostedThem: generateRandomBoolean()
+      },
       recommend: generateRandomRecommend()
     };
   }

--- a/modules/references/tests/server/reference.server.jobs.tests.js
+++ b/modules/references/tests/server/reference.server.jobs.tests.js
@@ -44,21 +44,23 @@ describe('Job: Set reference to public after a given period of time', function (
     return ['yes', 'no', 'unknown'][Math.floor(3 * Math.random())];
   }
 
-  var referenceData = {
-    get userFrom() { return generateRandomId(); },
-    get userTo() { return generateRandomId(); },
-    // here we don't care if all interactions are false
-    get met() { return generateRandomBoolean(); },
-    get hostedMe() { return generateRandomBoolean(); },
-    get hostedThem() { return generateRandomBoolean(); },
-    get recommend() { return generateRandomRecommend(); }
-  };
+  function generateReferenceData() {
+    return {
+      userFrom: generateRandomId(),
+      userTo: generateRandomId(),
+      // here we don't care if all interactions are false
+      met: generateRandomBoolean(),
+      hostedMe: generateRandomBoolean(),
+      hostedThem: generateRandomBoolean(),
+      recommend: generateRandomRecommend()
+    };
+  }
 
   function createReferences(count, done) {
     var references = [];
 
     for (var i = 0; i < count; ++i) {
-      references.push(new Reference(referenceData));
+      references.push(new Reference(generateReferenceData()));
     }
     async.eachSeries(references, function (reference, cb) { reference.save(cb); }, done);
   }

--- a/modules/references/tests/server/reference.server.jobs.tests.js
+++ b/modules/references/tests/server/reference.server.jobs.tests.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var async = require('async'),
-    crypto = require('crypto'),
     moment = require('moment'),
     mongoose = require('mongoose'),
     path = require('path'),
@@ -29,32 +28,17 @@ describe('Job: Set reference to public after a given period of time', function (
     Reference.deleteMany({}).exec(done);
   });
 
-  function generateRandomId() {
-    var result = crypto.randomBytes(12).toString('hex');
-    // padding with 0 to 24 characters
-    result = '0'.repeat(24 - result.length) + result;
-    return result;
-  }
-
-  function generateRandomBoolean() {
-    return !!Math.floor(2 * Math.random());
-  }
-
-  function generateRandomRecommend() {
-    return ['yes', 'no', 'unknown'][Math.floor(3 * Math.random())];
-  }
-
   function generateReferenceData() {
     return {
-      userFrom: generateRandomId(),
-      userTo: generateRandomId(),
+      userFrom: new mongoose.Types.ObjectId(),
+      userTo: new mongoose.Types.ObjectId(),
       // here we don't care if all interactions are false
       interactions: {
-        met: generateRandomBoolean(),
-        hostedMe: generateRandomBoolean(),
-        hostedThem: generateRandomBoolean()
+        met: true,
+        hostedMe: false,
+        hostedThem: true
       },
-      recommend: generateRandomRecommend()
+      recommend: 'yes'
     };
   }
 

--- a/modules/references/tests/server/reference.server.model.tests.js
+++ b/modules/references/tests/server/reference.server.model.tests.js
@@ -1,8 +1,175 @@
+'use strict';
+
+var should = require('should'),
+    mongoose = require('mongoose'),
+    User = mongoose.model('User'),
+    Reference = mongoose.model('Reference');
+
 describe('Reference Model Unit Tests', function () {
+
   describe('Method Save', function () {
-    it('save without problems');
-    it('show error when saving wrong recommendation value');
-    it('show error when saving duplicate reference (reference (from, to) already exists)');
+
+    var user1,
+        user2,
+        user3;
+
+    beforeEach(function () {
+      user1 = new User({
+        username: 'user1',
+        email: 'user1@example.com',
+        password: 'correcthorsebatterystaples'
+      });
+
+      user2 = new User({
+        username: 'user2',
+        email: 'user2@example.com',
+        password: 'correcthorsebatterystaples'
+      });
+
+      user3 = new User({
+        username: 'user3',
+        email: 'user3@example.com',
+        password: 'correcthorsebatterystaples'
+      });
+    });
+
+    afterEach(function (done) {
+      Reference.remove().exec(done);
+    });
+
+    it('save both directions without problems', function (done) {
+      var reference1 = new Reference({
+        userFrom: user1._id,
+        userTo: user2._id,
+        met: true,
+        hosted_me: true,
+        hosted_them: false,
+        recommend: 'no'
+      });
+
+      var reference2 = new Reference({
+        userFrom: user2._id,
+        userTo: user1._id,
+        met: true,
+        hosted_me: false,
+        hosted_them: true,
+        recommend: 'yes'
+      });
+
+      reference1.save(function (err) {
+        try {
+          should.not.exist(err);
+        } catch (e) {
+          return done(e);
+        }
+        reference2.save(function (err) {
+          try {
+            should.not.exist(err);
+          } catch (e) {
+            return done(e);
+          }
+          return done();
+        });
+      });
+    });
+
+    it('save multiple references from one user to different users without problems', function (done) {
+      var reference1 = new Reference({
+        userFrom: user1._id,
+        userTo: user2._id,
+        met: true,
+        hosted_me: true,
+        hosted_them: false,
+        recommend: 'no'
+      });
+
+      var reference2 = new Reference({
+        userFrom: user1._id,
+        userTo: user3._id,
+        met: true,
+        hosted_me: false,
+        hosted_them: true,
+        recommend: 'yes'
+      });
+
+      reference1.save(function (err) {
+        try {
+          should.not.exist(err);
+        } catch (e) {
+          return done(e);
+        }
+        reference2.save(function (err) {
+          try {
+            should.not.exist(err);
+          } catch (e) {
+            return done(e);
+          }
+          return done();
+        });
+      });
+    });
+
+    it('show error when saving invalid values of \'met\', \'recommend\', \'hosted_me\', \'hosted_them\'', function (done) {
+      var reference = new Reference({
+        userFrom: user1._id,
+        userTo: user2._id,
+        met: 'foo',
+        hosted_me: 'foolme',
+        hosted_them: 'foolthem',
+        recommend: 'bar'
+      });
+
+      reference.save(function (err) {
+        try {
+          should.exist(err);
+          should(err).match({ errors: {
+            met: { value: 'foo', kind: 'Boolean' },
+            hosted_me: { value: 'foolme', kind: 'Boolean' },
+            hosted_them: { value: 'foolthem', kind: 'Boolean' },
+            recommend: { value: 'bar', kind: 'enum' }
+          } });
+        } catch (e) {
+          return done(e);
+        }
+
+        return done();
+      });
+    });
+
+    it('show error when saving duplicate reference (reference (from, to) already exists)', function (done) {
+      var reference1 = new Reference({
+        userFrom: user2._id,
+        userTo: user1._id
+      });
+
+      var reference2 = new Reference({
+        userFrom: user2._id,
+        userTo: user1._id
+      });
+
+      reference1.save(function (err) {
+        try {
+          should.not.exist(err);
+        } catch (e) {
+          return done(e);
+        }
+        reference2.save(function (err) {
+          try {
+            should.exist(err);
+            console.log(err);
+            should(err).have.property('errors').match({
+              userFrom: { kind: 'unique' },
+              userTo: { kind: 'unique' }
+            });
+          } catch (e) {
+            return done(e);
+          }
+          return done();
+        });
+      });
+    });
+
+    // @TODO this check probably has to be implemented in application
     it('show error when saving reference to nonexistent user');
   });
 });

--- a/modules/references/tests/server/reference.server.model.tests.js
+++ b/modules/references/tests/server/reference.server.model.tests.js
@@ -167,8 +167,5 @@ describe('Reference Model Unit Tests', function () {
         });
       });
     });
-
-    // @TODO this check probably has to be implemented in application
-    it('show error when saving reference to nonexistent user');
   });
 });

--- a/modules/references/tests/server/reference.server.model.tests.js
+++ b/modules/references/tests/server/reference.server.model.tests.js
@@ -1,0 +1,8 @@
+describe('Reference Model Unit Tests', function () {
+  describe('Method Save', function () {
+    it('save without problems');
+    it('show error when saving wrong recommendation value');
+    it('show error when saving duplicate reference (reference (from, to) already exists)');
+    it('show error when saving reference to nonexistent user');
+  });
+});

--- a/modules/references/tests/server/reference.server.model.tests.js
+++ b/modules/references/tests/server/reference.server.model.tests.js
@@ -42,8 +42,8 @@ describe('Reference Model Unit Tests', function () {
         userFrom: user1._id,
         userTo: user2._id,
         met: true,
-        hosted_me: true,
-        hosted_them: false,
+        hostedMe: true,
+        hostedThem: false,
         recommend: 'no'
       });
 
@@ -51,8 +51,8 @@ describe('Reference Model Unit Tests', function () {
         userFrom: user2._id,
         userTo: user1._id,
         met: true,
-        hosted_me: false,
-        hosted_them: true,
+        hostedMe: false,
+        hostedThem: true,
         recommend: 'yes'
       });
 
@@ -78,8 +78,8 @@ describe('Reference Model Unit Tests', function () {
         userFrom: user1._id,
         userTo: user2._id,
         met: true,
-        hosted_me: true,
-        hosted_them: false,
+        hostedMe: true,
+        hostedThem: false,
         recommend: 'no'
       });
 
@@ -87,8 +87,8 @@ describe('Reference Model Unit Tests', function () {
         userFrom: user1._id,
         userTo: user3._id,
         met: true,
-        hosted_me: false,
-        hosted_them: true,
+        hostedMe: false,
+        hostedThem: true,
         recommend: 'yes'
       });
 
@@ -109,13 +109,13 @@ describe('Reference Model Unit Tests', function () {
       });
     });
 
-    it('show error when saving invalid values of \'met\', \'recommend\', \'hosted_me\', \'hosted_them\'', function (done) {
+    it('show error when saving invalid values of \'met\', \'recommend\', \'hostedMe\', \'hostedThem\'', function (done) {
       var reference = new Reference({
         userFrom: user1._id,
         userTo: user2._id,
         met: 'foo',
-        hosted_me: 'foolme',
-        hosted_them: 'foolthem',
+        hostedMe: 'foolme',
+        hostedThem: 'foolthem',
         recommend: 'bar'
       });
 
@@ -124,8 +124,8 @@ describe('Reference Model Unit Tests', function () {
           should.exist(err);
           should(err).match({ errors: {
             met: { value: 'foo', kind: 'Boolean' },
-            hosted_me: { value: 'foolme', kind: 'Boolean' },
-            hosted_them: { value: 'foolthem', kind: 'Boolean' },
+            hostedMe: { value: 'foolme', kind: 'Boolean' },
+            hostedThem: { value: 'foolthem', kind: 'Boolean' },
             recommend: { value: 'bar', kind: 'enum' }
           } });
         } catch (e) {
@@ -156,7 +156,6 @@ describe('Reference Model Unit Tests', function () {
         reference2.save(function (err) {
           try {
             should.exist(err);
-            console.log(err);
             should(err).have.property('errors').match({
               userFrom: { kind: 'unique' },
               userTo: { kind: 'unique' }

--- a/modules/references/tests/server/reference.server.model.tests.js
+++ b/modules/references/tests/server/reference.server.model.tests.js
@@ -41,18 +41,22 @@ describe('Reference Model Unit Tests', function () {
       var reference1 = new Reference({
         userFrom: user1._id,
         userTo: user2._id,
-        met: true,
-        hostedMe: true,
-        hostedThem: false,
+        interactions: {
+          met: true,
+          hostedMe: true,
+          hostedThem: false
+        },
         recommend: 'no'
       });
 
       var reference2 = new Reference({
         userFrom: user2._id,
         userTo: user1._id,
-        met: true,
-        hostedMe: false,
-        hostedThem: true,
+        interactions: {
+          met: true,
+          hostedMe: false,
+          hostedThem: true
+        },
         recommend: 'yes'
       });
 
@@ -77,18 +81,22 @@ describe('Reference Model Unit Tests', function () {
       var reference1 = new Reference({
         userFrom: user1._id,
         userTo: user2._id,
-        met: true,
-        hostedMe: true,
-        hostedThem: false,
+        interactions: {
+          met: true,
+          hostedMe: true,
+          hostedThem: false
+        },
         recommend: 'no'
       });
 
       var reference2 = new Reference({
         userFrom: user1._id,
         userTo: user3._id,
-        met: true,
-        hostedMe: false,
-        hostedThem: true,
+        interactions: {
+          met: true,
+          hostedMe: false,
+          hostedThem: true
+        },
         recommend: 'yes'
       });
 
@@ -113,9 +121,11 @@ describe('Reference Model Unit Tests', function () {
       var reference = new Reference({
         userFrom: user1._id,
         userTo: user2._id,
-        met: 'foo',
-        hostedMe: 'foolme',
-        hostedThem: 'foolthem',
+        interactions: {
+          met: 'foo',
+          hostedMe: 'foolme',
+          hostedThem: 'foolthem'
+        },
         recommend: 'bar'
       });
 
@@ -123,9 +133,9 @@ describe('Reference Model Unit Tests', function () {
         try {
           should.exist(err);
           should(err).match({ errors: {
-            met: { value: 'foo', kind: 'Boolean' },
-            hostedMe: { value: 'foolme', kind: 'Boolean' },
-            hostedThem: { value: 'foolthem', kind: 'Boolean' },
+            'interactions.met': { value: 'foo', kind: 'Boolean' },
+            'interactions.hostedMe': { value: 'foolme', kind: 'Boolean' },
+            'interactions.hostedThem': { value: 'foolthem', kind: 'Boolean' },
             recommend: { value: 'bar', kind: 'enum' }
           } });
         } catch (e) {


### PR DESCRIPTION
`POST /api/references`
```js
{
  userTo: UserId,
  interactions: {
    met: Boolean,
    hostedMe: Boolean,
    hostedThem: Boolean
  },
  recommend: Enum('yes', 'no', 'unknown')
}
```

Implementing parts of #718
Follow up: #759 #761 

# Behavior

1. A public user (`userFrom`) can create a reference for any other public user (`userTo`).
  - only one reference from `userFrom` to `userTo` can be given
  - references can't be edited or removed
2. The reference is not public. Email and push notifications are sent to the `userTo`. `userTo` has a limited time period (currently [14 days](https://github.com/Trustroots/trustroots/blob/references-create-api/config/env/default.js#L107)) to give a reference back.
3. When the `userTo` gives a reference to `userFrom`, both references become public. `userFrom` is notified that she received a reference and can see it.
4. If `userTo` doesn't give the reference back within the time period, the original reference will become public. (_TODO later_ both users should get notified about this).
5. When the reference is public, a new opposite direction reference can be positive only. `recommend: 'yes'`

Rationale: users should be able to give a neutral or negative reference and not receive a reciprocal negative reference.

# Notes
- configurables:
  - `limits.timeToReplyReference` ([./config/env/default.js](https://github.com/Trustroots/trustroots/blob/references-create-api/config/env/default.js#L107), currently 14 days)
  - period of repeating the `publish old unpublished references` job ([./config/lib/worker.js](https://github.com/Trustroots/trustroots/blob/references-create-api/config/lib/worker.js#L95), currently 23 minutes (very random choice))


- Email notifications will need some :art:, :heart: and :thought_balloon: from a designer. This kind of stuff is frustrating for me and somebody else may enjoy it.
  I would do it as a last resort only.
  - Email notification: First Reference between users was created. [html template](https://github.com/Trustroots/trustroots/blob/references-create-api/modules/core/server/views/email-templates/reference-notification-first.server.view.html), [text template](https://github.com/Trustroots/trustroots/blob/references-create-api/modules/core/server/views/email-templates-text/reference-notification-first.server.view.html)
  - Email notification: Second Reference between users was created. [html template](https://github.com/Trustroots/trustroots/blob/references-create-api/modules/core/server/views/email-templates/reference-notification-second.server.view.html), [text template](https://github.com/Trustroots/trustroots/blob/references-create-api/modules/core/server/views/email-templates-text/reference-notification-second.server.view.html)

- Push notifications' text needs some :heart: too. Currently the text is:
  - First reference: `<username> gave you a new reference. Give a reference back.` ([test](https://github.com/Trustroots/trustroots/blob/references-create-api/modules/references/tests/server/reference-create.server.routes.tests.js#L433))
  - Second (reply) reference: `<username> gave you a new reference. You can see it.` ([test](https://github.com/Trustroots/trustroots/blob/references-create-api/modules/references/tests/server/reference-create.server.routes.tests.js#L676))
  - [implementation here](https://github.com/Trustroots/trustroots/blob/references-create-api/modules/core/server/services/push.server.service.js#L95)

- Implementation of _No duplicate references!_ relies on MongoDB unique compound index on fields `userFrom` and `userTo`. ([code here](https://github.com/Trustroots/trustroots/blob/references-create-api/modules/references/server/models/reference.server.model.js#L77))
  Therefore, this index should be created directly in MongoDB when merged to production, because [mongoose documentation says so](https://mongoosejs.com/docs/faq.html#unique-doesnt-work). Or not. Just make sure it's present.
  Alternatively, the checks could be done before (more reads from database).

- still missing notifications to users when given time to reply passes and reference thus becomes public