### PR TITLE
Update Node version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.3
+FROM node:10.12
 
 # Install prerequisites
 # https://docs.docker.com/engine/articles/dockerfile_best-practices/#apt-get


### PR DESCRIPTION
This fixes the error reported in https://github.com/Trustroots/trustroots/issues/618#issuecomment-413538027

When trying to set up the Docker environment, I got a lot of errors when running `docker-compose up`, mostly due to the `npx` command. Example:

    trustroots    | npm info lifecycle trustroots@0.3.3~postinstall-if-no-modules: trustroots@0.3.3
    trustroots    | npm info ok
    trustroots    | sh: 1: npx: not found

This was happening because "npx" was introduced in npm 5.2, but the Dockerfile was installing npm 3.10.3. I updated the base image to "node:10.12" since the `.travis.yml` is targeting Node 10.

If you've already built the containers, you'll have to destroy the volume with the "node_modules", otherwise you'll get errors like the following:

    trustroots    | Error: The module '/trustroots/node_modules/mmmagic/build/Release/magic.node'
    trustroots    | was compiled against a different Node.js version using
    trustroots    | NODE_MODULE_VERSION 48. This version of Node.js requires
    trustroots    | NODE_MODULE_VERSION 64. Please try re-compiling or re-installing

The easiest way to do that is by running `docker-compose down --volumes`. This will destroy any DB data you have too.