### PR TITLE
Update Mongo version in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ maildev:
 
 ## Database container
 mongodb:
-  image: mongo:3.2
+  image: mongo:3.6
   container_name: db_1
   restart: always
   command: "--smallfiles --logpath=/dev/null"


### PR DESCRIPTION
When setting up the Docker environment, the "trustroots" container crashed with the following error:

    trustroots    | MongoDB version: 3.2.21
    trustroots    | MongoDB version incompatibility! Compatible version(s): >=3.6 <=4.0
    trustroots    | [Server] Script crashed.

I updated the Mongo image version in docker-compose.yml to 3.6, since that's the minimum supported version, which fixed it.

Note that if you've already built the container, you'll have to either upgrade the data files or destroy the volume, otherwise the `db_1` container will crash with exit code 62. See this for more details: https://stackoverflow.com/questions/47850004/mongodb-shutting-down-with-code62

The easiest way to to fix this is by running `docker-compose down --volumes` to destroy all the containers and volumes