### PR TITLE
Fix host in local.docker.js

### DIFF
--- a/config/env/local.docker.js
+++ b/config/env/local.docker.js
@@ -16,6 +16,8 @@
  */
 
 module.exports = {
+  // Need to listen on all addresses so the nginx container can access it
+  host: '0.0.0.0',
 
   /**
    * NodeMailer settings for Maildev Docker image


### PR DESCRIPTION
After setting up the Docker environment, I got "Connection refused" when attempting to connect to http://localhost:3000/ on my host machine, accompanied with the following in the logs:

    nginx         | nginx.1    | localhost 172.17.0.1 - - [21/Oct/2018:05:57:35 +0000] "GET /favicon.ico HTTP/1.1" 502 173 "-" "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:62.0) Gecko/20100101 Firefox/62.0"
    nginx         | nginx.1    | 2018/10/21 05:57:35 [error] 58#58: *1 connect() failed (111: Connection refused) while connecting to upstream, client: 172.17.0.1, server: localhost, request: "GET /favicon.ico HTTP/1.1", upstream: "http://172.17.0.5:3000/favicon.ico", host : "localhost:3080"

This was happening because Node was listening on 'localhost' inside the 'trustroots' container, which meant it was inaccessible from the 'nginx' container. Changing the "host" config value to "0.0.0.0" fixed it.