### PR TITLE
Collapse Tribes list at profile:about tab #404

### DIFF
--- a/modules/users/client/directives/tr-memberships-list.client.directive.js
+++ b/modules/users/client/directives/tr-memberships-list.client.directive.js
@@ -17,8 +17,18 @@
       scope: {
         memberships: '=trMembershipsList',
         isOwnProfile: '='
-      }
+      },
+      controller: trMembershipsListController
+
     };
+  }
+
+  function trMembershipsListController($scope) {
+    $scope.displayAllTribes = false;
+    $scope.toggle = function () {
+      $scope.displayAllTribes = true;
+    }
+
   }
 
 }());

--- a/modules/users/client/views/directives/tr-memberships-list.client.view.html
+++ b/modules/users/client/views/directives/tr-memberships-list.client.view.html
@@ -1,8 +1,19 @@
 <div>
-  <ul class="profile-memberships-list" ng-if="memberships && memberships.length">
-    <li class="tribe" ng-repeat="membership in ::memberships">
-      <div tr-tribe-badge="membership.tribe"></div>
-    </li>
+  <ul class="profile-memberships-list panel-more-wrap"
+  ng-if="memberships && memberships.length > 5 && !displayAllTribes">
+    <div class="panel-more-excerpt">
+      <li class="tribe" ng-repeat="membership in ::memberships | limitTo:5">
+        <div tr-tribe-badge="membership.tribe"></div>
+      </li>
+    </div>
+    <div class="panel-more-fade" ng-click="toggle()">Show more...</div>
+  </ul>
+
+  <ul class="profile-memberships-list"
+  ng-if="memberships && (memberships.length <= 5 || displayAllTribes)">
+      <li class="tribe" ng-repeat="membership in ::memberships">
+        <div tr-tribe-badge="membership.tribe"></div>
+      </li>
   </ul>
 
   <div class="text-center" ng-if="isOwnProfile">

--- a/modules/users/client/views/profile/profile-view-about.client.view.html
+++ b/modules/users/client/views/profile/profile-view-about.client.view.html
@@ -10,15 +10,14 @@
       <div class="panel-body">
 
         <!-- Short descriptions -->
-        <div ng-if="profileCtrl.profile.description.length < 2400" ng-bind-html="profileCtrl.profile.description | trustedHtml"></div>
+        <div ng-if="profileCtrl.profile.description.length < 2400 || profileCtrl.profileDescriptionToggle"
+        ng-bind-html="profileCtrl.profile.description | trustedHtml"></div>
 
         <!-- Long descriptions -->
-        <div ng-if="profileCtrl.profile.description.length >= 2400">
-          <div class="panel-more-wrap" ng-hide="profileCtrl.profileDescriptionToggle">
-            <div class="panel-more-excerpt" ng-bind-html="profileCtrl.profile.description | limitTo:2400 | trustedHtml" ng-click="profileCtrl.profileDescriptionToggle=true"></div>
-            <div class="panel-more-fade" ng-click="profileCtrl.profileDescriptionToggle=true">Show more...</div>
-          </div>
-          <div ng-if="profileCtrl.profileDescriptionToggle" ng-bind-html="profileCtrl.profile.description | trustedHtml"></div>
+        <div ng-if="profileCtrl.profile.description.length >= 2400 && !profileCtrl.profileDescriptionToggle"
+          class="panel-more-wrap" ng-click="profileCtrl.profileDescriptionToggle=true">
+            <div class="panel-more-excerpt" ng-bind-html="profileCtrl.profile.description | limitTo:2400 | trustedHtml" ></div>
+            <div class="panel-more-fade">Show more...</div>
         </div>
 
         <!-- If no description, show deep thoughts... -->
@@ -67,7 +66,7 @@
              tr-tribes-in-common="profileCtrl.profile.member"></div>
 
         <div tr-memberships-list="profileCtrl.profile.member"
-             is-own-profile="::profileCtrl.profile._id === app.user._id"></div>
+        is-own-profile="::profileCtrl.profile._id === app.user._id"></div>
 
       </div>
     </section>


### PR DESCRIPTION
Also did a small refactor of the Show more for description which I reused.
Checked also for own profile and also for an user with both long desc and many tribes.
Show more is displayed when user has more than 5 tribes
![screen shot 2018-10-22 at 22 56 07](https://user-images.githubusercontent.com/38785076/47319432-f5892880-d64e-11e8-8d58-f8d6bb654609.png)
