### PR TITLE
Remove common tribes from user tribe list

### DIFF
--- a/modules/users/client/directives/tr-memberships-list.client.directive.js
+++ b/modules/users/client/directives/tr-memberships-list.client.directive.js
@@ -9,16 +9,53 @@
     .directive('trMembershipsList', trMembershipsListDirective);
 
   /* @ngInject */
-  function trMembershipsListDirective() {
+  function trMembershipsListDirective(Authentication) {
     return {
       templateUrl: '/modules/users/views/directives/tr-memberships-list.client.view.html',
       restrict: 'A',
       replace: true,
       scope: {
-        memberships: '=trMembershipsList',
+        trMembershipsList: '=',
         isOwnProfile: '='
-      }
+      },
+      controller: trMembershipsListController,
+      controllerAs: 'tribesMembershipsList'
     };
-  }
 
+    /* @ngInject */
+    function trMembershipsListController($scope) {
+
+      // View Model
+      var vm = this;
+
+      // Exposed to the view
+      vm.memberships = [];
+
+      activate();
+
+      /**
+       * Initialize directive controller
+       */
+      function activate() {
+        var nonCommonTribes = [];
+
+        if ($scope.isOwnProfile) {
+          vm.memberships = $scope.trMembershipsList;
+          // Loop all tribes memberships
+        } else if (angular.isDefined($scope.trMembershipsList) &&
+          angular.isArray($scope.trMembershipsList) &&
+          Authentication.user.memberIds &&
+          Authentication.user.memberIds.length > 0) {
+          angular.forEach($scope.trMembershipsList, function (membership) {
+            // If authenticated user has it as well, it's already visible in the common tribes list
+            // so do not add it
+            if (membership.tribe && Authentication.user.memberIds.indexOf(membership.tribe._id) < 0) {
+              nonCommonTribes.push(membership);
+            }
+          });
+          vm.memberships = nonCommonTribes;
+        }
+      }
+    }
+  }
 }());

--- a/modules/users/client/views/directives/tr-memberships-list.client.view.html
+++ b/modules/users/client/views/directives/tr-memberships-list.client.view.html
@@ -1,12 +1,12 @@
 <div>
-  <ul class="profile-memberships-list" ng-if="memberships && memberships.length">
-    <li class="tribe" ng-repeat="membership in ::memberships">
+  <ul class="profile-memberships-list" ng-if="tribesMembershipsList.memberships && tribesMembershipsList.memberships.length">
+    <li class="tribe" ng-repeat="membership in ::tribesMembershipsList.memberships">
       <div tr-tribe-badge="membership.tribe"></div>
     </li>
   </ul>
 
-  <div class="text-center" ng-if="isOwnProfile">
-    <div class="content-empty" ng-if="memberships && memberships.length === 0">
+  <div class="text-center" ng-if="tribesMembershipsList.isOwnProfile">
+    <div class="content-empty" ng-if="tribesMembershipsList.memberships && tribesMembershipsList.memberships.length === 0">
       <div class="icon-tribes icon-3x text-muted"></div>
       <p><em>Joining Tribes helps you find likeminded Trustroots members.</em></p>
       <br><br>
@@ -14,7 +14,7 @@
         Join Tribes
       </a>
     </div>
-    <div ng-if="memberships && memberships.length > 0">
+    <div ng-if="tribesMembershipsList.memberships && tribesMembershipsList.memberships.length > 0">
       <hr class="hr-gray hr-tight"/>
       <a ui-sref="tribes.list" class="btn btn-sm btn-default">
         Join more Tribes


### PR DESCRIPTION
#### Proposed Changes

Since there's already a list of common tribes they shouldn't be shown again in the full list of the user's tribes right under the common tribes. Before showing the list of tribes the user is a member of the common ones will be removed

#### Testing Instructions

Check other user profiles with common tribes; without common tribes; with only common tribes; Also check currently logged in user profile

Fixes #744 