### PR TITLE
Updates to fix text zoom issue

### DIFF
--- a/modules/tribes/client/less/tribe.less
+++ b/modules/tribes/client/less/tribe.less
@@ -6,7 +6,6 @@
   left: 0;
   right: 0;
   .tribe-header-back {
-    //position: absolute;
     padding-top: (@navbar-height + 50px);
     margin-left: -30px;
     [class^="icon-"]:before,

--- a/modules/tribes/client/less/tribe.less
+++ b/modules/tribes/client/less/tribe.less
@@ -27,6 +27,7 @@
   width: 100%;
   min-height: 680px;
   height: 100vh;
+  overflow: auto;
   background: linear-gradient(to right, rgba(0,0,0,0.65) 0%,rgba(0,0,0,0) 100%);
   .tribe-pre {
     margin-bottom: 0;

--- a/modules/tribes/client/less/tribe.less
+++ b/modules/tribes/client/less/tribe.less
@@ -1,14 +1,14 @@
 .tribe-header {
   padding: 0;
   position: fixed;
-  top: @navbar-height;
+  top: 0;
   bottom: 0;
   left: 0;
   right: 0;
   .tribe-header-back {
-    position: absolute;
-    top: (@navbar-height + 10px);
-    left: 10px;
+    //position: absolute;
+    padding-top: (@navbar-height + 50px);
+    margin-left: -30px;
     [class^="icon-"]:before,
     [class*=" icon-"]:before {
       transition: all 0.2s ease-in-out;
@@ -22,18 +22,12 @@
         margin-left: 0;
       }
     }
-    @media (max-width: @screen-xs-max) {
-      position: absolute;
-      top: 0;
-      left: 0;
-      padding-right: 50px;
-      right: 0;
-    }
   }
 }
 .tribe-header-info {
   width: 100%;
   min-height: 680px;
+  height: 100vh;
   background: linear-gradient(to right, rgba(0,0,0,0.65) 0%,rgba(0,0,0,0) 100%);
   .tribe-pre {
     margin-bottom: 0;

--- a/modules/tribes/client/views/tribe.client.view.html
+++ b/modules/tribes/client/views/tribe.client.view.html
@@ -28,7 +28,7 @@
   </section>
 
   <!-- Tribe found -->
-  <section class="board flex-centered tribe-image tribe-header"
+  <section class="board tribe-image tribe-header"
            ng-if="tribeCtrl.tribe._id"
            tr-tribe-styles="{{::tribeCtrl.tribe}}"
            tr-tribe-styles-dimensions="1400x900"
@@ -36,15 +36,19 @@
            ng-swipe-left="tribeCtrl.goBack()"
            ng-swipe-right="tribeCtrl.goBack()"
            ng-class="{'is-guest': !app.user}">
-    <a ng-click="tribeCtrl.goBack()" class="btn btn-lg btn-link tribe-header-back">
-      <i class="icon-left"></i> More tribes
-    </a>
-    <div class="flex-centered tribe-header-info">
-      <div class="container">
+           <div class="tribe-header-info">
+             <div class="container">
+               <div class="row no-gutters">
+                 <div class="col-xs-12">
+                <a ng-click="tribeCtrl.goBack()" class="btn btn-lg btn-link tribe-header-back">
+                  <i class="icon-left"></i> More tribes
+                </a>
+              </div>
+          </div>
         <div class="row">
 
           <!-- For authenticated members -->
-          <div class="col-xs-10 col-sm-7 col-md-6 col-lg-5"
+          <div class="col-xs-10 col-sm-offset-1 col-sm-7 col-md-6 col-lg-5"
                ng-if="app.user">
             <p class="lead tribe-pre">Tribe</p>
             <h2 class="font-brand-regular tribe-title"
@@ -93,7 +97,7 @@
           </div>
 
           <!-- For non authenticated members -->
-          <div class="col-xs-12 col-sm-7 col-md-6 col-lg-5" ng-if="!app.user">
+          <div class="col-xs-12 col-sm-offset-1 col-sm-7 col-md-6 col-lg-5" ng-if="!app.user">
             <p class="lead tribe-pre">Trustroots Tribe</p>
             <h2 class="font-brand-regular tribe-title" ng-bind="::tribeCtrl.tribe.label"></h2>
             <ng-pluralize


### PR DESCRIPTION
#### Proposed Changes

* Remove position:absolute from .tribe-header-back and restructure the html to allow the page to move down when text is zoomed. 

#### Testing Instructions

* Increase the zoom of the page and the text will no longer clash into each other 

Fixes #769: tribes/*: overlapping text with big fonts

