### PR TITLE
Add button to open location in app for mobile devices

### DIFF
--- a/modules/core/client/app/init.js
+++ b/modules/core/client/app/init.js
@@ -53,6 +53,7 @@
     // @link https://docs.angularjs.org/guide/production#disable-comment-and-css-class-directives
     $compileProvider.commentDirectivesEnabled(false);
     $compileProvider.cssClassDirectivesEnabled(false);
+    $compileProvider.aHrefSanitizationWhitelist(/^geo:.*/);
 
     // By default tooltips and popovers are appended to
     // '$body' instead of the parent element

--- a/modules/offers/client/directives/tr-offer-host-view.client.directive.js
+++ b/modules/offers/client/directives/tr-offer-host-view.client.directive.js
@@ -22,7 +22,7 @@
     return directive;
 
     /* @ngInject */
-    function trOfferHostViewDirectiveController($scope, OffersByService) {
+    function trOfferHostViewDirectiveController($scope, $window, OffersByService) {
 
       // ViewModel
       var vm = this;
@@ -35,7 +35,7 @@
       vm.isUserPublic = false;
       vm.hostingDropdown = false;
       vm.hostingStatusLabel = hostingStatusLabel;
-      vm.isMobile = navigator.userAgent.toLowerCase().indexOf('mobile') >= 0;
+      vm.isMobile = $window.navigator.userAgent.toLowerCase().indexOf('mobile') >= 0 || $window.isNativeMobileApp;
       activate();
 
       /**

--- a/modules/offers/client/directives/tr-offer-host-view.client.directive.js
+++ b/modules/offers/client/directives/tr-offer-host-view.client.directive.js
@@ -35,7 +35,7 @@
       vm.isUserPublic = false;
       vm.hostingDropdown = false;
       vm.hostingStatusLabel = hostingStatusLabel;
-
+      vm.isMobile = navigator.userAgent.toLowerCase().indexOf('mobile') >= 0;
       activate();
 
       /**

--- a/modules/offers/client/views/directives/tr-offer-host-view.client.view.html
+++ b/modules/offers/client/views/directives/tr-offer-host-view.client.view.html
@@ -198,6 +198,11 @@
            class="btn btn-sm btn-inverse-primary">
           Bigger map
         </a>
+        <a ng-if="trOfferHost.isMobile"
+          ng-href="geo:{{trOfferHost.offer.location[0]}},{{trOfferHost.offer.location[1]}};u=200"
+           class="btn btn-sm btn-inverse-primary">
+          Open on device
+        </a>
       </div>
 
     </div>

--- a/modules/offers/client/views/directives/tr-offer-host-view.client.view.html
+++ b/modules/offers/client/views/directives/tr-offer-host-view.client.view.html
@@ -198,7 +198,7 @@
            class="btn btn-sm btn-inverse-primary">
           Bigger map
         </a>
-        <a ng-if="trOfferHost.isMobile"
+        <a ng-if="::trOfferHost.isMobile"
           ng-href="geo:{{trOfferHost.offer.location[0]}},{{trOfferHost.offer.location[1]}};u=200"
            class="btn btn-sm btn-inverse-primary">
           Open on device


### PR DESCRIPTION
#### Proposed Changes

Add "Open in device" button that has a Geo URI with the fuzzy location of the host;
Whitelisted "geo:" URIs;
Button is only visible on mobile devices

#### Testing Instructions

Test that the pressing the button opens a maps app or browser on mobile devices;
Test that button is not visible on desktop browsers and is visible in mobile browsers

Fixes #704