### PR TITLE
Set autocapitalize off for password field

### DIFF
--- a/modules/users/client/views/authentication/signin.client.view.html
+++ b/modules/users/client/views/authentication/signin.client.view.html
@@ -31,6 +31,7 @@
                          placeholder="Password"
                          class="form-control input-lg"
                          ng-attr-type="{{ showPassword ? 'text' : 'password' }}"
+                         autocapitalize="off"
                          ng-disabled="auth.isLoading"
                          ng-model="auth.credentials.password"
                          tabindex="2">

--- a/modules/users/client/views/authentication/signup.client.view.html
+++ b/modules/users/client/views/authentication/signup.client.view.html
@@ -138,6 +138,7 @@
                        tooltip-trigger="'none'"
                        tooltip-placement="top"
                        ng-attr-type="{{ showPassword ? 'text' : 'password' }}"
+                       autocapitalize="off"
                        ng-model="signup.credentials.password"
                        ng-minlength="8"
                        ng-disabled="signup.isLoading">


### PR DESCRIPTION
#### Proposed Changes

Add `autocapitalize="off"` for password field because it's error prone on mobile devices when user sets password to be visible

#### Testing Instructions

Test that the first typed letter in the password field is not capitalized when the password is visible

Fixes #775