### PR TITLE
Tribes: allow HTML in tribe descriptions

### DIFF
--- a/modules/tribes/client/views/tribe.client.view.html
+++ b/modules/tribes/client/views/tribe.client.view.html
@@ -59,7 +59,7 @@
               }"></ng-pluralize>
             <div class="lead tribe-meta"
                  ng-if="tribeCtrl.tribe.description"
-                 ng-bind="::tribeCtrl.tribe.description"></div>
+                 ng-bind-html="::tribeCtrl.tribe.description"></div>
             <br><br>
             <tr-tribe-join-button
                     class="btn btn-lg btn-primary tribe-join"


### PR DESCRIPTION
#### Proposed Changes

Allow HTML in Tribe descriptions.

#### Testing Instructions

Open a tribe with HTML in its description coming from MongoDB.

Resolves #768