### PR TITLE
Add random tribe background images from CDN data

### DIFF
--- a/bin/fillTestData/Tribes.js
+++ b/bin/fillTestData/Tribes.js
@@ -4,7 +4,13 @@ var path = require('path'),
     mongooseService = require(path.resolve('./config/lib/mongoose')),
     chalk = require('chalk'),
     faker = require('faker'),
+    fs = require('fs'),
+    tribesData = JSON.parse(fs.readFileSync(path.resolve('./bin/fillTestData/data/Tribes.json'), 'utf8')),
     mongoose = require('mongoose');
+
+var random = function (max) {
+  return Math.floor(Math.random() * max);
+};
 
 var addTribes = function (max) {
   var index = 0;
@@ -36,7 +42,7 @@ var addTribes = function (max) {
         tribe.created = Date.now();
         tribe.modified = Date.now();
         tribe.public = true;
-        // tribe.image_UUID = faker.random.uuid();
+        tribe.image_UUID = tribesData[random(tribesData.length)].image_UUID;
         tribe.attribution = faker.name.findName();
         tribe.attribution_url = faker.internet.url();
         tribe.description = faker.lorem.sentences();

--- a/bin/fillTestData/data/Tribes.json
+++ b/bin/fillTestData/data/Tribes.json
@@ -1,0 +1,407 @@
+[
+    {
+        "slug": "dumpster-divers",
+        "label": "Dumpster divers",
+        "color": "8e2c0b",
+        "labelHistory": [],
+        "slugHistory": [],
+        "synonyms": [],
+        "count": 9153.0,
+        "public": true,
+        "image_UUID": "171433b0-853b-4d19-a8b4-44def956696d",
+        "attribution": "Trashwiki (CC BY-NC-SA 3.0)",
+        "attribution_url": "http://trashwiki.org/en/File:Freshfromtrash.jpeg"
+    },
+    {
+        "slug": "hitchhikers",
+        "label": "Hitchhikers",
+        "color": "63930e",
+        "labelHistory": [],
+        "slugHistory": [],
+        "synonyms": [],
+        "count": 15982.0,
+        "public": true,
+        "image_UUID": "22028fde-5302-4172-954d-f54949afd7e4",
+        "attribution": "Gytė",
+        "attribution_url": "https://www.facebook.com/upe.pati.teka"
+    },
+    {
+        "slug": "families",
+        "label": "Families",
+        "color": "a82c03",
+        "labelHistory": [],
+        "slugHistory": [],
+        "synonyms": [],
+        "count": 813.0,
+        "public": true,
+        "image_UUID": "e69eb05f-773f-423c-9246-43629b5a8baf",
+        "attribution": "Deveion Acker (CC BY-ND 2.0)",
+        "attribution_url": "https://flic.kr/p/oA2oGw"
+    },
+    {
+        "slug": "vegans-vegetarians",
+        "label": "Vegans & Vegetarians",
+        "color": "02824f",
+        "labelHistory": [],
+        "slugHistory": [],
+        "synonyms": [],
+        "count": 8215.0,
+        "public": true,
+        "image_UUID": "3c8bb9f1-e313-4baa-bf4c-1d8994fd6c6c",
+        "attribution": "Veganwiki (CC BY-SA 3.0)",
+        "attribution_url": "http://veganwiki.info/en/File:Bibimbap-korea.jpg"
+    },
+    {
+        "slug": "ecoliving",
+        "label": "Ecoliving",
+        "color": "f4ce11",
+        "labelHistory": [],
+        "slugHistory": [],
+        "synonyms": [],
+        "count": 4873.0,
+        "public": true,
+        "image_UUID": "d5563f29-669f-4f18-9802-d1924ff31364",
+        "attribution": "Michael Würfel (CC BY-SA 3.0)",
+        "attribution_url": "https://commons.wikimedia.org/wiki/File:004A_mwuerfel.jpg"
+    },
+    {
+        "slug": "lindyhoppers",
+        "label": "Lindyhoppers",
+        "description": "The Lindy hop swing dance community.",
+        "color": "c916dd",
+        "labelHistory": [],
+        "slugHistory": [],
+        "synonyms": [],
+        "count": 525.0,
+        "public": true,
+        "image_UUID": "4ff6463d-c482-4be6-9a49-294fc8712d83",
+        "attribution": "Michela Simoncini (CC BY 2.0)",
+        "attribution_url": "https://flic.kr/p/iQuwwp"
+    },
+    {
+        "slug": "musicians",
+        "label": "Musicians",
+        "color": "ef098b",
+        "labelHistory": [],
+        "slugHistory": [],
+        "synonyms": [],
+        "count": 3397.0,
+        "public": true,
+        "image_UUID": "e4466aa6-46f1-460f-94ef-8cec882d7103",
+        "attribution": "Guillaume Ohz",
+        "attribution_url": ""
+    },
+    {
+        "slug": "hackers",
+        "label": "Hackers",
+        "color": "b816e5",
+        "labelHistory": [],
+        "slugHistory": [],
+        "synonyms": [],
+        "count": 1603.0,
+        "public": true,
+        "image_UUID": "12a2c124-a38a-4df8-8987-e01ee3741727",
+        "attribution": "Andrew Neel",
+        "attribution_url": "https://unsplash.com/photos/fkalryO4dUI"
+    },
+    {
+        "slug": "buskers",
+        "label": "Buskers",
+        "color": "001d5b",
+        "labelHistory": [],
+        "slugHistory": [],
+        "synonyms": [],
+        "count": 1425.0,
+        "public": true,
+        "image_UUID": "e23060e2-393d-4b4a-b469-450053538f8a",
+        "attribution": "Angela (CC BY-SA 3.0)",
+        "attribution_url": "http://nomadwiki.org/en/File:Angella-busking-soap-bubbles-3.jpg"
+    },
+    {
+        "slug": "nomads",
+        "label": "Nomads",
+        "color": "0b5e7c",
+        "labelHistory": [],
+        "slugHistory": [],
+        "synonyms": [],
+        "count": 6359.0,
+        "public": true,
+        "image_UUID": "6274fd88-9178-4cea-8bb4-60f22e4cc904",
+        "attribution": "Gary St (CC BY-SA 3.0)",
+        "attribution_url": "http://nomadwiki.org/en/File:Nomadwiki-front.jpg"
+    },
+    {
+        "slug": "punks",
+        "label": "Punks",
+        "color": "7c1e0b",
+        "labelHistory": [],
+        "slugHistory": [],
+        "synonyms": [],
+        "count": 1684.0,
+        "public": true,
+        "image_UUID": "fb2b6d50-9d51-4755-9b44-1395fae4cf5d",
+        "attribution": "Rosa Roùsa Lacavalla",
+        "attribution_url": ""
+    },
+    {
+        "slug": "cyclists",
+        "label": "Cyclists",
+        "color": "0aa9b7",
+        "labelHistory": [],
+        "slugHistory": [],
+        "synonyms": [],
+        "count": 3061.0,
+        "public": true,
+        "image_UUID": "656e4872-15a4-4be4-8059-6e7c39b07c5d",
+        "attribution": "Scott & Emily (CC BY-NC 2.0)",
+        "attribution_url": "https://www.flickr.com/photos/snordq/6440512215/in/album-72157628461235121/"
+    },
+    {
+        "slug": "foodsharing",
+        "label": "Foodsharing",
+        "color": "4a3520",
+        "labelHistory": [],
+        "slugHistory": [],
+        "synonyms": [],
+        "count": 3209.0,
+        "public": true,
+        "image_UUID": "e060263a-9684-4065-85f3-460e9fffbd40",
+        "attribution": "Foodsharing.de & Offenblen.de",
+        "attribution_url": "http://offenblen.de/",
+        "description": "Foodsharing.de activists and members."
+    },
+    {
+        "slug": "yoga",
+        "label": "Yoga",
+        "color": "551A8B",
+        "labelHistory": [],
+        "slugHistory": [],
+        "synonyms": [
+            "yogis",
+            "jogi",
+            "yogi",
+            "yogini",
+            "jogini"
+        ],
+        "count": 1312,
+        "public": true,
+        "image_UUID": "ad2062d0-aadd-475d-bf85-2cd2e30a9d38",
+        "attribution": "Edit Sztazics",
+        "attribution_url": "https://unsplash.com/photos/GlhUl9WuFmA",
+        "description": "For practitioners of yoga."
+    },
+    {
+        "slug": "climbers",
+        "label": "Climbers",
+        "color": "a65e33",
+        "labelHistory": [],
+        "slugHistory": [],
+        "synonyms": [],
+        "count": 1060,
+        "public": true,
+        "image_UUID": "bfaf468a-2c48-4798-b1bb-bffd0c6b716b",
+        "attribution": "Daiyi",
+        "attribution_url": "http://www.daiyi.co/",
+        "description": "Climbers & mountain lovers."
+    },
+    {
+        "slug": "hikers",
+        "label": "Hikers",
+        "labelHistory": [],
+        "slugHistory": [],
+        "color": "82550f",
+        "synonyms": [
+            "hiking"
+        ],
+        "count": 2857,
+        "public": true,
+        "image_UUID": "0fd49df4-88e7-4380-b38a-3625e4b02dde",
+        "attribution": "Nova Togatorop",
+        "attribution_url": "http://novatogatorop.com/",
+        "description": "For outdoorsy people who love hiking in nature."
+    },
+    {
+        "slug": "sailors",
+        "label": "Sailors",
+        "labelHistory": [],
+        "slugHistory": [],
+        "color": "1a55a4",
+        "synonyms": [
+            "sailing",
+            "mariners",
+            "seamens",
+            "seafarers",
+            "boaters"
+        ],
+        "count": 606,
+        "image_UUID": "cef34c15-b527-4f89-a7a5-456f62ff9ce2",
+        "attribution": "Lance Asper",
+        "attribution_url": "https://unsplash.com/photos/SLf9CvojiPo",
+        "description": "For sailors and seafarers."
+    },
+    {
+        "slug": "artists",
+        "label": "Artists",
+        "labelHistory": [],
+        "slugHistory": [],
+        "synonyms": [],
+        "color": "cf2727",
+        "count": 1479,
+        "public": true,
+        "image_UUID": "c84f93f1-421d-4339-a61f-a5efc2d24297",
+        "attribution": "Kyson Dana",
+        "attribution_url": "https://unsplash.com/photos/HR_jVFpAtWI",
+        "description": "Creators & Creatives."
+    },
+    {
+        "slug": "rainbow-gathering",
+        "label": "Rainbow gathering",
+        "color": "e0cb3e",
+        "labelHistory": [],
+        "slugHistory": [],
+        "synonyms": [
+            "rainbows",
+            "rainbow",
+            "rainbow-ramily",
+            "rainbowfamily",
+            "rainbowgathering"
+        ],
+        "count": 1164,
+        "public": true,
+        "image_UUID": "d4a04ce4-3aeb-43a4-882b-43b1974d86e0",
+        "attribution": "Andreas Waguluz",
+        "attribution_url": "https://unsplash.com/photos/t6t2-gXKxXM"
+    },
+    {
+        "slug": "slackline",
+        "label": "Slackliners",
+        "color": "e0cb3e",
+        "labelHistory": [],
+        "slugHistory": [],
+        "synonyms": [
+            "slackliners",
+            "slacklining"
+        ],
+        "count": 303,
+        "public": true,
+        "image_UUID": "310f68af-3e77-451e-96a7-09132d26fdb4",
+        "attribution": "Sven Kopf",
+        "attribution_url": "http://www.challengingtheworld.de"
+    },
+    {
+        "slug": "spirituals",
+        "label": "Spirituals",
+        "color": "2587c0",
+        "labelHistory": [],
+        "slugHistory": [],
+        "synonyms": [
+            "spiritual",
+            "spirituality",
+            "healers"
+        ],
+        "count": 897,
+        "public": true,
+        "image_UUID": "dcb0ed04-cdd6-45ea-b773-e09320a4f759",
+        "attribution": "Tamarcus Brown",
+        "attribution_url": "https://unsplash.com/photos/md7mo1noGis"
+    },
+    {
+        "slug": "dancers",
+        "label": "Dancers",
+        "description": "Modern dance, salsa, African dance... what ever might be your thing! Anyone who's into any sort of artistic human movement!",
+        "color": "7c3b01",
+        "labelHistory": [],
+        "slugHistory": [],
+        "synonyms": [
+            "dancing",
+            "dance",
+            "dancer",
+            "choreographer",
+            "danceartist"
+        ],
+        "count": 814,
+        "public": true,
+        "image_UUID": "434018c8-4f4f-4054-9bd2-6618e9d5a77f",
+        "attribution": "Ardian Lumi",
+        "attribution_url": "https://unsplash.com/photos/6Woj_wozqmA"
+    },
+    {
+        "slug": "acroyoga",
+        "label": "Acroyoga",
+        "description": "Practisioners of acroyoga",
+        "color": "d9534f",
+        "labelHistory": [],
+        "slugHistory": [],
+        "synonyms": [
+            "acroyogis",
+            "acroyogi"
+        ],
+        "count": 232,
+        "public": true,
+        "image_UUID": "0ce0abdf-6898-4191-9a86-4f03807291b5",
+        "attribution": "Victor Freitas",
+        "attribution_url": "https://unsplash.com/photos/lorGjRP4HRE"
+    },
+    {
+        "slug": "jugglers",
+        "label": "Jugglers",
+        "description": "Juggling community.",
+        "color": "800080",
+        "labelHistory": [],
+        "slugHistory": [],
+        "synonyms": [
+            "juggling"
+        ],
+        "count": 84,
+        "public": true,
+        "image_UUID": "0ebcabec-2bc5-4eee-ab17-991b9dd52eae",
+        "attribution": "David Mornet (CC BY-NC-ND 2.0)",
+        "attribution_url": "https://www.flickr.com/photos/davidmornet/31908214824/in/photolist-QBBWAU-REzoGQ-REzmy1-QBBQBE-REzoVA-RQuQvh-jbKv2U-a1xYJK-JegHv-iR92Q-RU94Pt-QEbpfZ-RHbPen-aEvUSf-QBBTbN-RU94tt-5Crx9x-bn9BKg-4soNPq-E2PyUC-5VW5TF-epr1Rh-67Juxm-eDdAKh-REzqUL-RHbQJg-X3U5SJ-67Ejpz-PyPTu-4bRLHQ-67Ej8V-6vdnz-fh3bNP-9DmmHb-QBBRGf-QBBVeL-cquCr5-53TUBL-6xdANq-2syaE-a1ASbN-6DyP8m-RQuQqN-VmsKPu-boKX8L-7faAjp-6vdo6-4otimz-2o9T-rPPnMm"
+    },
+    {
+        "slug": "vanlife",
+        "label": "Van life",
+        "description": "For folks hitting the nomadic road in their vans, camper vans, motorhomes, buses or what have you!",
+        "color": "7c3b01",
+        "labelHistory": [],
+        "slugHistory": [],
+        "synonyms": [
+            "campervan",
+            "motorhome",
+            "kombi",
+            "unimog"
+        ],
+        "count": 117,
+        "public": true,
+        "image_UUID": "4f7805e7-b5e6-4b40-bb32-3aafbe1bbc74",
+        "attribution": "Brina Blum",
+        "attribution_url": "https://unsplash.com/photos/LUfmqLfEAoE"
+    },
+    {
+        "slug": "lgbtq",
+        "label": "LGBTQ",
+        "color": "e5640d",
+        "labelHistory": [
+            "LGBT"
+        ],
+        "slugHistory": [
+            "lgbt"
+        ],
+        "synonyms": [
+            "GLBT",
+            "LGBTQQ",
+            "LGB&T",
+            "LGBTIQ",
+            "trans*",
+            "LGBT",
+            "LGBT+",
+            "LGBTQI+",
+            "LGBTQIAP+"
+        ],
+        "count": 1426.0,
+        "public": true,
+        "image_UUID": "69a500a4-a16e-4c4d-9981-84fbe310d531",
+        "attribution": "Wikipedia (CC BY 2.0)",
+        "attribution_url": "https://commons.wikimedia.org/wiki/File:Rainbow_flag_and_blue_skies.jpg#/media/File:Rainbow_flag_and_blue_skies.jpg"
+    }
+]


### PR DESCRIPTION
#### Proposed Changes
* Add random background image ids to the mock data  (using the tribe dump file (10-20-2018) provided by Mikael)
* This lets the mock tribes data use random images currently used by production tribes from the CDN

#### Testing Instructions

* Add mock tribe data via `npm run test-data:tribes 50`
* Add some users via `npm run test-data:users 10 admin1`
* Login as admin1 (L: admin1 PW: password123)
* Verify tribes have background images

Fixes 
This was one more issue related to #462.  
