### PR TITLE
Search: update CSP rules for new tile addresses

### DIFF
--- a/config/lib/express.js
+++ b/config/lib/express.js
@@ -333,7 +333,7 @@ module.exports.initHelmetHeaders = function (app) {
         '*.tiles.mapbox.com', // Map tiles
         'api.mapbox.com', // Map tiles/Geocoding
         '*.tile.openstreetmap.org', // Map tiles
-        '*.vis.earthdata.nasa.gov', // Map tiles
+        '*.earthdata.nasa.gov', // Map tiles
         '*.facebook.com',
         '*.fbcdn.net', // Facebook releated
         '*.fbsbx.com', // Facebook related


### PR DESCRIPTION
Since in https://github.com/Trustroots/trustroots/pull/724 we changed Nasa earth data URLs for tiles, we need to update also content security policy URL.

Not an issue on every browser with localhost but this will get rid of warnings nevertheless.

## Testing

- (At least on Firefox)
- Browse map on localhost without Mapbox settings configured
- Change to "satellite" tiles
- Before the change: CSP warnings in console
- After the change: 👌 