### PR TITLE
Set birth date back to unknown

### DIFF
--- a/modules/core/client/directives/tr-date-select.client.directive.js
+++ b/modules/core/client/directives/tr-date-select.client.directive.js
@@ -77,7 +77,7 @@
                 ngModel.$setViewValue(m.format('YYYY-MM-DD'));
               }
             } else {
-              ngModel.$setViewValue();
+              ngModel.$setViewValue(null);
             }
           });
 


### PR DESCRIPTION
#### Proposed Changes

Set birthdate to null whenever the user manually selects an invalid date (day, month, or year are not selected)

#### Testing Instructions

Test that changing the value from a valid one to an invalid one enables the save button
Test that saving the date both to a valid value and an invalid one work correctly
Test that whenever saving other fields the date will not be sent if it was not changed

Fixes #792
