### PR TITLE
Make all location fields autocomplete addresses/places

### DIFF
--- a/modules/core/client/directives/tr-location.client.directive.js
+++ b/modules/core/client/directives/tr-location.client.directive.js
@@ -34,6 +34,7 @@
       scope: {
         value: '=ngModel',
         // `?` makes these optional
+        limitLocationTypes: '=?',
         trLocationChange: '=?',
         trLocationNotfound: '=?',
         trLocationCenter: '=?',
@@ -61,7 +62,12 @@
         element.attr('typeahead-min-length', attr.typeaheadMinLength ? parseInt(attr.typeaheadMinLength, 10) : 3);
         element.attr('typeahead-wait-ms', attr.typeaheadWaitMs ? parseInt(attr.typeaheadWaitMs, 10) : 300);
         element.attr('typeahead-on-select', 'trLocation.onSelect($item, $model, $label, $event)');
-        element.attr('uib-typeahead', 'trTitle as address.trTitle for address in trLocation.searchSuggestions($viewValue)');
+        element.attr('uib-typeahead', 'trTitle as address.trTitle for address in trLocation.searchSuggestions('
+          + getQueryParameters(scope.limitLocationTypes) + ')');
+
+        function getQueryParameters(limitLocationTypes) {
+          return limitLocationTypes ? '$viewValue, "country,region,place,locality,neighborhood"' : '$viewValue';
+        }
 
         // Stop infinite rendering on $compile
         element.removeAttr('tr-location');
@@ -101,9 +107,9 @@
         /**
          * Get geolocation suggestions
          */
-        function searchSuggestions(query) {
+        function searchSuggestions(query, types) {
           $scope.trLocationNotfound = false;
-          return LocationService.suggestions(query).then(function (suggestions) {
+          return LocationService.suggestions(query, types).then(function (suggestions) {
             // Enter was pressed before we got these results, thus just pick first
             if ($scope.skipSuggestions) {
               $scope.skipSuggestions = false;

--- a/modules/core/client/services/location.client.service.js
+++ b/modules/core/client/services/location.client.service.js
@@ -65,16 +65,34 @@
      */
     function getBounds(geolocation) {
       if (!geolocation || !geolocation.bbox || !angular.isArray(geolocation.bbox) || geolocation.bbox.length !== 4) {
-        return false;
+        var center = geolocation.center;
+        if (!geolocation || !center || !angular.isArray(center) || center.length !== 2) {
+          return false;
+        } else {
+          var borderFromCenter = .002;
+          return getBoundsObject(
+            parseFloat(center[1]) + borderFromCenter,
+            parseFloat(center[0]) - borderFromCenter,
+            parseFloat(center[1]) - borderFromCenter,
+            parseFloat(center[0]) + borderFromCenter);
+        }
       }
+      return getBoundsObject(
+        parseFloat(geolocation.bbox[3]),
+        parseFloat(geolocation.bbox[2]),
+        parseFloat(geolocation.bbox[1]),
+        parseFloat(geolocation.bbox[0]));
+    }
+
+    function getBoundsObject(northEastLat, northEastLng, southWestLat, southWestLng) {
       return {
         'northEast': {
-          'lat': parseFloat(geolocation.bbox[3]),
-          'lng': parseFloat(geolocation.bbox[2])
+          'lat': northEastLat,
+          'lng': northEastLng
         },
         'southWest': {
-          'lat': parseFloat(geolocation.bbox[1]),
-          'lng': parseFloat(geolocation.bbox[0])
+          'lat': southWestLat,
+          'lng': southWestLng
         }
       };
     }
@@ -132,7 +150,7 @@
         'https://api.mapbox.com/geocoding/v5/mapbox.places/' + val + '.json'
         + '?access_token=' + appSettings.mapbox.publicKey
         + '&language=en'
-        + '&types=' + (types || 'country,region,place,locality,neighborhood'),
+        + (types ? '&types=' + types : ''),
         {
           // Tells Angular-Loading-Bar to ignore this http request
           // @link https://github.com/chieffancypants/angular-loading-bar#ignoring-particular-xhr-requests

--- a/modules/users/client/views/profile/profile-edit-locations.client.view.html
+++ b/modules/users/client/views/profile/profile-edit-locations.client.view.html
@@ -22,6 +22,7 @@
                    class="form-control"
                    placeholder="City, Country"
                    id="location-living"
+                   limit-location-types="true"
                    tr-location
                    tr-location-center="profileEditLocations.locationLivingCenter"
                    ng-model="profileEditLocations.user.locationLiving"
@@ -38,6 +39,7 @@
                    class="form-control"
                    placeholder="City, Country"
                    id="location-from"
+                   limit-location-types="true"
                    tr-location
                    tr-location-center="profileEditLocations.locationFromCenter"
                    ng-model="profileEditLocations.user.locationFrom"


### PR DESCRIPTION
#### Proposed Changes

Remove location type filters for all map search inputs and only add them for `From` and `Living` in the [user's profile](http://https://trustroots.org/profile/edit/locations).

#### Testing Instructions

Test that previous filters still apply for `From` and `Living` in [Edit Locations](http://https://trustroots.org/profile/edit/locations) but that they do not apply in other fields. For example in Search or Host you should be able to search for a coffee place, public park or other Point of Interest. 

Some POIs will still be missing since it's not in our control to add them.

Fixes #668