### PR TITLE
Update Node.js version in package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - 10
+  - 11
 env:
   - RUN=lint
   - RUN=test:client

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "url": "https://github.com/Trustroots/trustroots"
   },
   "engines": {
-    "node": ">=8.0.0 <11",
-    "npm": ">=5.0.0",
+    "node": ">=10.0.0",
+    "npm": ">=6.0.0",
     "mongodb": ">=3.6 <=4.0"
   },
   "browserslist": [


### PR DESCRIPTION
- Drop support for Node.js 8 since we're not actively testing it anyway.
- Expect at least the current latest LTS v10
- Allow Node.js v11 as it's current release

https://github.com/nodejs/Release#release-schedule

Convo https://trustroots.slack.com/archives/C08SENA9Z/p1541149972068100