### PR TITLE
Sign-out behaves differently for mobile view

### DIFF
--- a/modules/pages/client/views/navigation.client.view.html
+++ b/modules/pages/client/views/navigation.client.view.html
@@ -38,7 +38,8 @@
     Account
   </a>
 
-  <a href="/api/auth/signout"
+  <a ng-click="app.signout($event)"
+     href="/api/auth/signout"
      target="_top"
      class="list-group-item">
     <i class="icon-sign-out icon-fw icon-lg"></i>


### PR DESCRIPTION
#### Proposed Changes

Add ng-click to mobile sign-out button in order to get the same behavior as on desktop

#### Testing Instructions

Do login/logout and relogin and see that the behavior is the same on desktop and mobile browser

Fixes #810
