### PR TITLE
Replying "no" to push notification question does not persist between sessions

### DIFF
--- a/modules/core/client/services/push.client.service.js
+++ b/modules/core/client/services/push.client.service.js
@@ -17,6 +17,7 @@
     $q) {
 
     var LOCKER_KEY = 'tr.push';
+    var NOT_CLEARED_ON_SIGN_OUT_NAMESPACE = 'notClearedOnSignOut';
 
     var push = {
       isSupported: getIsSupported(),
@@ -104,7 +105,7 @@
       // - locker isn't supported (we can't store status)
       // - we've asked already (stored with `locker`)
       // - no authenticated user
-      if (!locker.supported() || locker.get(pushAskedKey) || !Authentication.user) {
+      if (!locker.supported() || locker.namespace(NOT_CLEARED_ON_SIGN_OUT_NAMESPACE).get(pushAskedKey) || !Authentication.user) {
         return;
       }
 
@@ -125,7 +126,7 @@
           // When modal is closed/dismissed
           $scope.$on('modal.closing', function () {
             // Store info that we've now asked and user reacted
-            locker.put(pushAskedKey, 'yes');
+            locker.namespace(NOT_CLEARED_ON_SIGN_OUT_NAMESPACE).put(pushAskedKey, 'yes');
           });
 
         },


### PR DESCRIPTION
#### Proposed Changes

Save `tr.push.asked` key on a different namespace so that it doesn't get cleared on sign out

#### Testing Instructions

The testing should be done on a desktop browser if tested before #811

1. Login, answer question `Can we send you push notifications?` with either yes or no.
2. Logout
3. Login again and check that the question popup is not shown again

Fixes #585