### PR TITLE
Search: exclude suspended users from search

### DIFF
--- a/modules/offers/server/controllers/offers.server.controller.js
+++ b/modules/offers/server/controllers/offers.server.controller.js
@@ -527,6 +527,16 @@ exports.list = function (req, res) {
     },
   });
 
+  // Check for suspended users
+  query.push({
+    $match: {
+      'user.public': true,
+      // We could do this, but since suspended users
+      // are always `public:false`, we don't have to.
+      // 'user.roles': { $ne: 'suspended' }
+    },
+  });
+
   // Last seen filter
   if (filters.hasObjectFilter('seen')) {
     query.push({

--- a/modules/offers/server/controllers/offers.server.controller.js
+++ b/modules/offers/server/controllers/offers.server.controller.js
@@ -527,13 +527,12 @@ exports.list = function (req, res) {
     },
   });
 
-  // Check for suspended users
+  // Check for suspended and shadowbanned users
   query.push({
     $match: {
+      // We could simply do this as performance improvement, but shadowbanned users are "public".
       'user.public': true,
-      // We could do this, but since suspended users
-      // are always `public:false`, we don't have to.
-      // 'user.roles': { $ne: 'suspended' }
+      'user.roles': { $nin: ['suspended', 'shadowban'] },
     },
   });
 

--- a/modules/offers/tests/server/offer-search.server.routes.tests.js
+++ b/modules/offers/tests/server/offer-search.server.routes.tests.js
@@ -1148,7 +1148,43 @@ describe('Offer search tests', function () {
       });
     });
   });
+  /*
+  describe('Exclude offers from shadowbanned, suspended and non-public users', () => {
+    afterEach(async () => {
+      await utils.signOut(agent);
+    });
 
+    ['shadowban', 'suspended'].forEach(role => {
+      it(`should not see users with "${role}"`, async () => {
+        user3.roles = [role];
+        await user3.save();
+        await utils.signIn(credentials, agent);
+
+        const { body } = await agent
+          .get('/api/offers' + testLocations.Europe.queryBoundingBox)
+          .expect(200)
+          .end();
+
+        // body.features.should.have.lengthOf(1);
+        console.log('🚀', role, body); //eslint-disable-line
+      });
+    });
+
+    it(`should not see users which are not public`, async () => {
+      user3.public = false;
+      await user3.save();
+      await utils.signIn(credentials, agent);
+
+      const { body } = await agent
+        .get('/api/offers' + testLocations.Europe.queryBoundingBox)
+        .expect(200)
+        .end();
+
+      // body.features.should.have.lengthOf(1);
+      console.log('🚀 non public', body); //eslint-disable-line
+    });
+  });
+*/
   it('should be able to get offers from users with circles in common and have "showOnlyInMyCircles" set', function (done) {
     // Verify that offers where showOnlyInMyCircles is true are only appearing
     // in searches where the authenticated user (user1) has at least one circle


### PR DESCRIPTION
Instead of manually setting their hosting activity to "no", we can just exclude them in the search.

Work in progress