### PR TITLE
Encode special characters while querying mapbox api for preventing bad request

### DIFF
--- a/modules/core/client/services/location.client.service.js
+++ b/modules/core/client/services/location.client.service.js
@@ -129,7 +129,7 @@
       }
 
       return $http.get(
-        'https://api.mapbox.com/geocoding/v5/mapbox.places/' + val + '.json'
+        'https://api.mapbox.com/geocoding/v5/mapbox.places/' + encodeURIComponent(val) + '.json'
         + '?access_token=' + appSettings.mapbox.publicKey
         + '&language=en'
         + '&types=' + (types || 'country,region,place,locality,neighborhood'),


### PR DESCRIPTION
#### Proposed Changes

* Encoding special characters(?, #, & etc.) while querying mapbox api for preventing bad request

#### Testing Instructions

* Enter special characters suc as '?', '#', '&' etc. into location search components. It should not make the user log out  

Fixes #814 
