### PR TITLE
Validate the length of location value before mapbox api call

### DIFF
--- a/modules/core/client/services/location.client.service.js
+++ b/modules/core/client/services/location.client.service.js
@@ -125,11 +125,11 @@
     function suggestions(val, types) {
       if (!appSettings.mapbox || !appSettings.mapbox.publicKey) {
         $log.warn('No Mapbox settings found; cannot do geocoding!');
-        return [];
+        return Promise.resolve([]);
       }
 
       if (val == null || val.length <= 1) {
-        return [];
+        return Promise.resolve([]);
       }
 
       return $http.get(
@@ -149,7 +149,7 @@
               return geolocation;
             });
           } else {
-            return [];
+            return Promise.resolve([]);
           }
         });
     }

--- a/modules/core/client/services/location.client.service.js
+++ b/modules/core/client/services/location.client.service.js
@@ -128,6 +128,10 @@
         return [];
       }
 
+      if (val == null || val.length <= 1) {
+        return [];
+      }
+
       return $http.get(
         'https://api.mapbox.com/geocoding/v5/mapbox.places/' + val + '.json'
         + '?access_token=' + appSettings.mapbox.publicKey


### PR DESCRIPTION
#### Proposed Changes

* Validate the length of location value before mapbox api call 

#### Testing Instructions

* Type one character then check if there is a request to mapbox api

Fixes #814 
