### PR TITLE
Integrate message-center module to the app

### DIFF
--- a/config/assets/default.js
+++ b/config/assets/default.js
@@ -60,7 +60,6 @@ module.exports = {
         'node_modules/leaflet-active-area/src/leaflet.activearea.js',
         'node_modules/angular-waypoints/dist/angular-waypoints.all.js',
         'node_modules/ng-file-upload/dist/ng-file-upload.js',
-        'node_modules/message-center/message-center.js',
         'node_modules/chosen-js/chosen.jquery.js',
         'node_modules/angular-chosen-localytics/dist/angular-chosen.js',
         'node_modules/angular-loading-bar/build/loading-bar.js',

--- a/modules/core/client/app/config.js
+++ b/modules/core/client/app/config.js
@@ -34,7 +34,6 @@ var AppConfig = (function () {
     'ui-leaflet',
     'ngFileUpload',
     'zumba.angular-waypoints',
-    'MessageCenterModule',
     'localytics.directives',
     'angular-loading-bar',
     'trTrustpass',

--- a/modules/core/client/directives/message-center.client.directive.js
+++ b/modules/core/client/directives/message-center.client.directive.js
@@ -1,0 +1,62 @@
+/**
+ * Modified from
+ * @link https://github.com/e0ipso/message-center
+ *
+ * Licensed under GNU General Public License v2.0
+ * @link https://github.com/e0ipso/message-center/blob/0187464a2dacfdb74fedb265302cb71e48df7e93/LICENSE.txt
+ *
+ * See also modules/core/client/services/message-center-client.service.js
+ *
+ * See usage instructions from https://github.com/e0ipso/message-center
+ */
+
+(function () {
+  'use strict';
+
+  /**
+   * Directive for error/success/info etc notifications
+   */
+  angular
+    .module('core')
+    .directive('mcMessages', mcMessages);
+
+  /* @ngInject */
+  function mcMessages($rootScope, messageCenterService) {
+    var templateString = '\
+    <div id="mc-messages-wrapper">\
+      <div class="alert alert-{{ message.type }} {{ animation }}" ng-repeat="message in mcMessages">\
+        <a class="close" ng-click="message.close();" data-dismiss="alert" aria-hidden="true">&times;</a>\
+        <span ng-switch on="message.html">\
+          <span ng-switch-when="true">\
+            <span ng-bind-html="message.message"></span>\
+          </span>\
+          <span ng-switch-default>\
+            {{ message.message }}\
+          </span>\
+        </span>\
+      </div>\
+    </div>\
+    ';
+    return {
+      restrict: 'EA',
+      template: templateString,
+      link: function (scope, element, attrs) {
+        // Bind the messages from the service to the root scope.
+        messageCenterService.flush();
+        var changeReaction = function () { // event, to, from
+          // Update 'unseen' messages to be marked as 'shown'.
+          messageCenterService.markShown();
+          // Remove the messages that have been shown.
+          messageCenterService.removeShown();
+          $rootScope.mcMessages = messageCenterService.mcMessages;
+          messageCenterService.flush();
+        };
+        if (angular.isUndefined(messageCenterService.offlistener)) {
+          messageCenterService.offlistener = $rootScope.$on('$locationChangeSuccess', changeReaction);
+        }
+        scope.animation = attrs.animation || 'fade in';
+      }
+    };
+  }
+
+}());

--- a/modules/core/client/services/message-center-client.service.js
+++ b/modules/core/client/services/message-center-client.service.js
@@ -1,0 +1,119 @@
+/**
+ * Modified from
+ * @link https://github.com/e0ipso/message-center
+ *
+ * Licensed under GNU General Public License v2.0
+ * @link https://github.com/e0ipso/message-center/blob/0187464a2dacfdb74fedb265302cb71e48df7e93/LICENSE.txt
+ *
+ * See also modules/core/client/directives/message-center.client.directive.js
+ */
+
+(function () {
+  'use strict';
+
+  /**
+   * Service for error/success/info etc notifications
+   *
+   * See usage instructions from https://github.com/e0ipso/message-center
+   */
+  angular
+    .module('core')
+    .provider('$messageCenterService', MessageCenterServiceProvider)
+    .service('messageCenterService', MessageCenterService);
+
+  /* @ngInject */
+  function MessageCenterServiceProvider() {
+    var _this = this;
+    _this.options = {};
+    _this.setGlobalOptions = function (options) {
+      _this.options = options;
+    };
+    _this.getOptions = function () {
+      return _this.options;
+    };
+    this.$get = function () {
+      return {
+        setGlobalOptions: _this.setGlobalOptions,
+        options: _this.options,
+        getOptions: _this.getOptions
+      };
+    };
+  }
+
+  /* @ngInject */
+  function MessageCenterService($rootScope, $sce, $timeout, $messageCenterService) {
+    return {
+      mcMessages: this.mcMessages || [],
+      offlistener: this.offlistener || undefined,
+      status: {
+        unseen: 'unseen',
+        shown: 'shown',
+        /** @var Odds are that you will show a message and right after that
+         * change your route/state. If that happens your message will only be
+         * seen for a fraction of a second. To avoid that use the "next"
+         * status, that will make the message available to the next page */
+        next: 'next',
+        /** @var Do not delete this message automatically. */
+        permanent: 'permanent'
+      },
+      add: function (type, message, options) {
+        var availableTypes = ['info', 'warning', 'danger', 'success'],
+            service = this;
+        options = options || {};
+        var options = angular.extend({}, $messageCenterService.getOptions(), options);
+        if (availableTypes.indexOf(type) === -1) {
+          // eslint-disable-next-line no-throw-literal
+          throw 'Invalid message type';
+        }
+        var messageObject = {
+          type: type,
+          status: options.status || this.status.unseen,
+          processed: false,
+          close: function () {
+            return service.remove(this);
+          }
+        };
+        messageObject.message = options.html ? $sce.trustAsHtml(message) : message;
+        messageObject.html = !!options.html;
+        if (angular.isDefined(options.timeout)) {
+          messageObject.timer = $timeout(function () {
+            messageObject.close();
+          }, options.timeout);
+        }
+        this.mcMessages.push(messageObject);
+        return messageObject;
+      },
+      remove: function (message) {
+        var index = this.mcMessages.indexOf(message);
+        this.mcMessages.splice(index, 1);
+      },
+      reset: function () {
+        this.mcMessages = [];
+      },
+      removeShown: function () {
+        for (var index = this.mcMessages.length - 1; index >= 0; index--) {
+          if (this.mcMessages[index].status === this.status.shown) {
+            this.remove(this.mcMessages[index]);
+          }
+        }
+      },
+      markShown: function () {
+        for (var index = this.mcMessages.length - 1; index >= 0; index--) {
+          if (!this.mcMessages[index].processed) {
+            if (this.mcMessages[index].status === this.status.unseen) {
+              this.mcMessages[index].status = this.status.shown;
+              this.mcMessages[index].processed = true;
+            }
+            else if (this.mcMessages[index].status === this.status.next) {
+              this.mcMessages[index].status = this.status.unseen;
+            }
+          }
+        }
+      },
+      flush: function () {
+        $rootScope.mcMessages = this.mcMessages;
+      }
+    };
+  }
+
+}());

--- a/package-lock.json
+++ b/package-lock.json
@@ -11650,10 +11650,6 @@
         "readable-stream": "^2.0.1"
       }
     },
-    "message-center": {
-      "version": "git+https://github.com/Trustroots/message-center.git#aeec6be1c22c69568f7d78896df261e56e427e72",
-      "from": "git+https://github.com/Trustroots/message-center.git#aeec6be1c22c69568f7d78896df261e56e427e72"
-    },
     "method-override": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/method-override/-/method-override-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,6 @@
     "lodash": "~4.17.11",
     "medium-editor": "~5.23.0",
     "merge-stream": "~1.0.1",
-    "message-center": "git+https://github.com/Trustroots/message-center.git#aeec6be1c22c69568f7d78896df261e56e427e72",
     "method-override": "~3.0.0",
     "migrate": "~0.2.4",
     "mkdir-recursive": "~0.4.0",


### PR DESCRIPTION
Original module: https://github.com/e0ipso/message-center

Since there were issues with deploying this module directly from GitHub and the actual version in NPM wants to run `bower install`, I'm bringing this directly to the codebase.

Annoying but seems like the most robust solution for now.