### PR TITLE
Build: name functions for better visibility to Gulp tasks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -176,7 +176,7 @@ gulp.task('env:prod', gulp.series(
 ));
 
 // Watch files for changes
-gulp.task('watch', function (done) {
+gulp.task('watch', function watch(done) {
   // Start Refresh
   plugins.refresh.listen();
 
@@ -209,7 +209,7 @@ gulp.task('watch', function (done) {
 });
 
 // Watch server test files
-gulp.task('watch:server:run-tests', function () {
+gulp.task('watch:server:run-tests', function watchServerRunTests() {
   // Start Refresh
   plugins.refresh.listen();
 
@@ -240,7 +240,7 @@ gulp.task('watch:server:run-tests', function () {
 });
 
 // ESLint JS linting task
-gulp.task('eslint', function () {
+gulp.task('eslint', function eslint() {
   var lintAssets = _.union(
     [
       defaultAssets.server.gulpConfig,
@@ -268,7 +268,7 @@ gulp.task('eslint', function () {
 // ESLint JS linting task for Angular files
 gulp.task('eslint-angular', gulp.series(
   loadConfig,
-  function () {
+  function eslintAngular() {
     var lintAssets = _.union(
       assets.client.js,
       // Don't lint dist and lib files
@@ -298,17 +298,17 @@ gulp.task('scripts', gulp.series(
 ));
 
 // Clean JS files -task
-gulp.task('clean:js', function () {
+gulp.task('clean:js', function cleanJS() {
   return del(['public/dist/*.js']);
 });
 
 // Clean CSS files -task
-gulp.task('clean:css', function () {
+gulp.task('clean:css', function cleanCSS() {
   return del(['public/dist/*.css']);
 });
 
 // CSS styles task
-gulp.task('styles', function () {
+gulp.task('styles', function buildStyles() {
   if (process.env.NODE_ENV === 'production') {
 
     var cssStream = gulp.src(defaultAssets.client.lib.css)
@@ -354,7 +354,6 @@ gulp.task('styles', function () {
 // we can pick modules we need. Therefore we need
 // to manually compile our UIB templates.
 function angularUibTemplatecache() {
-
   var uibModulesStreams = new MergeStream();
 
   // Loop trough module names
@@ -464,7 +463,6 @@ function karmaWatch(done) {
     singleRun: false
   }, done).start();
 }
-
 
 // Analyse code for potential errors
 gulp.task('lint', gulp.parallel('eslint', 'eslint-angular'));


### PR DESCRIPTION
This will give names for some of these `<anonymous>` lines:

```
[00:26:27] Starting 'lint'...
[00:26:27] Starting 'eslint'...
[00:26:27] Starting 'eslint-angular'...
[00:26:27] Starting 'loadConfig'...
[00:26:27] Finished 'loadConfig' after 384 μs
[00:26:27] Starting '<anonymous>'...
[00:26:30] Finished '<anonymous>' after 3.4 s
[00:26:30] Finished 'eslint-angular' after 3.4 s
[00:26:32] Finished 'eslint' after 5.33 s
[00:26:32] Finished 'lint' after 5.33 s
[00:27:38] Starting 'lint'...
[00:27:38] Starting 'eslint'...
[00:27:38] Starting 'eslint-angular'...
[00:27:38] Starting 'loadConfig'...
[00:27:38] Finished 'loadConfig' after 223 μs
[00:27:38] Starting '<anonymous>'...
[00:27:41] Finished '<anonymous>' after 3.09 s
[00:27:41] Finished 'eslint-angular' after 3.09 s
[00:27:44] Finished 'eslint' after 5.56 s
[00:27:44] Finished 'lint' after 5.56 s
[00:27:48] Starting 'lint'...
[00:27:48] Starting 'eslint'...
[00:27:48] Starting 'eslint-angular'...
[00:27:48] Starting 'loadConfig'...
[00:27:48] Finished 'loadConfig' after 162 μs
[00:27:48] Starting '<anonymous>'...
[00:27:50] Finished '<anonymous>' after 2.55 s
[00:27:50] Finished 'eslint-angular' after 2.56 s
[00:27:52] Finished 'eslint' after 4.71 s
[00:27:52] Finished 'lint' after 4.71 s
[00:27:56] Starting 'lint'...
[00:27:56] Starting 'eslint'...
[00:27:56] Starting 'eslint-angular'...
[00:27:56] Starting 'loadConfig'...
[00:27:56] Finished 'loadConfig' after 200 μs
[00:27:56] Starting '<anonymous>'...
[00:27:59] Finished '<anonymous>' after 2.97 s
```