### PR TITLE
added option to ansible for selecting branch for cmdline

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -7,10 +7,33 @@ will have `playbooks/initdigitalocean.yml`.
 
 
 
-### examples of running ansible
+## examples of running ansible
+
+### checking behaviour of --limit
+```
+ansible-playbook playbooks/hetznerinit.yml --limit staging --list-hosts
+```
+
+### running ansible on all server in "--check" mode, not changing things
 
 ```
-# running ansible on all server in "--check" mode, not changing things
 ansible-playbook --check playbooks/hetznerinit.yml
+```
+
+### running ansible on only dev server
+```
+ansible-playbook playbooks/hetznerinit.yml --limit dev
+```
+
+### running ansible on dev and staging
+```
+ansible-playbook playbooks/hetznerinit.yml --limit non-prod
+```
+
+### deploy specific branch
+### branch can be the full 40-character SHA-1 hash, the literal string HEAD, a branch name, or a tag name.
+
+```
+ansible-playbook playbooks/trustroots.yml --limit dev --extra-vars "version=any_branch"
 ```
 

--- a/ansible/hosts
+++ b/ansible/hosts
@@ -1,12 +1,20 @@
-# Use ansible_ssh_user=root for setup
-
 [hetzner]
-dev.trustroots.org     ansible_ssh_user=guaka
+dev.trustroots.org ansible_ssh_user=guaka
 staging.trustroots.org ansible_ssh_user=guaka
 
+
+[non-prod]
+dev.trustroots.org ansible_ssh_user=guaka
+staging.trustroots.org ansible_ssh_user=guaka
+
+
 [dev]
-dev.trustroots.org   
-staging.trustroots.org
+dev.trustroots.org ansible_ssh_user=guaka
+
+
+[staging]
+staging.trustroots.org ansible_ssh_user=guaka
 
 
 [prod]
+trustroots.org 

--- a/ansible/playbooks/trustroots.yml
+++ b/ansible/playbooks/trustroots.yml
@@ -1,5 +1,7 @@
 ---
 - hosts: dev
+  vars:
+    version: "{{ version }}"
   become: yes
 
   roles:

--- a/ansible/roles/trustroots/tasks/main.yml
+++ b/ansible/roles/trustroots/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Clone/pull project repo
-  git: repo=https://github.com/trustroots/trustroots.git dest=/srv/trustroots force=yes
+  git: repo=https://github.com/trustroots/trustroots.git dest=/srv/trustroots force=yes version={{ version }}
   tags:
     - git
 


### PR DESCRIPTION
#### Proposed Changes
* when running ansible, one can now specify the version/branch of trustroot that git pulls

(needed to restructure the ansible inventory so that only dev or only staging can be selected with ansible's --limit paramter.. )

* added some more examples to ansible/README.md

* added ssh user name paramter to rest of hosts in ansible inventory


#### Testing Instructions
ansible-playbook playbooks/trustroots.yml --limit dev --extra-vars "version=your_branch_name"

Fixes # 
