### PR TITLE
Add command line options for seeding

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -130,13 +130,15 @@ For more custom setups, you can alternatively run the scripts for generating dat
 1. To add tribes, run `npm run seed:tribes 50` — This will create 50 tribes.
     * Run this prior to adding users to add users to tribes automatically
 
-2. To add users, run `npm run seed:users 1000 adminusername` — This will create 1000 users and hosting offers. `adminusername` is optional (a-z0-9) and will create an admin user.
+2. To add users, run `npm run seed:users 1000 -- --userNames adminusername` — This will create 1000 users and hosting offers. `adminusername` is optional (a-z0-9) and will create an admin user.
     * It can take up to 5 minutes. Mongoose might complain about duplicates — just ignore these errors.
     * To see the result, log in with your chosen username and password `password123`.
-    * Additional admin usernames are also supported (eg. `npm run seed:users 1000 admin1 admin2 admin3`)
+    * Additional admin usernames are also supported (eg. `npm run seed:users 1000 -- --userNames admin1 admin2 admin3`)
     * If tribes exist, users will also be added to random tribes
 
 3. To add messages, run `npm run seed:messages 1000 10` — This will create 1000 message threads between random users with up to 10 messages in each thread.
+
+All scripts additionally support `--debug` and `--limit` flags showing database debug information and not creating new elements if the number of database items already exist respectively.
 
 ## Clean database
 

--- a/bin/fillTestData/Messages.js
+++ b/bin/fillTestData/Messages.js
@@ -64,11 +64,9 @@ var addThreads = function () {
     console.log('...this might really take a while... go grab some coffee!');
   }
 
-  if (debug) {
-    console.log(chalk.white('--'));
-    console.log(chalk.green('Trustroots test tribes data'));
-    console.log(chalk.white('--'));
-  }
+  console.log(chalk.white('--'));
+  console.log(chalk.green('Trustroots test tribes data'));
+  console.log(chalk.white('--'));
 
   // Override debug mode to use the option set by the user
   config.db.debug = debug;

--- a/bin/fillTestData/Messages.js
+++ b/bin/fillTestData/Messages.js
@@ -179,7 +179,8 @@ var addThreads = function () {
                             else {
                               process.stdout.write('.');
                               threadsSaved += 1;
-                              if (threadsSaved >= numThreads) {
+                              if ((limit && (threadsSaved + threads.length >= numThreads))
+                                  || !limit && ((threadsSaved >= numThreads))) {
                                 console.log('');
                                 console.log(chalk.green(threads.length + ' threads existed in the database.'));
                                 console.log(chalk.green(threadsSaved + ' threads successfully added.'));

--- a/bin/fillTestData/Messages.js
+++ b/bin/fillTestData/Messages.js
@@ -177,9 +177,13 @@ var addThreads = function () {
                               console.log(err);
                             }
                             else {
+                              process.stdout.write('.');
                               threadsSaved += 1;
                               if (threadsSaved >= numThreads) {
-                                console.log(chalk.green('Done with ' + numThreads + ' test threads!'));
+                                console.log('');
+                                console.log(chalk.green(threads.length + ' threads existed in the database.'));
+                                console.log(chalk.green(threadsSaved + ' threads successfully added.'));
+                                console.log(chalk.green('Database now contains ' + (threads.length + threadsSaved) + ' threads.'));
                                 console.log(chalk.white('')); // Reset to white
                                 process.exit(0);
                               }

--- a/bin/fillTestData/Messages.js
+++ b/bin/fillTestData/Messages.js
@@ -22,12 +22,12 @@ var argv = yargs.usage('$0 <numberOfThreads> <maxMessages>',
         describe: 'Maximum number of messages per thread to add',
         type: 'number'
       })
-      .boolean('verbose')
+      .boolean('debug')
       .boolean('limit')
-      .describe('verbose', 'Enable extra database output (default=false)')
+      .describe('debug', 'Enable extra database output (default=false)')
       .describe('limit', 'If threads already exist in the database, only add up to the number of threads (default=false)')
       .example('$0 100 10', 'Adds 100 random threads wth up to 10 messages per thread to the database')
-      .example('$0 100 10 --verbose', 'Adds 100 random threads wth up to 10 messages per thread to the database with verbose database output')
+      .example('$0 100 10 --debug', 'Adds 100 random threads wth up to 10 messages per thread to the database with debug database output')
       .example('$0 10 5 --limit', 'Adds up to 10 randomly seeded threads to the database with up to 5 message per thread (eg. If 5 threads already exist, 5 threads will be added)')
       .check(function (argv) {
         if (argv.numberOfThreads < 1) {
@@ -56,7 +56,7 @@ var addThreads = function () {
   var index = 0;
   var numThreads = argv.numberOfThreads;
   var maxMessages= argv.maxMessages;
-  var verbose = (argv.verbose === true);
+  var debug = (argv.debug === true);
   var limit = (argv.limit === true);
 
   console.log('Generating ' + numThreads + ' messages...');
@@ -64,14 +64,14 @@ var addThreads = function () {
     console.log('...this might really take a while... go grab some coffee!');
   }
 
-  if (verbose) {
+  if (debug) {
     console.log(chalk.white('--'));
     console.log(chalk.green('Trustroots test tribes data'));
     console.log(chalk.white('--'));
   }
 
   // Override debug mode to use the option set by the user
-  config.db.debug = verbose;
+  config.db.debug = debug;
 
   // Bootstrap db connection
   mongooseService.connect(function () {

--- a/bin/fillTestData/Messages.js
+++ b/bin/fillTestData/Messages.js
@@ -16,6 +16,7 @@ var _ = require('lodash'),
         }
         return true;
       })
+      .strict()
       .argv,
     faker = require('faker'),
     mongoose = require('mongoose');

--- a/bin/fillTestData/Messages.js
+++ b/bin/fillTestData/Messages.js
@@ -4,6 +4,19 @@ var _ = require('lodash'),
     path = require('path'),
     mongooseService = require(path.resolve('./config/lib/mongoose')),
     chalk = require('chalk'),
+    argv = require('yargs')
+      .usage('Usage: $0 <number of threads to add> <max messages per thread>')
+      .demandCommand(2)
+      .check(function (argv) {
+        if (argv._[0] < 1) {
+          throw new Error('Error: Number of threads should be greater than 0');
+        }
+        else if (argv._[1]) {
+          throw new Error('Error: Max messages per thread should be greater than 0');
+        }
+        return true;
+      })
+      .argv,
     faker = require('faker'),
     mongoose = require('mongoose');
 
@@ -138,14 +151,8 @@ var addThreads = function (numThreads, maxMessages) {
   });
 };
 
-// Number of threads and max number of messages is required
-if (process.argv[2] == null || process.argv[2] < 1 || process.argv[3]== null || process.argv[3] < 1) {
-  console.log(chalk.red('Usage: node fillTestMessageData <number of threads to add> <max messages per thread>'));
-} else {
+var numberOfThreads = argv._[0];
+var maxMessages= argv._[1];
 
-  var numberOfThreads = process.argv[2];
-  var maxMessages= process.argv[3];
-
-  // Add messages
-  addThreads(numberOfThreads, maxMessages);
-}
+// Add messages
+addThreads(numberOfThreads, maxMessages);

--- a/bin/fillTestData/Messages.js
+++ b/bin/fillTestData/Messages.js
@@ -4,31 +4,43 @@ var _ = require('lodash'),
     path = require('path'),
     mongooseService = require(path.resolve('./config/lib/mongoose')),
     chalk = require('chalk'),
-    argv = require('yargs')
-      .usage('Usage: $0 <number of threads to add> <max messages per thread> {options}')
-      .boolean('verbose')
-      .boolean('limit')
-      .describe('verbose', 'Enable extra database output (default=false)')
-      .describe('limit', 'If threads already exist in the database, only add up to the number of threads (default=false)')
-      .demandCommand(2)
-      .example('node $0 100 10', 'Adds 100 random threads wth up to 10 messages per thread to the database')
-      .example('node $0 100 10 --verbose', 'Adds 100 random threads wth up to 10 messages per thread to the database with verbose database output')
-      .example('node $0 10 5 --limit', 'Adds up to 10 randomly seeded threads to the database with up to 5 message per thread (eg. If 5 threads already exist, 5 threads will be added)')
-      .check(function (argv) {
-        if (argv._[0] < 1) {
-          throw new Error('Error: Number of threads should be greater than 0');
-        }
-        else if (argv._[1] < 1) {
-          throw new Error('Error: Max messages per thread should be greater than 0');
-        }
-        return true;
-      })
-      .strict()
-      .argv,
+    yargs = require('yargs'),
     faker = require('faker'),
     mongoose = require('mongoose'),
     async = require('async'),
     config = require(path.resolve('./config/config'));
+
+var argv = yargs.usage('$0 <numberOfThreads> <maxMessages>',
+  'Seed database with number of threads with up to max messages per thread',
+  function (yargs) {
+    return yargs
+      .positional('numberOfThreads', {
+        describe: 'Number of threads to add',
+        type: 'number'
+      })
+      .positional('maxMessages', {
+        describe: 'Maximum number of messages per thread to add',
+        type: 'number'
+      })
+      .boolean('verbose')
+      .boolean('limit')
+      .describe('verbose', 'Enable extra database output (default=false)')
+      .describe('limit', 'If threads already exist in the database, only add up to the number of threads (default=false)')
+      .example('$0 100 10', 'Adds 100 random threads wth up to 10 messages per thread to the database')
+      .example('$0 100 10 --verbose', 'Adds 100 random threads wth up to 10 messages per thread to the database with verbose database output')
+      .example('$0 10 5 --limit', 'Adds up to 10 randomly seeded threads to the database with up to 5 message per thread (eg. If 5 threads already exist, 5 threads will be added)')
+      .check(function (argv) {
+        if (argv.numberOfThreads < 1) {
+          throw new Error('Error: Number of threads should be greater than 0');
+        }
+        else if (argv.maxMessages < 1) {
+          throw new Error('Error: Max messages per thread should be greater than 0');
+        }
+        return true;
+      })
+      .strict().yargs;
+  })
+  .argv;
 
 var random = function (max) {
   return Math.floor(Math.random() * max);
@@ -42,8 +54,8 @@ var addDays = function addDays(date, days) {
 
 var addThreads = function () {
   var index = 0;
-  var numThreads = argv._[0];
-  var maxMessages= argv._[1];
+  var numThreads = argv.numberOfThreads;
+  var maxMessages= argv.maxMessages;
   var verbose = (argv.verbose === true);
   var limit = (argv.limit === true);
 

--- a/bin/fillTestData/Tribes.js
+++ b/bin/fillTestData/Tribes.js
@@ -98,11 +98,18 @@ var addTribes = function () {
           index = tribes.length;
         }
 
-        if (index < max) {
-          (function addNextTribe() {
+        if (index >= max) {
+          console.log(chalk.green(tribes.length + ' tribes already exist. No tribes created!'));
+          console.log(chalk.white('')); // Reset to white
+          process.exit(0);
+        }
+
+        while (index < max) {
+          var savedTribes = 0;
+          (function addNextTribe(tribeIndex) {
             var tribe = new Tribe();
 
-            tribe.label = faker.lorem.word() + '_' + index;
+            tribe.label = faker.lorem.word() + '_' + tribeIndex;
             tribe.labelHistory = faker.random.words();
             tribe.slugHistory = faker.random.words();
             tribe.synonyms = faker.random.words();
@@ -121,23 +128,16 @@ var addTribes = function () {
                 console.log(err);
               }
               else {
-                if (index >= max) {
+                savedTribes += 1;
+                if (savedTribes >= max) {
                   console.log(chalk.green('Done with ' + max + ' test tribes!'));
                   console.log(chalk.white('')); // Reset to white
                   process.exit(0);
                 }
               }
             });
-            index+=1;
-            if (index < max) {
-              addNextTribe();
-            }
-          }());
-        }
-        else {
-          console.log(chalk.green(tribes.length + ' tribes already exist. No tribes created!'));
-          console.log(chalk.white('')); // Reset to white
-          process.exit(0);
+          }(index));
+          index+=1;
         }
       });
     });

--- a/bin/fillTestData/Tribes.js
+++ b/bin/fillTestData/Tribes.js
@@ -102,7 +102,7 @@ var addTribes = function () {
           (function addNextTribe() {
             var tribe = new Tribe();
 
-            tribe.label = faker.random.word() + '_' + index;
+            tribe.label = faker.lorem.word() + '_' + index;
             tribe.labelHistory = faker.random.words();
             tribe.slugHistory = faker.random.words();
             tribe.synonyms = faker.random.words();

--- a/bin/fillTestData/Tribes.js
+++ b/bin/fillTestData/Tribes.js
@@ -109,7 +109,7 @@ var addTribes = function () {
           (function addNextTribe(tribeIndex) {
             var tribe = new Tribe();
 
-            tribe.label = faker.lorem.word() + '_' + tribeIndex;
+            tribe.label = faker.lorem.word() + '_' + (tribes.length + tribeIndex);
             tribe.labelHistory = faker.random.words();
             tribe.slugHistory = faker.random.words();
             tribe.synonyms = faker.random.words();

--- a/bin/fillTestData/Tribes.js
+++ b/bin/fillTestData/Tribes.js
@@ -130,7 +130,8 @@ var addTribes = function () {
               else {
                 process.stdout.write('.');
                 savedTribes += 1;
-                if (savedTribes >= max) {
+                if ((limit && (savedTribes + tribes.length >= max))
+                    || !limit && ((savedTribes >= max))) {
                   console.log('');
                   console.log(chalk.green(tribes.length + ' tribes existed in the database.'));
                   console.log(chalk.green(savedTribes + ' tribes successfully added.'));

--- a/bin/fillTestData/Tribes.js
+++ b/bin/fillTestData/Tribes.js
@@ -4,27 +4,32 @@ var _ = require('lodash'),
     path = require('path'),
     mongooseService = require(path.resolve('./config/lib/mongoose')),
     chalk = require('chalk'),
-    argv = require('yargs')
-      .usage('Usage: node $0 <number of tribes to add> {options}')
-      .boolean('verbose')
-      .boolean('limit')
-      .describe('verbose', 'Enable extra database output (default=false)')
-      .describe('limit', 'If tribes already exist in the database, only add up to the number of tribes (default=false)')
-      .demandCommand(1)
-      .example('node $0 1000', 'Adds 1000 randomly seeded tribes to the database')
-      .example('node $0 100 --verbose', 'Adds 100 randomly seeded tribes to the database with verbose database output')
-      .example('node $0 100 --limit', 'Adds up to 100 randomly seeded tribes to the database (eg. If 20 tribes already exist, 80 tribes will be added)')
-      .check(function (argv) {
-        if (argv._[0] < 1) {
-          throw new Error('Error: Number of tribes should be greater than 0');
-        }
-        return true;
-      })
-      .strict()
-      .argv,
+    yargs = require('yargs'),
     faker = require('faker'),
     mongoose = require('mongoose'),
     config = require(path.resolve('./config/config'));
+
+var argv = yargs.usage('$0 <numberOfTribes>', 'Seed database with number of tribes', function (yargs) {
+  return yargs
+    .positional('numberOfTribes', {
+      describe: 'Number of tribes to add',
+      type: 'number'
+    })
+    .boolean('verbose')
+    .boolean('limit')
+    .describe('verbose', 'Enable extra database output (default=false)')
+    .describe('limit', 'If tribes already exist in the database, only add up to the number of tribes (default=false)')
+    .example('node $0 1000', 'Adds 1000 randomly seeded tribes to the database')
+    .example('node $0 100 --verbose', 'Adds 100 randomly seeded tribes to the database with verbose database output')
+    .example('node $0 100 --limit', 'Adds up to 100 randomly seeded tribes to the database (eg. If 20 tribes already exist, 80 tribes will be added)')
+    .check(function (argv) {
+      if (argv.numberOfTribes < 1) {
+        throw new Error('Error: Number of tribes should be greater than 0');
+      }
+      return true;
+    })
+    .strict().yargs;
+}).argv;
 
 var tribeImageUUIDs = [
   '171433b0-853b-4d19-a8b4-44def956696d',
@@ -57,7 +62,7 @@ var tribeImageUUIDs = [
 
 var addTribes = function () {
   var index = 0;
-  var max = argv._[0];
+  var max = argv.numberOfTribes;
   var verbose = (argv.verbose === true);
   var limit = (argv.limit === true);
 

--- a/bin/fillTestData/Tribes.js
+++ b/bin/fillTestData/Tribes.js
@@ -5,9 +5,12 @@ var _ = require('lodash'),
     mongooseService = require(path.resolve('./config/lib/mongoose')),
     chalk = require('chalk'),
     argv = require('yargs')
-      .usage('Usage: $0 <number of tribes to add>')
-      // Number of tribes is required
+      .usage('Usage: node $0 <number of tribes to add> {options}')
+      .boolean('verbose')
+      .describe('verbose', 'Enable extra database output (default=false)')
       .demandCommand(1)
+      .example('node $0 1000', 'Adds 1000 randomly seeded tribes to the database')
+      .example('node $0 100 --verbose', 'Adds 100 randomly seeded tribes to the database with verbose database output')
       .check(function (argv) {
         if (argv._[0] < 1) {
           throw new Error('Error: Number of tribes should be greater than 0');
@@ -16,7 +19,8 @@ var _ = require('lodash'),
       })
       .argv,
     faker = require('faker'),
-    mongoose = require('mongoose');
+    mongoose = require('mongoose'),
+    config = require(path.resolve('./config/config'));
 
 var tribeImageUUIDs = [
   '171433b0-853b-4d19-a8b4-44def956696d',
@@ -47,8 +51,10 @@ var tribeImageUUIDs = [
   '69a500a4-a16e-4c4d-9981-84fbe310d531'
 ];
 
-var addTribes = function (max) {
+var addTribes = function () {
   var index = 0;
+  var max = argv._[0];
+  var verbose = (argv.verbose === true);
 
   // Add tribes
   console.log('Generating ' + max + ' tribes...');
@@ -56,9 +62,14 @@ var addTribes = function (max) {
     console.log('...this might really take a while... go grab some coffee!');
   }
 
-  console.log(chalk.white('--'));
-  console.log(chalk.green('Trustroots test tribes data'));
-  console.log(chalk.white('--'));
+  if (verbose) {
+    console.log(chalk.white('--'));
+    console.log(chalk.green('Trustroots test tribes data'));
+    console.log(chalk.white('--'));
+  }
+
+  // Override debug mode to use the option set by the user
+  config.db.debug = verbose;
 
   // Bootstrap db connection
   mongooseService.connect(function () {
@@ -103,5 +114,4 @@ var addTribes = function (max) {
   });
 };
 
-var numberOfTribes= argv._[0];
-addTribes(numberOfTribes);
+addTribes();

--- a/bin/fillTestData/Tribes.js
+++ b/bin/fillTestData/Tribes.js
@@ -20,6 +20,7 @@ var _ = require('lodash'),
         }
         return true;
       })
+      .strict()
       .argv,
     faker = require('faker'),
     mongoose = require('mongoose'),

--- a/bin/fillTestData/Tribes.js
+++ b/bin/fillTestData/Tribes.js
@@ -15,12 +15,12 @@ var argv = yargs.usage('$0 <numberOfTribes>', 'Seed database with number of trib
       describe: 'Number of tribes to add',
       type: 'number'
     })
-    .boolean('verbose')
+    .boolean('debug')
     .boolean('limit')
-    .describe('verbose', 'Enable extra database output (default=false)')
+    .describe('debug', 'Enable extra database output (default=false)')
     .describe('limit', 'If tribes already exist in the database, only add up to the number of tribes (default=false)')
     .example('node $0 1000', 'Adds 1000 randomly seeded tribes to the database')
-    .example('node $0 100 --verbose', 'Adds 100 randomly seeded tribes to the database with verbose database output')
+    .example('node $0 100 --debug', 'Adds 100 randomly seeded tribes to the database with debug database output')
     .example('node $0 100 --limit', 'Adds up to 100 randomly seeded tribes to the database (eg. If 20 tribes already exist, 80 tribes will be added)')
     .check(function (argv) {
       if (argv.numberOfTribes < 1) {
@@ -63,7 +63,7 @@ var tribeImageUUIDs = [
 var addTribes = function () {
   var index = 0;
   var max = argv.numberOfTribes;
-  var verbose = (argv.verbose === true);
+  var debug = (argv.debug === true);
   var limit = (argv.limit === true);
 
   // Add tribes
@@ -72,14 +72,14 @@ var addTribes = function () {
     console.log('...this might really take a while... go grab some coffee!');
   }
 
-  if (verbose) {
+  if (debug) {
     console.log(chalk.white('--'));
     console.log(chalk.green('Trustroots test tribes data'));
     console.log(chalk.white('--'));
   }
 
   // Override debug mode to use the option set by the user
-  config.db.debug = verbose;
+  config.db.debug = debug;
 
   // Bootstrap db connection
   mongooseService.connect(function () {

--- a/bin/fillTestData/Tribes.js
+++ b/bin/fillTestData/Tribes.js
@@ -72,11 +72,9 @@ var addTribes = function () {
     console.log('...this might really take a while... go grab some coffee!');
   }
 
-  if (debug) {
-    console.log(chalk.white('--'));
-    console.log(chalk.green('Trustroots test tribes data'));
-    console.log(chalk.white('--'));
-  }
+  console.log(chalk.white('--'));
+  console.log(chalk.green('Trustroots test tribes data'));
+  console.log(chalk.white('--'));
 
   // Override debug mode to use the option set by the user
   config.db.debug = debug;

--- a/bin/fillTestData/Tribes.js
+++ b/bin/fillTestData/Tribes.js
@@ -4,6 +4,17 @@ var _ = require('lodash'),
     path = require('path'),
     mongooseService = require(path.resolve('./config/lib/mongoose')),
     chalk = require('chalk'),
+    argv = require('yargs')
+      .usage('Usage: $0 <number of tribes to add>')
+      // Number of tribes is required
+      .demandCommand(1)
+      .check(function (argv) {
+        if (argv._[0] < 1) {
+          throw new Error('Error: Number of tribes should be greater than 0');
+        }
+        return true;
+      })
+      .argv,
     faker = require('faker'),
     mongoose = require('mongoose');
 
@@ -92,10 +103,5 @@ var addTribes = function (max) {
   });
 };
 
-// Number of tribes is required
-if (process.argv[2] == null || process.argv[2] < 1) {
-  console.log(chalk.red('Usage: node fillTestTribesData.js <number of tribes to add>'));
-} else {
-  var numberOfTribes= process.argv[2];
-  addTribes(numberOfTribes);
-}
+var numberOfTribes= argv._[0];
+addTribes(numberOfTribes);

--- a/bin/fillTestData/Tribes.js
+++ b/bin/fillTestData/Tribes.js
@@ -128,9 +128,13 @@ var addTribes = function () {
                 console.log(err);
               }
               else {
+                process.stdout.write('.');
                 savedTribes += 1;
                 if (savedTribes >= max) {
-                  console.log(chalk.green('Done with ' + max + ' test tribes!'));
+                  console.log('');
+                  console.log(chalk.green(tribes.length + ' tribes existed in the database.'));
+                  console.log(chalk.green(savedTribes + ' tribes successfully added.'));
+                  console.log(chalk.green('Database now contains ' + (tribes.length + savedTribes) + ' tribes.'));
                   console.log(chalk.white('')); // Reset to white
                   process.exit(0);
                 }

--- a/bin/fillTestData/Users.js
+++ b/bin/fillTestData/Users.js
@@ -9,6 +9,7 @@ var _ = require('lodash'),
     fs = require('fs'),
     moment = require('moment'),
     mongoose = require('mongoose'),
+    config = require(path.resolve('./config/config')),
     cities = JSON.parse(fs.readFileSync(path.resolve('./bin/fillTestData/data/Cities.json'), 'utf8')),
     savedCounter = 0;
 
@@ -88,6 +89,7 @@ var addOffer = function (id, index, max) {
 var addUsers = function (max, adminUsers) {
   var index = 0;
   var numAdminUsers;
+  var debug = (argv.debug === true);
 
   if (adminUsers === null || adminUsers === undefined) {
     numAdminUsers = 0;
@@ -105,6 +107,9 @@ var addUsers = function (max, adminUsers) {
   if (numAdminUsers === 0) {
     printWarning();
   }
+
+  // Override debug mode to use the option set by the user
+  config.db.debug = debug;
 
   // Bootstrap db connection
   mongooseService.connect(function () {

--- a/bin/fillTestData/Users.js
+++ b/bin/fillTestData/Users.js
@@ -4,6 +4,16 @@ var _ = require('lodash'),
     path = require('path'),
     mongooseService = require(path.resolve('./config/lib/mongoose')),
     chalk = require('chalk'),
+    argv = require('yargs')
+      .usage('Usage: $0 <number of users to add> {user names}')
+      .demandCommand(1)
+      .check(function (argv) {
+        if (argv._[0] < 1) {
+          throw new Error('Error: Number of users should be greater than 0');
+        }
+        return true;
+      })
+      .argv,
     faker = require('faker'),
     fs = require('fs'),
     moment = require('moment'),
@@ -197,22 +207,17 @@ var addUsers = function (max, adminUsers) {
   });
 }; // addUsers()
 
-// Number of users is required
-if (process.argv[2] == null) {
-  console.log(chalk.red('Usage: node fillTestData.js <number of users to add> {user names}'));
+// Parse optional admin users
+var numberOfUsers = argv._[0];
+var adminUsers = [];
+for (var i = 1; i < argv._.length; i++) {
+  if (argv._[i] !== null) {
+    adminUsers.push(argv._[i]);
+  }
+}
+// Add users
+if (adminUsers.length > 0) {
+  addUsers(numberOfUsers, adminUsers);
 } else {
-  // Parse optional admin users
-  var numberOfUsers = process.argv[2];
-  var adminUsers = [];
-  for (var i = 3; i < process.argv.length; i++) {
-    if (process.argv[i] !== null) {
-      adminUsers.push(process.argv[i]);
-    }
-  }
-  // Add users
-  if (adminUsers.length > 0) {
-    addUsers(numberOfUsers, adminUsers);
-  } else {
-    addUsers(numberOfUsers);
-  }
+  addUsers(numberOfUsers);
 }

--- a/bin/fillTestData/Users.js
+++ b/bin/fillTestData/Users.js
@@ -78,7 +78,7 @@ var addOffer = function (id, index, max, callback) {
     if (err != null) console.log(err);
     else {
       savedCounter++;
-      if (index >= max) {
+      if (savedCounter >= max) {
         console.log(chalk.green('Done with ' + max + ' test users!'));
         console.log(chalk.white('')); // Reset to white
         callback(null, null);
@@ -134,22 +134,29 @@ var addUsers = function (max, adminUsers) {
           if (limit) {
             index = users.length;
           }
-          if (index < max) {
-            var getTribes = new Promise(function (resolve, reject) {
-              Tribe.find(function (err, tribes) {
-                if (err) {
-                  reject(err);
-                }
-                resolve(tribes);
-              });
+
+          if (index >= max) {
+            console.log(chalk.green(users.length + ' users already exist. No users created!'));
+            console.log(chalk.white('')); // Reset to white
+            process.exit(0);
+          }
+
+          var getTribes = new Promise(function (resolve, reject) {
+            Tribe.find(function (err, tribes) {
+              if (err) {
+                reject(err);
+              }
+              resolve(tribes);
             });
+          });
 
-            getTribes.then(function (tribes) {
+          getTribes.then(function (tribes) {
 
-              console.log(chalk.white('--'));
-              console.log(chalk.green('Trustroots test user data'));
-              console.log(chalk.white('--'));
+            console.log(chalk.white('--'));
+            console.log(chalk.green('Trustroots test user data'));
+            console.log(chalk.white('--'));
 
+            while (index < max) {
               (function addNextUser(){
                 var user = new User();
                 var admin;
@@ -222,7 +229,6 @@ var addUsers = function (max, adminUsers) {
                   }
                 });
 
-                index++;
                 addOffer(user._id, index, max, done);
 
                 // No more admin users
@@ -233,25 +239,14 @@ var addUsers = function (max, adminUsers) {
                 if (admin !== undefined) {
                   numAdminUsers--;
                 }
-
-                if (index < max) {
-                  addNextUser();
-                }
               }());
 
-              while (numAdminUsers > 0) {
-
-              }
-            }).catch(function (err) {
-              console.log(err);
-              done(err, null);
-            });
-          }
-          else {
-            console.log(chalk.green(users.length + ' users already exist. No users created!'));
-            console.log(chalk.white('')); // Reset to white
-            process.exit(0);
-          }
+              index++;
+            }
+          }).catch(function (err) {
+            console.log(err);
+            done(err, null);
+          });
         }
       ]);
 

--- a/bin/fillTestData/Users.js
+++ b/bin/fillTestData/Users.js
@@ -58,7 +58,7 @@ var randomizeLoaction = function () {
   return parseFloat(random.toFixed(5));
 };
 
-var addOffer = function (id, index, max, callback) {
+var addOffer = function (id, index, max, usersLength, callback) {
   var offer = new Offer();
 
   var city = cities[random(cities.length)];
@@ -79,7 +79,10 @@ var addOffer = function (id, index, max, callback) {
     else {
       savedCounter++;
       if (savedCounter >= max) {
-        console.log(chalk.green('Done with ' + max + ' test users!'));
+        console.log('');
+        console.log(chalk.green(usersLength + ' users existed in the database.'));
+        console.log(chalk.green(savedCounter + ' users successfully added.'));
+        console.log(chalk.green('Database now contains ' + (usersLength + savedCounter) + ' users.'));
         console.log(chalk.white('')); // Reset to white
         callback(null, null);
         process.exit(0);
@@ -219,6 +222,7 @@ var addUsers = function (max, adminUsers) {
 
                 // Save the user
                 user.save(function (err) {
+                  process.stdout.write('.');
                   if (admin!== undefined) {
                     console.log('Created admin user. Login with: ' + admin + ' / password');
                   } else if (err && admin !== undefined) {
@@ -229,7 +233,7 @@ var addUsers = function (max, adminUsers) {
                   }
                 });
 
-                addOffer(user._id, index, max, done);
+                addOffer(user._id, index, max, users.length, done);
 
                 // No more admin users
                 if (numAdminUsers === 1) {

--- a/bin/fillTestData/Users.js
+++ b/bin/fillTestData/Users.js
@@ -98,7 +98,6 @@ var addUsers = function () {
   var limit = (argv.limit === true);
   var max = argv.numberOfUsers;
   var adminUsers = argv.userNames;
-  console.log(adminUsers);
 
   if (adminUsers === null || adminUsers === undefined) {
     numAdminUsers = 0;

--- a/bin/fillTestData/Users.js
+++ b/bin/fillTestData/Users.js
@@ -233,7 +233,7 @@ var addUsers = function () {
                 user.save(function (err) {
                   savedUsers++;
                   process.stdout.write('.');
-                  if (admin!== undefined) {
+                  if (!err && admin!== undefined) {
                     console.log('Created admin user. Login with: ' + admin + ' / password');
                   } else if (err && admin !== undefined) {
                     console.log(chalk.red('Could not add admin user ' + admin));

--- a/bin/fillTestData/Users.js
+++ b/bin/fillTestData/Users.js
@@ -21,14 +21,14 @@ var argv = yargs.usage('$0 <numberOfUsers>', 'Seed database with number of tribe
       type: 'number'
     })
     .array('userNames')
-    .boolean('verbose')
+    .boolean('debug')
     .boolean('limit')
     .describe('userNames', 'List of admin usernames')
-    .describe('verbose', 'Enable extra database output (default=false)')
+    .describe('debug', 'Enable extra database output (default=false)')
     .describe('limit', 'If users already exist in the database, only add up to the number of users (default=false)')
     .example('node $0 1000', 'Adds 1000 randomly seeded users to the database')
     .example('node $0 100 --userNames admin1 admin2 admin3 --', 'Adds 100 randomly seeded users including usernames: admin1, admin2, and admin3 all using the password \'password123\'')
-    .example('node $0 100 --verbose', 'Adds 100 randomly seeded users to the database with verbose database output')
+    .example('node $0 100 --debug', 'Adds 100 randomly seeded users to the database with debug database output')
     .example('node $0 100 --limit', 'Adds up to 100 randomly seeded users to the database (eg. If 20 users already exist, 80 users will be added)')
     .check(function (argv) {
       if (argv.numberOfUsers < 1) {

--- a/bin/fillTestData/Users.js
+++ b/bin/fillTestData/Users.js
@@ -242,16 +242,9 @@ var addUsers = function () {
                     console.log(err);
                   }
 
-                  // Exit if we have completed saving all users and offers
-                  if ((limit && (savedUsers + users.length >= max && savedOffers + users.length >= max))
-                       || ((!limit && (savedUsers >= max && savedOffers >= max)))) {
-                    printSummary(users.length, savedUsers);
-                    done(null, null);
-                    process.exit(0);
-                  }
+                  addOffer(user._id, index, max, users.length, limit, done);
                 });
 
-                addOffer(user._id, index, max, users.length, limit, done);
 
                 // No more admin users
                 if (numAdminUsers === 1) {

--- a/bin/fillTestData/Users.js
+++ b/bin/fillTestData/Users.js
@@ -13,6 +13,7 @@ var _ = require('lodash'),
         }
         return true;
       })
+      .strict()
       .argv,
     faker = require('faker'),
     fs = require('fs'),

--- a/bin/fillTestData/Users.js
+++ b/bin/fillTestData/Users.js
@@ -91,11 +91,14 @@ var addOffer = function (id, index, max, usersLength, callback) {
   });
 };
 
-var addUsers = function (max, adminUsers) {
+var addUsers = function () {
   var index = 0;
   var numAdminUsers;
   var debug = (argv.debug === true);
   var limit = (argv.limit === true);
+  var max = argv.numberOfUsers;
+  var adminUsers = argv.userNames;
+  console.log(adminUsers);
 
   if (adminUsers === null || adminUsers === undefined) {
     numAdminUsers = 0;
@@ -259,19 +262,4 @@ var addUsers = function (max, adminUsers) {
   });
 }; // addUsers()
 
-// Parse optional admin users
-var numberOfUsers = argv.numberOfUsers;
-var adminUsers = [];
-if (argv.userNames) {
-  for (var i = 0; i < argv.userNames.length; i++) {
-    if (argv.userNames[i] !== null) {
-      adminUsers.push(argv.userNames[i]);
-    }
-  }
-}
-// Add users
-if (adminUsers.length > 0) {
-  addUsers(numberOfUsers, adminUsers);
-} else {
-  addUsers(numberOfUsers);
-}
+addUsers();

--- a/package-lock.json
+++ b/package-lock.json
@@ -882,9 +882,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.5.tgz",
-      "integrity": "sha512-xKnPpXG/pvK1B90JkwwxSGii90rQGKtzcMt2gI5G6+M0REXaq6rOHsGC2ay6/d0Uje7zzvSzjEzfR3ENhFlrfA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
+      "integrity": "sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==",
       "requires": {
         "regenerator-runtime": "^0.12.0"
       },
@@ -897,18 +897,18 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.1.5.tgz",
-      "integrity": "sha512-WsYRwQsFhVmxkAqwypPTZyV9GpkqMEaAr2zOItOmqSX2GBFaI+eq98CN81e13o0zaUKJOQGYyjhNVqj56nnkYg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.2.0.tgz",
+      "integrity": "sha512-kPfmKoRI8Hpo5ZJGACWyrc9Eq1j3ZIUpUAQT2yH045OuYpccFJ9kYA/eErwzOM2jeBG1sC8XX1nl1EArtuM8tg==",
       "requires": {
         "core-js": "^2.5.7",
         "regenerator-runtime": "^0.12.0"
       },
       "dependencies": {
         "core-js": {
-          "version": "2.5.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.0.tgz",
+          "integrity": "sha512-kLRC6ncVpuEW/1kwrOXYX6KQASCVtrh1gQr/UiaVgFlf9WE5Vp+lNe5+h3LuMr5PAucWnnEXwH0nQHRH/gpGtw=="
         },
         "regenerator-runtime": {
           "version": "0.12.1",
@@ -1046,9 +1046,9 @@
       }
     },
     "@types/node": {
-      "version": "10.12.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.9.tgz",
-      "integrity": "sha512-eajkMXG812/w3w4a1OcBlaTwsFPO5F7fJ/amy+tieQxEMWBlbV1JGSjkFM+zkHNf81Cad+dfIRA+IBkvmvdAeA==",
+      "version": "10.12.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.15.tgz",
+      "integrity": "sha512-9kROxduaN98QghwwHmxXO2Xz3MaWf+I1sLVAA6KJDF5xix+IyXVhds0MAfdNwtcpSrzhaTsNB0/jnL86fgUhqA==",
       "dev": true
     },
     "@webassemblyjs/ast": {
@@ -2271,6 +2271,11 @@
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
     },
+    "array-unique": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+    },
     "array.prototype.flat": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.1.tgz",
@@ -2281,6 +2286,12 @@
         "es-abstract": "^1.10.0",
         "function-bind": "^1.1.1"
       }
+    },
+    "arraybuffer.slice": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
+      "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco=",
+      "dev": true
     },
     "arrify": {
       "version": "1.0.1",
@@ -3474,6 +3485,534 @@
         "upath": "^1.0.5"
       },
       "dependencies": {
+        "fsevents": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+          "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+          "optional": true,
+          "requires": {
+            "nan": "^2.9.2",
+            "node-pre-gyp": "^0.10.0"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+              "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+              "optional": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+            },
+            "aproba": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+              "optional": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.4",
+              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+              "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+              "optional": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+              }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+              "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "chownr": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+              "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+              "optional": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+              "optional": true
+            },
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "optional": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "deep-extend": {
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+              "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
+              "optional": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+              "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+              "optional": true
+            },
+            "detect-libc": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+              "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+              "optional": true
+            },
+            "fs-minipass": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+              "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+              "optional": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+              "optional": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+              "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+              "optional": true,
+              "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
+            },
+            "glob": {
+              "version": "7.1.2",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+              "optional": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+              "optional": true
+            },
+            "iconv-lite": {
+              "version": "0.4.21",
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+              "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
+              "optional": true,
+              "requires": {
+                "safer-buffer": "^2.1.0"
+              }
+            },
+            "ignore-walk": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+              "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+              "optional": true,
+              "requires": {
+                "minimatch": "^3.0.4"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+              "optional": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+            },
+            "ini": {
+              "version": "1.3.5",
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+              "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+              "optional": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "optional": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+            },
+            "minipass": {
+              "version": "2.2.4",
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
+              "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+              "requires": {
+                "safe-buffer": "^5.1.1",
+                "yallist": "^3.0.0"
+              }
+            },
+            "minizlib": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+              "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+              "optional": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "optional": true
+            },
+            "needle": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
+              "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
+              "optional": true,
+              "requires": {
+                "debug": "^2.1.2",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
+              }
+            },
+            "node-pre-gyp": {
+              "version": "0.10.0",
+              "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.0.tgz",
+              "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
+              "optional": true,
+              "requires": {
+                "detect-libc": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "needle": "^2.2.0",
+                "nopt": "^4.0.1",
+                "npm-packlist": "^1.1.6",
+                "npmlog": "^4.0.2",
+                "rc": "^1.1.7",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^4"
+              }
+            },
+            "nopt": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+              "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+              "optional": true,
+              "requires": {
+                "abbrev": "1",
+                "osenv": "^0.1.4"
+              }
+            },
+            "npm-bundled": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
+              "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
+              "optional": true
+            },
+            "npm-packlist": {
+              "version": "1.1.10",
+              "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
+              "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
+              "optional": true,
+              "requires": {
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+              "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+              "optional": true,
+              "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+              "optional": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+              "optional": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+              "optional": true
+            },
+            "osenv": {
+              "version": "0.1.5",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+              "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+              "optional": true,
+              "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+              "optional": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+              "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+              "optional": true
+            },
+            "rc": {
+              "version": "1.2.7",
+              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
+              "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
+              "optional": true,
+              "requires": {
+                "deep-extend": "^0.5.1",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                  "optional": true
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.6",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+              "optional": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.2",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+              "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+              "optional": true,
+              "requires": {
+                "glob": "^7.0.5"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.1",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+              "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+              "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+              "optional": true
+            },
+            "sax": {
+              "version": "1.2.4",
+              "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+              "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+              "optional": true
+            },
+            "semver": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+              "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+              "optional": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+              "optional": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+              "optional": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "optional": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+              "optional": true
+            },
+            "tar": {
+              "version": "4.4.1",
+              "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
+              "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
+              "optional": true,
+              "requires": {
+                "chownr": "^1.0.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.2.4",
+                "minizlib": "^1.1.0",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.1",
+                "yallist": "^3.0.2"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+              "optional": true
+            },
+            "wide-align": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+              "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+              "optional": true,
+              "requires": {
+                "string-width": "^1.0.2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            },
+            "yallist": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+              "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+            }
+          }
+        },
         "glob-parent": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
@@ -3505,6 +4044,12 @@
           "requires": {
             "is-extglob": "^2.1.1"
           }
+        },
+        "nan": {
+          "version": "2.11.1",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+          "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+          "optional": true
         }
       }
     },
@@ -5033,12 +5578,6 @@
         "wtf-8": "1.0.0"
       },
       "dependencies": {
-        "arraybuffer.slice": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
-          "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco=",
-          "dev": true
-        },
         "wtf-8": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz",
@@ -5119,9 +5658,9 @@
       }
     },
     "enzyme-adapter-react-16": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.7.0.tgz",
-      "integrity": "sha512-rDr0xlnnFPffAPYrvG97QYJaRl9unVDslKee33wTStsBEwZTkESX1H7VHGT5eUc6ifNzPgOJGvSh2zpHT4gXjA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.7.1.tgz",
+      "integrity": "sha512-OQXKgfHWyHN3sFu2nKj3mhgRcqIPIJX6aOzq5AHVFES4R9Dw/vCBZFMPyaG81g2AZ5DogVh39P3MMNUbqNLTcw==",
       "dev": true,
       "requires": {
         "enzyme-adapter-utils": "^1.9.0",
@@ -5514,12 +6053,6 @@
         "braces": "^0.1.2"
       },
       "dependencies": {
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-          "dev": true
-        },
         "braces": {
           "version": "0.1.5",
           "resolved": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz",
@@ -8347,13 +8880,6 @@
         "has-gulplog": "^0.1.0",
         "micromatch": "^2.3.8",
         "resolve": "^1.1.7"
-      },
-      "dependencies": {
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
-        }
       }
     },
     "gulp-mocha": {
@@ -11767,9 +12293,9 @@
       }
     },
     "map-age-cleaner": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.2.tgz",
-      "integrity": "sha512-UN1dNocxQq44IhJyMI4TU8phc2m9BddacHRPRjKGLYaF0jqd3xLz0jS0skpAU9WgYyoR4gHtUpzytNBS385FWQ==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
       "dev": true,
       "requires": {
         "p-defer": "^1.0.0"
@@ -12311,11 +12837,6 @@
         "regex-cache": "^0.4.2"
       },
       "dependencies": {
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
-        },
         "braces": {
           "version": "1.8.5",
           "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
@@ -14861,9 +15382,9 @@
       }
     },
     "react-transition-group": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.5.0.tgz",
-      "integrity": "sha512-qYB3JBF+9Y4sE4/Mg/9O6WFpdoYjeeYqx0AFb64PTazVy8RPMiE3A47CG9QmM4WJ/mzDiZYslV+Uly6O1Erlgw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.5.1.tgz",
+      "integrity": "sha512-8x/CxUL9SjYFmUdzsBPTgtKeCxt7QArjNSte0wwiLtF/Ix/o1nWNJooNy5o9XbHIKS31pz7J5VF2l41TwlvbHQ==",
       "requires": {
         "dom-helpers": "^3.3.1",
         "loose-envify": "^1.4.0",
@@ -17344,7 +17865,7 @@
     },
     "underscore": {
       "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+      "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
       "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
       "dev": true
     },
@@ -18600,12 +19121,6 @@
       "integrity": "sha1-GFqIjATspGw+QHDZn3tJ3jUomS0=",
       "dev": true
     },
-    "xregexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
-      "integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg==",
-      "dev": true
-    },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
@@ -18630,13 +19145,13 @@
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.2.tgz",
-      "integrity": "sha512-e7SkEx6N6SIZ5c5H22RTZae61qtn3PYUE8JYbBFlK9sYmh3DMQ6E5ygtaG/2BW0JZi4WGgTR2IV5ChqlqrDGVQ==",
+      "version": "12.0.5",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+      "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
       "dev": true,
       "requires": {
         "cliui": "^4.0.0",
-        "decamelize": "^2.0.0",
+        "decamelize": "^1.2.0",
         "find-up": "^3.0.0",
         "get-caller-file": "^1.0.1",
         "os-locale": "^3.0.0",
@@ -18646,7 +19161,7 @@
         "string-width": "^2.0.0",
         "which-module": "^2.0.0",
         "y18n": "^3.2.1 || ^4.0.0",
-        "yargs-parser": "^10.1.0"
+        "yargs-parser": "^11.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -18677,15 +19192,6 @@
             "semver": "^5.5.0",
             "shebang-command": "^1.2.0",
             "which": "^1.2.9"
-          }
-        },
-        "decamelize": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
-          "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
-          "dev": true,
-          "requires": {
-            "xregexp": "4.0.0"
           }
         },
         "execa": {
@@ -18766,18 +19272,19 @@
       }
     },
     "yargs-parser": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-      "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+      "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
       "dev": true,
       "requires": {
-        "camelcase": "^4.1.0"
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
       },
       "dependencies": {
         "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "seed:messages": "node ./bin/fillTestData/Messages.js",
     "seed:tribes": "node ./bin/fillTestData/Tribes.js",
     "seed:users": "node ./bin/fillTestData/Users.js",
-    "seed": "npm run seed:tribes 100 && npm run seed:users 1000 admin1 admin2 admin3 && npm run seed:messages 2000 10",
+    "seed": "npm run seed:tribes 100 && npm run seed:users 1000 -- --userNames admin1 admin2 admin3 && npm run seed:messages 2000 10",
     "start:develop": "gulp develop",
     "start:docker": "npm run prestart && concurrently --raw --kill-others --kill-others-on-fail 'gulp develop' 'npm run start:worker'",
     "start:prod": "gulp prod",

--- a/package.json
+++ b/package.json
@@ -220,7 +220,8 @@
     "webpack": "~4.27.1",
     "webpack-cli": "~3.1.2",
     "webpack-merge": "~4.1.5",
-    "webpack-stream": "~5.2.1"
+    "webpack-stream": "~5.2.1",
+    "yargs": "^12.0.5"
   },
   "bugs": {
     "url": "https://github.com/Trustroots/trustroots/issues"


### PR DESCRIPTION
#### Proposed Changes

* Switch to using 'yargs' with the same usage for all seeding scripts
* Adds the following command line options naming previous command line options if required
  * --verbose -enables database output which by default is now turned off. 
  * --limit -only seeds up to the number of items if there is already data in the database. 

#### Testing Instructions

* TBD

Fixes #843 
