### PR TITLE
Improve email templates for References

### DIFF
--- a/config/env/development.js
+++ b/config/env/development.js
@@ -11,6 +11,11 @@
  */
 
 module.exports = {
+  // Feature flags
+  featureFlags: {
+    // enable references?
+    reference: true
+  },
   db: {
     uri: 'mongodb://' + (process.env.DB_1_PORT_27017_TCP_ADDR || 'localhost') + '/trustroots-dev',
     options: {

--- a/modules/core/server/services/email.server.service.js
+++ b/modules/core/server/services/email.server.service.js
@@ -417,6 +417,7 @@ exports.sendReferenceNotificationFirst = function (userFrom, userTo, callback) {
   var params = exports.addEmailBaseTemplateParams({
     subject: 'New reference from ' + userFrom.username,
     email: userTo.email,
+    username: userTo.username, // data needed for link to profile in footer
     userFrom: userFrom,
     userTo: userTo,
     userFromProfileUrl: url + '/profile/' + userFrom.username,
@@ -434,6 +435,7 @@ exports.sendReferenceNotificationSecond = function (userFrom, userTo, reference,
   var params = exports.addEmailBaseTemplateParams({
     subject: 'New reference from ' + userFrom.username,
     email: userTo.email,
+    username: userTo.username, // data needed for link to profile in footer
     userFrom: userFrom,
     userTo: userTo,
     userFromProfileUrl: url + '/profile/' + userFrom.username,

--- a/modules/core/server/services/email.server.service.js
+++ b/modules/core/server/services/email.server.service.js
@@ -417,6 +417,9 @@ exports.sendReferenceNotificationFirst = function (userFrom, userTo, callback) {
   var params = exports.addEmailBaseTemplateParams({
     subject: 'New reference from ' + userFrom.username,
     email: userTo.email,
+    userFrom: userFrom,
+    userTo: userTo,
+    userFromProfileUrl: url + '/profile/' + userFrom.username,
     giveReferenceUrl: url + '/profile/' + userFrom.username + '/references/new'
   });
 
@@ -431,6 +434,9 @@ exports.sendReferenceNotificationSecond = function (userFrom, userTo, reference,
   var params = exports.addEmailBaseTemplateParams({
     subject: 'New reference from ' + userFrom.username,
     email: userTo.email,
+    userFrom: userFrom,
+    userTo: userTo,
+    userFromProfileUrl: url + '/profile/' + userFrom.username,
     seeReferencesUrl: url + '/profile/' + userTo.username + '/references',
     recommend: reference.recommend
   });

--- a/modules/core/server/views/email-templates-text/reference-notification-first.server.view.html
+++ b/modules/core/server/views/email-templates-text/reference-notification-first.server.view.html
@@ -1,6 +1,15 @@
 {% extends './email.server.view.html' %}
 
 {% block content %}
-give the reference, too: {{giveReferenceUrl}}
-And give more explanation about time limit etc.
+Hello BOB-FIRSTNAME,
+
+Great news! [LINK-TO-PROFILE]ALICE-FIRSTNAME left you a reference on Trustroots.
+
+You will be able to see their reference after you leave them a reference as well.
+Ideally you go to {{giveReferenceUrl}} right now.
+
+Otherwise you will have two weeks to do this. If you don't leave them
+a reference in the next two weeks their reference to you will show and
+you will only be able to leave a positive reference.
+
 {% endblock content %}

--- a/modules/core/server/views/email-templates-text/reference-notification-first.server.view.html
+++ b/modules/core/server/views/email-templates-text/reference-notification-first.server.view.html
@@ -1,15 +1,15 @@
 {% extends './email.server.view.html' %}
 
 {% block content %}
-Hello {{userTo.firstName}},
+Hello {{userTo.firstName}}!
 
 Great news! {{userFrom.firstName}} ({{userFromProfileUrl}}) left you a reference on Trustroots.
 
 You will be able to see their reference after you leave them a reference as well.
-Ideally you go to {{giveReferenceUrl}} right now.
 
-Otherwise you will have two weeks to do this. If you don't leave them
-a reference in the next two weeks their reference to you will show and
-you will only be able to leave a positive reference.
+Go to {{giveReferenceUrl}} and give them a reference right now!
 
+You have two weeks to do this.
+After two weeks, their reference for you will become public
+and you will only be able to give them a positive reference.
 {% endblock content %}

--- a/modules/core/server/views/email-templates-text/reference-notification-first.server.view.html
+++ b/modules/core/server/views/email-templates-text/reference-notification-first.server.view.html
@@ -1,9 +1,9 @@
 {% extends './email.server.view.html' %}
 
 {% block content %}
-Hello BOB-FIRSTNAME,
+Hello {{userTo.firstName}},
 
-Great news! [LINK-TO-PROFILE]ALICE-FIRSTNAME left you a reference on Trustroots.
+Great news! {{userFrom.firstName}} ({{userFromProfileUrl}}) left you a reference on Trustroots.
 
 You will be able to see their reference after you leave them a reference as well.
 Ideally you go to {{giveReferenceUrl}} right now.

--- a/modules/core/server/views/email-templates-text/reference-notification-second.server.view.html
+++ b/modules/core/server/views/email-templates-text/reference-notification-second.server.view.html
@@ -1,10 +1,11 @@
 {% extends './email.server.view.html' %}
 
 {% block content %}
-Hi {{userTo.firstName}},
+Hi {{userTo.firstName}}!
 
-Good news, {{userFrom.firstName}} ({{userFromProfileUrl}}) has left you a reference as
-well. The recommendation was {{recommend}}.
+Good news, {{userFrom.firstName}} ({{userFromProfileUrl}}) has left you a reference as well.
+
+Their recommendation was {{recommend}}.
 
 You can see your own references at {{seeReferencesUrl}}.
 

--- a/modules/core/server/views/email-templates-text/reference-notification-second.server.view.html
+++ b/modules/core/server/views/email-templates-text/reference-notification-second.server.view.html
@@ -1,11 +1,11 @@
 {% extends './email.server.view.html' %}
 
 {% block content %}
-Hi ALICE-FIRSTNAME,
+Hi {{userTo.firstName}},
 
-Good news, [LINKTOPROFILE]BOB-FIRSTNAME has left you a reference as
-well. The recommendation was {{recommend}}
+Good news, {{userFrom.firstName}} ({{userFromProfileUrl}}) has left you a reference as
+well. The recommendation was {{recommend}}.
 
-You can see your own references at {{seeReferencesUrl}}
+You can see your own references at {{seeReferencesUrl}}.
 
 {% endblock content %}

--- a/modules/core/server/views/email-templates-text/reference-notification-second.server.view.html
+++ b/modules/core/server/views/email-templates-text/reference-notification-second.server.view.html
@@ -1,7 +1,11 @@
 {% extends './email.server.view.html' %}
 
 {% block content %}
-see my own references: {{seeReferencesUrl}}
-the recommendation was {{recommend}}
-and we can show other reference data, too.
+Hi ALICE-FIRSTNAME,
+
+Good news, [LINKTOPROFILE]BOB-FIRSTNAME has left you a reference as
+well. The recommendation was {{recommend}}
+
+You can see your own references at {{seeReferencesUrl}}
+
 {% endblock content %}

--- a/modules/core/server/views/email-templates/email-with-container.server.view.html
+++ b/modules/core/server/views/email-templates/email-with-container.server.view.html
@@ -1,0 +1,59 @@
+{% extends './email.server.view.html' %}
+
+{% block content %}
+
+  <!-- MODULE ROW // -->
+  <tr>
+      <td align="center" valign="top">
+          <!-- CENTERING TABLE // -->
+            <!--
+              The centering table keeps the content
+                tables centered in the emailBody table,
+                in case its width is set to 100%.
+            -->
+          <table border="0" cellpadding="0" cellspacing="0" width="100%">
+              <tr>
+                  <td align="center" valign="top">
+                      <!-- FLEXIBLE CONTAINER // -->
+                        <!--
+                          The flexible container has a set width
+                            that gets overridden by the media query.
+                            Most content tables within can then be
+                            given 100% widths.
+                        -->
+                      <table border="0" cellpadding="0" cellspacing="0" width="600" class="flexibleContainer">
+                          <tr>
+                              <td align="center" valign="top" width="600" class="flexibleContainerCell">
+
+                                  <!-- CONTENT TABLE // -->
+                                  <!--
+                                    The content table is the first element
+                                      that's entirely separate from the structural
+                                      framework of the email.
+                                  -->
+                                  <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                                      <tr>
+                                          <td valign="top" class="textContent">
+
+                                              {% block textcontent %}{% endblock textcontent %}
+
+                                          </td>
+                                      </tr>
+                                  </table>
+                                  <!-- // CONTENT TABLE -->
+
+                              </td>
+                          </tr>
+                      </table>
+                      <!-- // FLEXIBLE CONTAINER -->
+                  </td>
+              </tr>
+          </table>
+          <!-- // CENTERING TABLE -->
+      </td>
+  </tr>
+  <!-- // MODULE ROW -->
+
+  {% block actionbutton %}{% endblock actionbutton %}
+
+{% endblock content %}

--- a/modules/core/server/views/email-templates/reference-notification-first.server.view.html
+++ b/modules/core/server/views/email-templates/reference-notification-first.server.view.html
@@ -1,5 +1,27 @@
-{% extends './email.server.view.html' %}
+{% extends './email-with-container.server.view.html' %}
 
-{% block content %}
-<a href="{{giveReferenceUrl}}">give a reference</a>
-{% endblock content %}
+{% block textcontent %}
+  <p>
+    Hello {{userTo.firstName}}!
+  </p>
+
+  <p>
+    Great news! <a href="{{userFromProfileUrl}}">{{userFrom.firstName}}</a> left you a reference on Trustroots.
+  </p>
+
+  <p>You will be able to see their reference after you leave them a reference as well.</p>
+
+  <p>
+    Otherwise you will have two weeks to do this.
+    After two weeks, their reference for you will become public
+    and you will only be able to give them a positive reference.
+  </p>
+{% endblock textcontent %}
+
+{% block actionbutton %}
+  {% from "./partials/button.server.view.html" import button %}
+  {{button(giveReferenceUrl, 'Give a reference to ' + userFrom.firstName + ' now')}}
+
+  {% from "./partials/copypasteurl.server.view.html" import copyPasteUrl %}
+  {{copyPasteUrl(giveReferenceUrl)}}
+{% endblock actionbutton %}

--- a/modules/core/server/views/email-templates/reference-notification-first.server.view.html
+++ b/modules/core/server/views/email-templates/reference-notification-first.server.view.html
@@ -12,7 +12,7 @@
   <p>You will be able to see their reference after you leave them a reference as well.</p>
 
   <p>
-    Otherwise you will have two weeks to do this.
+    You have two weeks to do this.
     After two weeks, their reference for you will become public
     and you will only be able to give them a positive reference.
   </p>

--- a/modules/core/server/views/email-templates/reference-notification-second.server.view.html
+++ b/modules/core/server/views/email-templates/reference-notification-second.server.view.html
@@ -1,7 +1,24 @@
-{% extends './email.server.view.html' %}
+{% extends './email-with-container.server.view.html' %}
 
-{% block content %}
-<a href="{{seeReferencesUrl}}">see my references</a>
-the recommendation was {{recommend}} <!-- yes, no, unknown -->
-and we can show other reference data, too.
-{% endblock content %}
+{% block textcontent %}
+  <p>
+    Hi {{userTo.firstName}}!
+  </p>
+
+  <p>
+    Good news, <a href="{{userFromProfileUrl}}">{{userFrom.firstName}}</a> has left you a reference as well.
+  </p>
+
+  <p>
+    Their recommendation was {{recommend}}. <!-- yes, no, unknown -->
+  </p>
+{% endblock textcontent %}
+
+{% block actionbutton %}
+  {% from "./partials/button.server.view.html" import button %}
+  {{button(seeReferencesUrl, 'See my references')}}
+
+  {% from "./partials/copypasteurl.server.view.html" import copyPasteUrl %}
+  {{copyPasteUrl(seeReferencesUrl)}}
+<!-- It's also possible to say if the other person said they hosted us or met us etc. -->
+{% endblock actionbutton %}


### PR DESCRIPTION
#### Proposed Changes

* Improved email templates for references
* DRYing templates a bit
* Further suggestions for improvements are very welcome!

#### Currently looks like this:
Notification for user1 that user2 gave a reference:
![reference_notification_1](https://user-images.githubusercontent.com/7449720/49888246-bef5b000-fe3e-11e8-8013-7112615c09bf.png)

Notification for user2 that user1 gave a reference back:
![reference_notification_2](https://user-images.githubusercontent.com/7449720/49677384-d4558d80-fa7e-11e8-8e82-67fb9ad31552.png)

TODO show text email templates

#### Testing instructions
TODO (has to create references via API)

Work on #849
