### PR TITLE
Implicit meet offer does not display through date

### DIFF
--- a/modules/offers/client/directives/tr-offer-valid-until.client.directive.js
+++ b/modules/offers/client/directives/tr-offer-valid-until.client.directive.js
@@ -66,6 +66,8 @@
         if ($scope.validUntil) {
           vm.isCalendarVisible = true;
           vm.validUntil = $scope.validUntil;
+        } else {
+          setValidUntilDays(vm.offerValidityInDays);
         }
 
         $scope.$watch('trOfferValidUntil.offerValidityInDays', function (newValue, oldValue) {


### PR DESCRIPTION
`setValidUntilDays()` is not called when first opening the "New meet" page because the default is already set

#### Proposed Changes

On the `activate()` function of the directive a call to `setValidUntilDays()` will be done if the date was not pre-populated

#### Testing Instructions

- Open `offer/meet/add` page. Check that the text under `How long should this be visible?` is not only `Visible through` but also contains a date until the meet will be visible.
- Try to modify an existing Meet and check that the date is still populated correctly.

Fixes #923