### PR TITLE
Fixed `gulp run fontello` not working

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,6 +16,7 @@ var _ = require('lodash'),
     webpack = require('webpack'),
     webpackStream = require('webpack-stream'),
     merge = require('webpack-merge'),
+    print = require('gulp-print').default,
     plugins = gulpLoadPlugins({
       rename: {
         'gulp-angular-templatecache': 'templateCache'
@@ -403,9 +404,9 @@ function fontello() {
     .pipe(plugins.fontello({
       font: 'font', // Destination dir for Fonts and Glyphs
       css: 'css', // Destination dir for CSS Styles,
-      assetsOnly: true // extract from ZipFile only CSS Styles and Fonts exclude config.json, LICENSE.txt, README.txt and demo.html
+      assetsOnly: false
     }))
-    .pipe(plugins.print())
+    .pipe(print())
     .pipe(gulp.dest('modules/core/client/fonts/fontello'))
     .pipe(plugins.refresh());
 }
@@ -496,6 +497,9 @@ gulp.task('build:prod', gulp.series(
     'build:scripts'
   )
 ));
+
+// Run fontello update
+gulp.task('fontello', fontello);
 
 // Run the project tests
 gulp.task('test', gulp.series(


### PR DESCRIPTION
#### Proposed Changes

* Using `gulp-print` for printing (plugins.print()) doesn't work.
* Switched assetsOnly to true, because false apparently creates the new icons but I haven't been able to have them available.
* created gulp task for fontello.

#### Testing Instructions

* Follow these instructions: https://github.com/Trustroots/trustroots/blob/master/docs/Icons.md

Fixes https://github.com/Trustroots/trustroots/pull/927#issuecomment-445494156
