### PR TITLE
Show Save&Exit only when editing existing Meetup

### DIFF
--- a/modules/offers/client/less/edit.less
+++ b/modules/offers/client/less/edit.less
@@ -166,3 +166,7 @@
     margin-top: 40px;
   }
 }
+
+.btn-inverse-primary {
+  margin-left: 5px;
+}

--- a/modules/offers/client/less/edit.less
+++ b/modules/offers/client/less/edit.less
@@ -167,6 +167,8 @@
   }
 }
 
-.btn-inverse-primary {
-  margin-left: 5px;
+.offers-edit {
+  .btn-inverse-primary {
+    margin-left: 5px;
+  }
 }

--- a/modules/offers/client/views/offer-meet-edit.client.view.html
+++ b/modules/offers/client/views/offer-meet-edit.client.view.html
@@ -9,9 +9,17 @@
   <button type="submit"
           class="btn btn-lg btn-inverse-primary pull-right hidden-xs"
           aria-hidden="true"
-          ng-disabled="offerMeet.isLoading">
+          ng-disabled="offerMeet.isLoading"
+          ng-if="!offerMeet.newOffer">
     Save and Exit
   </button>
+
+  <button
+  class="btn btn-lg btn-inverse-primary pull-right hidden-xs"
+  aria-label="Cancel adding a meet offer"
+  ui-sref="offer.meet.list">
+  Cancel
+ </button>
 
   <uib-tabset class="offer-tabs" active="offerMeet.offerTab">
 
@@ -156,13 +164,13 @@
     <div class="container">
       <ul class="nav navbar-nav nav-justified" role="toolbar" aria-label="Offer actions">
         <li>
-          <a ng-if="offerMeet.offerTab === 0"
+          <button ng-if="offerMeet.offerTab === 0"
              type="button"
              class="btn btn-lg btn-primary"
              aria-label="Cancel adding a meet offer"
              ui-sref="offer.meet.list">
             Cancel
-          </a>
+          </button>
           <button ng-if="offerMeet.offerTab >= 1"
              type="button"
              class="btn btn-lg btn-primary"


### PR DESCRIPTION
Fixes #924 
#### Proposed Changes
All is for big-screen version
* Show Save&Exit only when editing existing Meetup
* added Cancel button to both add/edit

#### Testing Instructions

* Check if it feels like good UI


