### PR TITLE
Interface for selecting an app language

### DIFF
--- a/config/client/i18n.js
+++ b/config/client/i18n.js
@@ -61,7 +61,7 @@ i18n
     detection: {
       lookupCookie: 'i18n',
       order: ['cookie'],
-      chaches: ['cookie']
+      caches: ['cookie']
     }
     // saveMissingPlurals: true,
     // debug: true // show missing translation keys in console.log

--- a/config/client/i18n.js
+++ b/config/client/i18n.js
@@ -1,6 +1,7 @@
 import i18n from 'i18next';
 import { reactI18nextModule } from 'react-i18next';
 import backend from 'i18next-xhr-backend';
+import detector from 'i18next-browser-languagedetector';
 import moment from 'moment';
 
 /**
@@ -44,17 +45,23 @@ function format(value, format, languageCode) {
 }
 
 i18n
+  .use(detector)
   .use(backend)
   .use(reactI18nextModule) // passes i18n down to react-i18next
   .init({
-    lng: 'en', // a default app locale
     // allow keys to be phrases having `:`, `.`
+    fallbackLng: 'en', // a default app locale
     nsSeparator: false,
-    // saveMissing: true, // @TODO send not translated keys to endpoint
     keySeparator: false, // we do not use keys in form messages.welcome
+    // saveMissing: true, // @TODO send not translated keys to endpoint
     interpolation: {
       escapeValue: false, // react already safes from xss
       format
+    },
+    detection: {
+      lookupCookie: 'i18n',
+      order: ['cookie'],
+      chaches: ['cookie']
     }
     // saveMissingPlurals: true,
     // debug: true // show missing translation keys in console.log

--- a/config/client/i18n.js
+++ b/config/client/i18n.js
@@ -49,8 +49,8 @@ i18n
   .use(backend)
   .use(reactI18nextModule) // passes i18n down to react-i18next
   .init({
-    // allow keys to be phrases having `:`, `.`
     fallbackLng: 'en', // a default app locale
+    // allow keys to be phrases having `:`, `.`
     nsSeparator: false,
     keySeparator: false, // we do not use keys in form messages.welcome
     // saveMissing: true, // @TODO send not translated keys to endpoint

--- a/modules/core/client/components/LanguageSwitch.component.js
+++ b/modules/core/client/components/LanguageSwitch.component.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import i18n from '@/config/client/i18n';
 import locales from '@/config/shared/locales';
 import PropTypes from 'prop-types';
 import { Dropdown, MenuItem } from 'react-bootstrap';
+import LanguageSwitchContainer from './LanguageSwitchContainer';
 
-function LanguageSwitchPresentation({ currentLanguageCode, onChangeLanguage }) {
-  // selected language
-  const currentLanguage = locales.find(language => language.code === currentLanguageCode);
+function LanguageSwitchDropdownPresentation({ currentLanguageCode, onChangeLanguage }) {
   // languages which are not selected
   const otherLanguages = locales.filter(language => language.code !== currentLanguageCode);
+  // selected language
+  const currentLanguage = locales.find(language => language.code === currentLanguageCode);
 
   return (
     <Dropdown
@@ -31,36 +31,41 @@ function LanguageSwitchPresentation({ currentLanguageCode, onChangeLanguage }) {
   );
 };
 
-LanguageSwitchPresentation.propTypes = {
+LanguageSwitchDropdownPresentation.propTypes = {
   currentLanguageCode: PropTypes.string,
   onChangeLanguage: PropTypes.func
 };
 
-export default class LanguageSwitch extends React.Component {
-  constructor(props) {
-    super(props);
+function LanguageSwitchSelectPresentation({ currentLanguageCode, onChangeLanguage }) {
+  return (
+    <select
+      className="form-control"
+      id="locale"
+      value={currentLanguageCode}
+      onChange={(event) => onChangeLanguage(event.target.value)}
+    >
+      {locales.map(language => (
+        <option key={language.code} value={language.code} >
+          {language.name}
+        </option>
+      ))}
+    </select>
+  );
+};
 
-    this.state = {
-      currentLanguageCode: 'en'
-    };
+LanguageSwitchSelectPresentation.propTypes = {
+  currentLanguageCode: PropTypes.string,
+  onChangeLanguage: PropTypes.func
+};
 
-    // bind class context to class methods
-    this.handleChangeLanguage = this.handleChangeLanguage.bind(this);
-  }
-
-  handleChangeLanguage(languageCode) {
-    this.setState(() => ({ currentLanguageCode: languageCode }));
-    i18n.changeLanguage(languageCode);
-  }
-
-  render() {
-    return (
-      <LanguageSwitchPresentation
-        currentLanguageCode={this.state.currentLanguageCode}
-        onChangeLanguage={this.handleChangeLanguage}
-      />
-    );
-  }
+export default function LanguageSwitch({ presentation='dropdown' }) {
+  return (
+    <LanguageSwitchContainer presentation={
+      (presentation === 'dropdown') ? LanguageSwitchDropdownPresentation : LanguageSwitchSelectPresentation
+    } />
+  );
 }
 
-LanguageSwitch.propTypes = {};
+LanguageSwitch.propTypes = {
+  presentation: PropTypes.string
+};

--- a/modules/core/client/components/LanguageSwitch.component.js
+++ b/modules/core/client/components/LanguageSwitch.component.js
@@ -16,6 +16,7 @@ function LanguageSwitchDropdownPresentation({ currentLanguageCode, onChangeLangu
       title={currentLanguage.name}
       id={`dropdown-basic-${currentLanguage.code}`}
       pullRight
+      className="disable-hover-display"
     >
       <Dropdown.Toggle className="btn-inverse">
         {currentLanguage.label}

--- a/modules/core/client/components/LanguageSwitch.component.js
+++ b/modules/core/client/components/LanguageSwitch.component.js
@@ -1,19 +1,66 @@
 import React from 'react';
 import i18n from '@/config/client/i18n';
 import locales from '@/config/shared/locales';
+import PropTypes from 'prop-types';
+import { Dropdown, MenuItem } from 'react-bootstrap';
 
-export default function LanguageSwitch() {
-  const changeLanguage = (languageCode) => {
-    i18n.changeLanguage(languageCode);
-  };
+function LanguageSwitchPresentation({ currentLanguageCode, onChangeLanguage }) {
+  // selected language
+  const currentLanguage = locales.find(language => language.code === currentLanguageCode);
+  // languages which are not selected
+  const otherLanguages = locales.filter(language => language.code !== currentLanguageCode);
 
   return (
-    <select onChange={(event) => changeLanguage(event.target.value)}>
-      {locales.map(({ code, label }) => (
-        <option key={code} value={code}>{label}</option>
-      ))}
-    </select>
+    <Dropdown
+      bsSize="large"
+      title={currentLanguage.name}
+      id={`dropdown-basic-${currentLanguage.code}`}
+      pullRight
+    >
+      <Dropdown.Toggle className="btn-inverse">
+        {currentLanguage.label}
+      </Dropdown.Toggle>
+      <Dropdown.Menu>
+        {otherLanguages.map(({ code, label }) => (
+          <MenuItem key={code} onClick={() => onChangeLanguage(code)}>
+            {label}
+          </MenuItem>
+        ))}
+      </Dropdown.Menu>
+    </Dropdown>
   );
 };
+
+LanguageSwitchPresentation.propTypes = {
+  currentLanguageCode: PropTypes.string,
+  onChangeLanguage: PropTypes.func
+};
+
+export default class LanguageSwitch extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      currentLanguageCode: 'en'
+    };
+
+    // bind class context to class methods
+    this.handleChangeLanguage = this.handleChangeLanguage.bind(this);
+  }
+
+  handleChangeLanguage(languageCode) {
+    this.setState(() => ({ currentLanguageCode: languageCode }));
+    i18n.changeLanguage(languageCode);
+  }
+
+  render() {
+    return (
+      <LanguageSwitchPresentation
+        currentLanguageCode={this.state.currentLanguageCode}
+        onChangeLanguage={this.handleChangeLanguage}
+      />
+    );
+  }
+}
 
 LanguageSwitch.propTypes = {};

--- a/modules/core/client/components/LanguageSwitch.component.js
+++ b/modules/core/client/components/LanguageSwitch.component.js
@@ -1,64 +1,13 @@
 import React from 'react';
-import locales from '@/config/shared/locales';
 import PropTypes from 'prop-types';
-import { Dropdown, MenuItem } from 'react-bootstrap';
 import LanguageSwitchContainer from './LanguageSwitchContainer';
+import { LanguageSwitchDropdownPresentation, LanguageSwitchSelectPresentation } from './LanguageSwitchPresentational';
 
-function LanguageSwitchDropdownPresentation({ currentLanguageCode, onChangeLanguage }) {
-  // languages which are not selected
-  const otherLanguages = locales.filter(language => language.code !== currentLanguageCode);
-  // selected language
-  const currentLanguage = locales.find(language => language.code === currentLanguageCode);
-
-  return (
-    <Dropdown
-      bsSize="large"
-      title={currentLanguage.name}
-      id={`dropdown-basic-${currentLanguage.code}`}
-      pullRight
-      className="disable-hover-display"
-    >
-      <Dropdown.Toggle className="btn-inverse">
-        {currentLanguage.label}
-      </Dropdown.Toggle>
-      <Dropdown.Menu>
-        {otherLanguages.map(({ code, label }) => (
-          <MenuItem key={code} onClick={() => onChangeLanguage(code)}>
-            {label}
-          </MenuItem>
-        ))}
-      </Dropdown.Menu>
-    </Dropdown>
-  );
-};
-
-LanguageSwitchDropdownPresentation.propTypes = {
-  currentLanguageCode: PropTypes.string,
-  onChangeLanguage: PropTypes.func
-};
-
-function LanguageSwitchSelectPresentation({ currentLanguageCode, onChangeLanguage }) {
-  return (
-    <select
-      className="form-control"
-      id="locale"
-      value={currentLanguageCode}
-      onChange={(event) => onChangeLanguage(event.target.value)}
-    >
-      {locales.map(language => (
-        <option key={language.code} value={language.code} >
-          {language.name}
-        </option>
-      ))}
-    </select>
-  );
-};
-
-LanguageSwitchSelectPresentation.propTypes = {
-  currentLanguageCode: PropTypes.string,
-  onChangeLanguage: PropTypes.func
-};
-
+/**
+ * The main LanguageSwitch component.
+ * @param {'dropdown'|'select'} presentation - should we show dropdown (header), or select (account) selector?
+ * @param {Boolean} [saveToAPI=false] - should we save selected language to API?
+ */
 export default function LanguageSwitch({ presentation='dropdown', saveToAPI=false }) {
   return (
     <LanguageSwitchContainer presentation={

--- a/modules/core/client/components/LanguageSwitch.component.js
+++ b/modules/core/client/components/LanguageSwitch.component.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import LanguageSwitchContainer from './LanguageSwitchContainer';
-import { LanguageSwitchDropdownPresentation, LanguageSwitchSelectPresentation } from './LanguageSwitchPresentational';
+import { LanguageSwitchDropdown, LanguageSwitchSelect } from './LanguageSwitchPresentational';
 
 /**
  * The main LanguageSwitch component.
@@ -11,7 +11,7 @@ import { LanguageSwitchDropdownPresentation, LanguageSwitchSelectPresentation } 
 export default function LanguageSwitch({ presentation='dropdown', saveToAPI=false }) {
   return (
     <LanguageSwitchContainer presentation={
-      (presentation === 'dropdown') ? LanguageSwitchDropdownPresentation : LanguageSwitchSelectPresentation
+      (presentation === 'dropdown') ? LanguageSwitchDropdown : LanguageSwitchSelect
     } saveToAPI={saveToAPI} />
   );
 }

--- a/modules/core/client/components/LanguageSwitch.component.js
+++ b/modules/core/client/components/LanguageSwitch.component.js
@@ -58,14 +58,15 @@ LanguageSwitchSelectPresentation.propTypes = {
   onChangeLanguage: PropTypes.func
 };
 
-export default function LanguageSwitch({ presentation='dropdown' }) {
+export default function LanguageSwitch({ presentation='dropdown', saveToAPI=false }) {
   return (
     <LanguageSwitchContainer presentation={
       (presentation === 'dropdown') ? LanguageSwitchDropdownPresentation : LanguageSwitchSelectPresentation
-    } />
+    } saveToAPI={saveToAPI} />
   );
 }
 
 LanguageSwitch.propTypes = {
-  presentation: PropTypes.string
+  presentation: PropTypes.string,
+  saveToAPI: PropTypes.bool
 };

--- a/modules/core/client/components/LanguageSwitchContainer.js
+++ b/modules/core/client/components/LanguageSwitchContainer.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import i18n from '@/config/client/i18n';
 import PropTypes from 'prop-types';
+import * as users from '@/modules/users/client/api/users.api';
+
+const api = { users };
 
 export default class LanguageSwitchContainer extends React.Component {
   constructor(props) {
@@ -14,9 +17,14 @@ export default class LanguageSwitchContainer extends React.Component {
     this.handleChangeLanguage = this.handleChangeLanguage.bind(this);
   }
 
-  handleChangeLanguage(languageCode) {
+  async handleChangeLanguage(languageCode) {
     this.setState(() => ({ currentLanguageCode: languageCode }));
     i18n.changeLanguage(languageCode);
+
+    // save the user's choice to api
+    if (this.props.saveToAPI) {
+      await api.users.update({ locale: languageCode });
+    }
   }
 
   render() {
@@ -30,5 +38,6 @@ export default class LanguageSwitchContainer extends React.Component {
 }
 
 LanguageSwitchContainer.propTypes = {
-  presentation: PropTypes.func.isRequired
+  presentation: PropTypes.func.isRequired,
+  saveToAPI: PropTypes.bool.isRequired
 };

--- a/modules/core/client/components/LanguageSwitchContainer.js
+++ b/modules/core/client/components/LanguageSwitchContainer.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import i18n from '@/config/client/i18n';
+import PropTypes from 'prop-types';
+
+export default class LanguageSwitchContainer extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      currentLanguageCode: i18n.language
+    };
+
+    // bind class context to class methods
+    this.handleChangeLanguage = this.handleChangeLanguage.bind(this);
+  }
+
+  handleChangeLanguage(languageCode) {
+    this.setState(() => ({ currentLanguageCode: languageCode }));
+    i18n.changeLanguage(languageCode);
+  }
+
+  render() {
+    return (
+      <this.props.presentation
+        currentLanguageCode={this.state.currentLanguageCode}
+        onChangeLanguage={this.handleChangeLanguage}
+      />
+    );
+  }
+}
+
+LanguageSwitchContainer.propTypes = {
+  presentation: PropTypes.func.isRequired
+};

--- a/modules/core/client/components/LanguageSwitchContainer.js
+++ b/modules/core/client/components/LanguageSwitchContainer.js
@@ -23,6 +23,7 @@ export default class LanguageSwitchContainer extends React.Component {
 
     // save the user's choice to api
     if (this.props.saveToAPI) {
+      // @TODO this needs some feedback. Currently no feedback to user that this was saved.
       await api.users.update({ locale: languageCode });
     }
   }

--- a/modules/core/client/components/LanguageSwitchContainer.js
+++ b/modules/core/client/components/LanguageSwitchContainer.js
@@ -5,6 +5,15 @@ import * as users from '@/modules/users/client/api/users.api';
 
 const api = { users };
 
+/**
+ * Smart component for Language switch.
+ * It expects (as Component attributes):
+ * @param {Component} presentation - a presentational component with props:
+ *   - currentLanguageCode
+ *   - languages
+ *   - onChangeLanguage
+ * @param {Boolean} saveToAPI - save the selection to API or not?
+ */
 export default class LanguageSwitchContainer extends React.Component {
   constructor(props) {
     super(props);

--- a/modules/core/client/components/LanguageSwitchPresentational.js
+++ b/modules/core/client/components/LanguageSwitchPresentational.js
@@ -10,8 +10,6 @@ import locales from '@/config/shared/locales';
  * @param {Function} onChangeLanguage - what to do when language is changed
  */
 export function LanguageSwitchDropdown({ currentLanguageCode, onChangeLanguage }) {
-  // languages which are not selected
-  const otherLanguages = locales.filter(language => language.code !== currentLanguageCode);
   // selected language
   const currentLanguage = locales.find(language => language.code === currentLanguageCode);
 
@@ -27,8 +25,8 @@ export function LanguageSwitchDropdown({ currentLanguageCode, onChangeLanguage }
         {currentLanguage.label}
       </Dropdown.Toggle>
       <Dropdown.Menu>
-        {otherLanguages.map(({ code, label }) => (
-          <MenuItem key={code} onClick={() => onChangeLanguage(code)}>
+        {locales.map(({ code, label }) => (
+          <MenuItem key={code} onClick={() => onChangeLanguage(code)} active={code === currentLanguageCode}>
             {label}
           </MenuItem>
         ))}

--- a/modules/core/client/components/LanguageSwitchPresentational.js
+++ b/modules/core/client/components/LanguageSwitchPresentational.js
@@ -9,7 +9,7 @@ import locales from '@/config/shared/locales';
  * @param {String} currentLanguageCode - code of current language
  * @param {Function} onChangeLanguage - what to do when language is changed
  */
-export function LanguageSwitchDropdownPresentation({ currentLanguageCode, onChangeLanguage }) {
+export function LanguageSwitchDropdown({ currentLanguageCode, onChangeLanguage }) {
   // languages which are not selected
   const otherLanguages = locales.filter(language => language.code !== currentLanguageCode);
   // selected language
@@ -42,7 +42,7 @@ export function LanguageSwitchDropdownPresentation({ currentLanguageCode, onChan
  * Is used in user's account.
  * Params are the same as for LanguageSwitchDropdownPresentation.
  */
-export function LanguageSwitchSelectPresentation({ currentLanguageCode, onChangeLanguage }) {
+export function LanguageSwitchSelect({ currentLanguageCode, onChangeLanguage }) {
   return (
     <select
       className="form-control"
@@ -59,7 +59,7 @@ export function LanguageSwitchSelectPresentation({ currentLanguageCode, onChange
   );
 };
 
-LanguageSwitchSelectPresentation.propTypes = LanguageSwitchDropdownPresentation.propTypes = {
+LanguageSwitchSelect.propTypes = LanguageSwitchDropdown.propTypes = {
   currentLanguageCode: PropTypes.string,
   onChangeLanguage: PropTypes.func
 };

--- a/modules/core/client/components/LanguageSwitchPresentational.js
+++ b/modules/core/client/components/LanguageSwitchPresentational.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Dropdown, MenuItem } from 'react-bootstrap';
+import locales from '@/config/shared/locales';
+
+/**
+ * A presentational component of LanguageSwitch.
+ * Is used in header for non-logged users.
+ * @param {String} currentLanguageCode - code of current language
+ * @param {Function} onChangeLanguage - what to do when language is changed
+ */
+export function LanguageSwitchDropdownPresentation({ currentLanguageCode, onChangeLanguage }) {
+  // languages which are not selected
+  const otherLanguages = locales.filter(language => language.code !== currentLanguageCode);
+  // selected language
+  const currentLanguage = locales.find(language => language.code === currentLanguageCode);
+
+  return (
+    <Dropdown
+      bsSize="large"
+      title={currentLanguage.label}
+      id={`dropdown-basic-${currentLanguage.code}`}
+      pullRight
+      className="disable-hover-display"
+    >
+      <Dropdown.Toggle className="btn-inverse">
+        {currentLanguage.label}
+      </Dropdown.Toggle>
+      <Dropdown.Menu>
+        {otherLanguages.map(({ code, label }) => (
+          <MenuItem key={code} onClick={() => onChangeLanguage(code)}>
+            {label}
+          </MenuItem>
+        ))}
+      </Dropdown.Menu>
+    </Dropdown>
+  );
+};
+
+/**
+ * A presentational component of LanguageSwitch.
+ * Is used in user's account.
+ * Params are the same as for LanguageSwitchDropdownPresentation.
+ */
+export function LanguageSwitchSelectPresentation({ currentLanguageCode, onChangeLanguage }) {
+  return (
+    <select
+      className="form-control"
+      id="locale"
+      value={currentLanguageCode}
+      onChange={(event) => onChangeLanguage(event.target.value)}
+    >
+      {locales.map(({ code, label }) => (
+        <option key={code} value={code} >
+          {label}
+        </option>
+      ))}
+    </select>
+  );
+};
+
+LanguageSwitchSelectPresentation.propTypes = LanguageSwitchDropdownPresentation.propTypes = {
+  currentLanguageCode: PropTypes.string,
+  onChangeLanguage: PropTypes.func
+};

--- a/modules/core/client/less/layout/header.less
+++ b/modules/core/client/less/layout/header.less
@@ -64,7 +64,7 @@
   @media (min-width: @grid-float-breakpoint) {
 
     /* Make Bootstrap dropdowns open at hover */
-    .dropdown:hover .dropdown-menu {
+    .dropdown:hover:not(.disable-hover-display) .dropdown-menu {
       display: block;
     }
 
@@ -88,6 +88,7 @@
   align-items: center;
   justify-content: center;
   padding: 5px 0;
+
   .header-more-text,
   .header-welcome-text {
     font-size: 18px;
@@ -99,5 +100,20 @@
   .header-welcome-text,
   .btn {
     margin: 0 10px;
+  }
+
+  .flex-side {
+    flex: 1;
+  }
+
+  .language-switch {
+    display: flex;
+    justify-content: flex-end;
+
+    .dropdown-menu {
+      margin-top: 5px;
+      margin-right: 10px;
+      min-width: 100%; // We'd like dropdown-menu to be similar size to button. But it's 10px wider.
+    }
   }
 }

--- a/modules/core/client/less/layout/header.less
+++ b/modules/core/client/less/layout/header.less
@@ -112,7 +112,7 @@
 
     .dropdown-menu {
       margin-top: 5px;
-      margin-right: 10px;
+      margin-right: 5px;
       min-width: 100%; // We'd like dropdown-menu to be similar size to button. But it's 10px wider.
     }
   }

--- a/modules/core/server/views/partials/header.server.view.html
+++ b/modules/core/server/views/partials/header.server.view.html
@@ -24,7 +24,7 @@
         Read more
       </a>
 
-      <language-switch ng-if="app.appSettings.i18nEnabled"></language-switch>
+      <language-switch aria-label="Localization" ng-if="app.appSettings.i18nEnabled"></language-switch>
     </nav>
   </div>
   <!-- /Header for non-authenticated users -->
@@ -197,9 +197,6 @@
         <a ui-sref="navigation" aria-label="My profile, info and support">
           <i class="icon-menu icon-fw icon-lg"></i>
         </a>
-      </li>
-      <li ng-if="app.appSettings.i18nEnabled">
-        <language-switch></language-switch>
       </li>
     </ul>
 

--- a/modules/core/server/views/partials/header.server.view.html
+++ b/modules/core/server/views/partials/header.server.view.html
@@ -10,6 +10,8 @@
   <!-- Header for non-authenticated users -->
   <div class="container" ng-if="!app.user">
     <nav class="header-welcome text-center" aria-label="Page navigation" role="navigation">
+      <!-- a span for centering the main header content -->
+      <span class="flex-side"></span>
       <span class="header-welcome-text hidden-xs">New to Trustroots?</span>
       <a ui-sref="signup" class="btn btn-lg btn-default">
         Join
@@ -24,7 +26,7 @@
         Read more
       </a>
 
-      <language-switch aria-label="Localization" ng-if="app.appSettings.i18nEnabled"></language-switch>
+      <language-switch class="flex-side language-switch" aria-label="Localization" ng-if="app.appSettings.i18nEnabled"></language-switch>
     </nav>
   </div>
   <!-- /Header for non-authenticated users -->

--- a/modules/users/client/api/users.api.js
+++ b/modules/users/client/api/users.api.js
@@ -1,0 +1,10 @@
+import axios from 'axios';
+
+/**
+ * API request: update user
+ * @param {object} reference - reference to save
+ * @returns Promise<Reference> - saved reference
+ */
+export async function update(data) {
+  await axios.put('/api/users', data);
+}

--- a/modules/users/client/components/InterfaceLanguagePanel.component.js
+++ b/modules/users/client/components/InterfaceLanguagePanel.component.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import LanguageSwitch from '@/modules/core/client/components/LanguageSwitch.component';
+
+export default function InterfaceLanguagePanel() {
+  return (
+    <div className="panel panel-default" id="locale">
+      <div className="panel-heading">
+        Interface language
+      </div>
+      <div className="panel-body">
+
+        <form>
+          <div className="form-horizontal">
+
+            <div className="form-group">
+              <label className="col-sm-3 text-right control-label">Change language</label>
+              <div className="col-sm-9">
+
+                <div className="form-group">
+                  <div className="col-sm-9 col-md-7 col-lg-6">
+                    <LanguageSwitch presentation="select" />
+                  </div>
+                </div>
+
+                <p className="help-block"><small>This is the language of the interface you see across the site.</small></p>
+                <p className="help-block"><small>Thanks to all our community members who helped translate! <a href="/volunteering">You can help us out!</a></small></p>
+
+              </div>
+            </div>
+
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+InterfaceLanguagePanel.propTypes = {};

--- a/modules/users/client/components/InterfaceLanguagePanel.component.js
+++ b/modules/users/client/components/InterfaceLanguagePanel.component.js
@@ -18,7 +18,10 @@ export default function InterfaceLanguagePanel() {
 
                 <div className="form-group">
                   <div className="col-sm-9 col-md-7 col-lg-6">
-                    <LanguageSwitch presentation="select" />
+                    <LanguageSwitch
+                      presentation="select"
+                      saveToAPI={true}
+                    />
                   </div>
                 </div>
 

--- a/modules/users/client/components/InterfaceLanguagePanel.component.js
+++ b/modules/users/client/components/InterfaceLanguagePanel.component.js
@@ -1,11 +1,14 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import LanguageSwitch from '@/modules/core/client/components/LanguageSwitch.component';
+import '@/config/lib/i18n';
+import { withNamespaces } from 'react-i18next';
 
-export default function InterfaceLanguagePanel() {
+export function InterfaceLanguagePanel({ t }) {
   return (
     <div className="panel panel-default" id="locale">
       <div className="panel-heading">
-        Interface language
+        {t('Interface language')}
       </div>
       <div className="panel-body">
 
@@ -13,7 +16,7 @@ export default function InterfaceLanguagePanel() {
           <div className="form-horizontal">
 
             <div className="form-group">
-              <label className="col-sm-3 text-right control-label">Change language</label>
+              <label className="col-sm-3 text-right control-label">{t('Change language')}</label>
               <div className="col-sm-9">
 
                 <div className="form-group">
@@ -25,8 +28,8 @@ export default function InterfaceLanguagePanel() {
                   </div>
                 </div>
 
-                <p className="help-block"><small>This is the language of the interface you see across the site.</small></p>
-                <p className="help-block"><small>Thanks to all our community members who helped translate! <a href="/volunteering">You can help us out!</a></small></p>
+                <p className="help-block"><small>{t('This is the language of the interface you see across the site.')}</small></p>
+                <p className="help-block"><small>{t('Thanks to all our community members who helped translate!')} <a href="/volunteering">{t('You can help us out!')}</a></small></p>
 
               </div>
             </div>
@@ -38,4 +41,14 @@ export default function InterfaceLanguagePanel() {
   );
 }
 
-InterfaceLanguagePanel.propTypes = {};
+const InterfaceLanguagePanelHOC = withNamespaces('user')(InterfaceLanguagePanel);
+
+InterfaceLanguagePanelHOC.propTypes = {};
+
+Object.defineProperty(InterfaceLanguagePanelHOC, 'name', { value: InterfaceLanguagePanel.name });
+
+InterfaceLanguagePanel.propTypes = {
+  t: PropTypes.func.isRequired
+};
+
+export default InterfaceLanguagePanelHOC;

--- a/modules/users/client/components/InterfaceLanguagePanel.component.js
+++ b/modules/users/client/components/InterfaceLanguagePanel.component.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import LanguageSwitch from '@/modules/core/client/components/LanguageSwitch.component';
-import '@/config/lib/i18n';
-import { withNamespaces } from 'react-i18next';
+import '@/config/client/i18n';
+import { withNamespaces } from '@/modules/core/client/utils/i18n-angular-load';
 
 export function InterfaceLanguagePanel({ t }) {
   return (
@@ -41,14 +41,8 @@ export function InterfaceLanguagePanel({ t }) {
   );
 }
 
-const InterfaceLanguagePanelHOC = withNamespaces('user')(InterfaceLanguagePanel);
-
-InterfaceLanguagePanelHOC.propTypes = {};
-
-Object.defineProperty(InterfaceLanguagePanelHOC, 'name', { value: InterfaceLanguagePanel.name });
-
 InterfaceLanguagePanel.propTypes = {
   t: PropTypes.func.isRequired
 };
 
-export default InterfaceLanguagePanelHOC;
+export default withNamespaces('user')(InterfaceLanguagePanel);

--- a/modules/users/client/views/profile/profile-edit-account.client.view.html
+++ b/modules/users/client/views/profile/profile-edit-account.client.view.html
@@ -112,6 +112,10 @@
 </div>
 <!-- /Notifications -->
 
+<!-- Interface language -->
+<interface-language-panel ng-if="app.appSettings.i18nEnabled"></interface-language-panel>
+<!-- /Interface language -->
+
 <!-- Password -->
 <div class="panel panel-default" id="password">
   <div class="panel-heading">
@@ -282,7 +286,7 @@
 
   </div>
 </div>
-  <!-- /Data liberation -->
+<!-- /Data liberation -->
 
 <!-- Remove -->
 <div class="panel panel-default" id="remove">

--- a/package-lock.json
+++ b/package-lock.json
@@ -10208,6 +10208,11 @@
       "resolved": "https://registry.npmjs.org/i18next/-/i18next-13.0.0.tgz",
       "integrity": "sha512-P8SDA5PN4bI5/ZdLE2AlanZhU+eXh31icrojQvbGcG7jovoDoz79eKY9mSgQ0LAeuDFKAw4Vl4mGf1/EWGFACg=="
     },
+    "i18next-browser-languagedetector": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-2.2.4.tgz",
+      "integrity": "sha512-wPbtH18FdOuB245I8Bhma5/XSDdN/HpYlX+wga1eMy+slhaFQSnrWX6fp+aYSL2eEuj0RlfHeEVz6Fo/lxAj6A=="
+    },
     "i18next-xhr-backend": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/i18next-xhr-backend/-/i18next-xhr-backend-1.5.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15921,15 +15921,15 @@
       }
     },
     "react-test-renderer": {
-      "version": "16.8.2",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.2.tgz",
-      "integrity": "sha512-gsd4NoOaYrZD2R8zi+CBV9wTGMsGhE2bRe4wvenGy0WcLJgdPscRZDDz+kmLjY+/5XpYC8yRR/v4CScgYfGyoQ==",
+      "version": "16.7.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.7.0.tgz",
+      "integrity": "sha512-tFbhSjknSQ6+ttzmuGdv+SjQfmvGcq3PFKyPItohwhhOBmRoTf1We3Mlt3rJtIn85mjPXOkKV+TaKK4irvk9Yg==",
       "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "react-is": "^16.8.2",
-        "scheduler": "^0.13.2"
+        "react-is": "^16.7.0",
+        "scheduler": "^0.12.0"
       },
       "dependencies": {
         "object-assign": {
@@ -15939,10 +15939,20 @@
           "dev": true
         },
         "react-is": {
-          "version": "16.8.2",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.2.tgz",
-          "integrity": "sha512-D+NxhSR2HUCjYky1q1DwpNUD44cDpUXzSmmFyC3ug1bClcU/iDNy0YNn1iwme28fn+NFhpA13IndOd42CrFb+Q==",
+          "version": "16.7.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.7.0.tgz",
+          "integrity": "sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g==",
           "dev": true
+        },
+        "scheduler": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.12.0.tgz",
+          "integrity": "sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
         }
       }
     },
@@ -16731,24 +16741,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-    },
-    "scheduler": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.2.tgz",
-      "integrity": "sha512-qK5P8tHS7vdEMCW5IPyt8v9MJOHqTrOUgPXib7tqm9vh834ibBX5BNhwkplX/0iOzHW5sXyluehYfS9yrkz9+w==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        }
-      }
     },
     "schema-utils": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "helmet": "~3.15.0",
     "html-to-text": "~4.0.0",
     "i18next": "~13.0.0",
+    "i18next-browser-languagedetector": "^2.2.4",
     "i18next-xhr-backend": "^1.5.1",
     "imagesloaded": "~4.1.0",
     "influx": "~5.0.7",


### PR DESCRIPTION
Follow up of #921 

- [x] visitor can select a language in a header
  - the selected language will be saved in a cookie
- [x] user can select a language in account page
  - [x] the selected language will be saved in the database
  - [ ] the saved language will be loaded to i18n on signin or page reload #1054 
- [x] design of buttons (see [a proposed design](https://github.com/Trustroots/trustroots/pull/921#issuecomment-446142245))
  - [x] the language switch button in header needs positioning and some other details. i can't do that.

- API was updated in #962 