### PR TITLE
Add Search users pagination

### DIFF
--- a/config/env/default.js
+++ b/config/env/default.js
@@ -103,8 +103,8 @@ module.exports = {
     unreadMessageReminders: [{ minutes: 10 }, { hours: 24 }],
     // after what delay to stop sending further unread message reminders
     unreadMessageRemindersTooLate: { days: 14 },
-    // how many users should we return from search at maximum at one page
-    userSearchPageLimit: 10,
+    // pagination: how many results should we return per page
+    paginationLimit: 20,
     // Time intervals between welcome sequence emails
     welcomeSequence: {
       first: { minutes: 0 },

--- a/config/env/default.js
+++ b/config/env/default.js
@@ -103,8 +103,8 @@ module.exports = {
     unreadMessageReminders: [{ minutes: 10 }, { hours: 24 }],
     // after what delay to stop sending further unread message reminders
     unreadMessageRemindersTooLate: { days: 14 },
-    // how many users should we return from search at maximum
-    userSearchLimit: 10,
+    // how many users should we return from search at maximum at one page
+    userSearchPageLimit: 10,
     // Time intervals between welcome sequence emails
     welcomeSequence: {
       first: { minutes: 0 },

--- a/config/lib/express.js
+++ b/config/lib/express.js
@@ -111,7 +111,7 @@ module.exports.initMiddleware = function (app) {
 
   // Initialize pagination middleware
   // Set Pagination default values (limit, max limit)
-  app.use(paginate.middleware(20, 50));
+  app.use(paginate.middleware(config.limits.paginationLimit, 50));
 
   // Initialize favicon middleware
   app.use(favicon('public/favicon.ico'));

--- a/modules/users/server/controllers/users.profile.server.controller.js
+++ b/modules/users/server/controllers/users.profile.server.controller.js
@@ -1496,6 +1496,8 @@ exports.search = function (req, res, next) {
     });
   }
 
+
+
   // perform the search
   User
     .find({ $and: [
@@ -1510,7 +1512,9 @@ exports.search = function (req, res, next) {
     .select(exports.userSearchProfileFields)
     .sort({ score: { $meta: 'textScore' } })
     // limit the amount of found users (config)
-    .limit(config.limits.userSearchLimit)
+    .limit(config.limits.userSearchPageLimit)
+    // skip to the page, automatically handles invalid page number
+    .skip((req.query.page-1)*config.limits.userSearchPageLimit)
     .exec(function (err, users) {
       if (err) return next(err);
       return res.send(users);

--- a/modules/users/server/controllers/users.profile.server.controller.js
+++ b/modules/users/server/controllers/users.profile.server.controller.js
@@ -1496,8 +1496,6 @@ exports.search = function (req, res, next) {
     });
   }
 
-
-
   // perform the search
   User
     .find({ $and: [
@@ -1511,10 +1509,10 @@ exports.search = function (req, res, next) {
     // select only the right profile properties
     .select(exports.userSearchProfileFields)
     .sort({ score: { $meta: 'textScore' } })
-    // limit the amount of found users (config)
-    .limit(config.limits.userSearchPageLimit)
+    // limit the amount of found users
+    .limit(req.query.limit)
     // skip to the page, automatically handles invalid page number
-    .skip((req.query.page-1)*config.limits.userSearchPageLimit)
+    .skip(req.skip)
     .exec(function (err, users) {
       if (err) return next(err);
       return res.send(users);


### PR DESCRIPTION
Partially deals with #944 
#### Proposed Changes

* Added pagination to search users API
* Updated tests and added checks for this
* Limit for one page is configurable

#### Testing Instructions

* call `GET /api/users?page=2&search=xxx`
* calling without (or with invalid) page parameter should return the first page
* also request `GET /api/users?page=2&limit=10&search=xxx` should be supported

