### PR TITLE
Delete .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,0 @@
-node_modules
-public/assets


### PR DESCRIPTION
It will be useful in the future, but now it got here by mistake.