### PR TITLE
ansible: configured vault in ansible.cfg and added doku to README.md

### DIFF
--- a/deploy/ansible/README.md
+++ b/deploy/ansible/README.md
@@ -21,24 +21,39 @@ ansible-playbook playbooks/dev/tr.yml --limit staging --list-hosts
 ansible-playbook --check playbooks/dev/tr.yml
 ```
 
-### running ansible on only dev server
-```
-ansible-playbook playbooks/dev/tr.yml --limit dev
-```
-
-### running ansible on dev and staging
-```
-# TODO: make this possible again
-#ansible-playbook playbooks/dev/tr.yml --limit non-prod
-```
-
 ### deploy specific branch
 ```
 # 'branch' can be the full 40-character SHA-1 hash, the literal string HEAD, a branch name, or a tag name.
-ansible-playbook playbooks/dev/tr.yml --limit dev --extra-vars "version=any_branch"
+ansible-playbook playbooks/dev/tr.yml --extra-vars "version=any_branch"
 ```
 
 ### limit roles with --tag paramter
 ```
 ansible-playbook playbooks/dev/tr.yml --tags nginx --extra-vars "version=other_branch"
+```
+
+# ansible-vault
+
+## configure anisble vault
+
+0. Ask guaka for ansible-vault password
+1. put vault password where ansible is configured to look for it
+3. if needed, configure the env var $EDITOR (export or shell rc)
+
+```
+md5sum ~/.vault/trustroots-vault-pass.ansible
+b64d326e03c3c717941ef3200c7a41ca
+```
+
+## usage / test
+
+### decrypt to stdout
+```
+cd  repos/trustroots/deploy/ansible
+ansible-vault decrypt  ../files/secrets/dev.trustroots.org.local.js --output=-
+```
+
+### edit
+```
+ansible-vault edit  ../files/secrets/dev.trustroots.org.local.js
 ```

--- a/deploy/ansible/ansible.cfg
+++ b/deploy/ansible/ansible.cfg
@@ -2,3 +2,4 @@
 transport = ssh
 roles_path = roles/
 inventory = hosts
+vault_password_file = /home/zrth/.vault/trustroots-vault-pass.ansible


### PR DESCRIPTION
#### Proposed Changes
* Added TR specific ansible-vault doku to the ansible  README
* Add ansible-vault config to ansible config
This means one can run `ansible-vault` without specifying the 
`--vault-password-file=path_to_passwd`  parameter.

#### Testing Instructions
```
cd  repos/trustroots/deploy/ansible
ansible-vault decrypt  ../files/secrets/dev.trustroots.org.local.js --output=-
```
(see the readme for more details)

Fixes #
simplifies the process a bit