### PR TITLE
ansible: cd /srv/trustroots at ssh login

### DIFF
--- a/deploy/ansible/roles/users/files/_.zshrc
+++ b/deploy/ansible/roles/users/files/_.zshrc
@@ -3770,3 +3770,6 @@ zrclocal
 # Local variables:
 # mode: sh
 # End:
+
+cd /srv/trustroots
+


### PR DESCRIPTION
#### Proposed Changes

add `cd /srv/trustroots` to .zshrc so users `cd` automatically when they login via `ssh`

#### Testing Instructions

ssh dev_server

Fixes #

general simplification