### PR TITLE
Translate components of ReferencesNew

### DIFF
--- a/config/lib/i18n.js
+++ b/config/lib/i18n.js
@@ -41,6 +41,7 @@ i18n
       escapeValue: false, // react already safes from xss
       format
     }
+    // debug: true // show missing translation keys in console.log
   });
 
 export default i18n;

--- a/modules/references/client/components/CreateReference.component.js
+++ b/modules/references/client/components/CreateReference.component.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Tab, Tabs } from 'react-bootstrap';
 import '@/config/lib/i18n';
-import { NamespacesConsumer } from 'react-i18next';
+import { withNamespaces } from 'react-i18next';
 import * as references from '../api/references.api';
 import Navigation from './create-reference/Navigation';
 import Interaction from './create-reference/Interaction';
@@ -11,7 +11,7 @@ import { ReferenceToSelfInfo, LoadingInfo, DuplicateInfo, SubmittedInfo } from '
 
 const api = { references };
 
-export default class CreateReference extends React.Component {
+export class CreateReference extends React.Component {
 
   constructor(props) {
     super(props);
@@ -99,6 +99,7 @@ export default class CreateReference extends React.Component {
   }
 
   render() {
+    const { t } = this.props;
     const { hostedMe, hostedThem, met, recommend, report, reportMessage } = this.state;
     const primaryInteraction = (hostedMe && 'hostedMe') || (hostedThem && 'hostedThem') || 'met';
 
@@ -134,7 +135,7 @@ export default class CreateReference extends React.Component {
       return <SubmittedInfo isReported={isReported} isPublic={isPublic} userFrom={this.props.userFrom} userTo={this.props.userTo} />;
     }
 
-    return (<NamespacesConsumer ns="reference">{ t => (
+    return (
       <div>
         <Tabs
           activeKey={this.state.tab}
@@ -164,11 +165,22 @@ export default class CreateReference extends React.Component {
           onSubmit={this.handleSubmit}
         />
       </div>
-    )}</NamespacesConsumer>);
+    );
   }
 }
 
-CreateReference.propTypes = {
+const CreateReferenceHOC = withNamespaces('reference')(CreateReference);
+
+Object.defineProperty(CreateReferenceHOC, 'name', { value: 'CreateReference' });
+
+CreateReferenceHOC.propTypes = {
   userFrom: PropTypes.object.isRequired,
   userTo: PropTypes.object.isRequired
 };
+
+CreateReference.propTypes = {
+  ...CreateReferenceHOC.propTypes,
+  t: PropTypes.func.isRequired
+};
+
+export default CreateReferenceHOC;

--- a/modules/references/client/components/CreateReference.component.js
+++ b/modules/references/client/components/CreateReference.component.js
@@ -57,11 +57,7 @@ export class CreateReference extends React.Component {
   }
 
   handleChangeInteraction(interactionType) {
-    this.setState(state => {
-      const interaction = { };
-      interaction[interactionType] = !state[interactionType];
-      return interaction;
-    });
+    this.setState(state => ({ [interactionType]: !state[interactionType] }));
   }
 
   handleChangeRecommend(recommend) {

--- a/modules/references/client/components/CreateReference.component.js
+++ b/modules/references/client/components/CreateReference.component.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Tab, Tabs } from 'react-bootstrap';
-import '@/config/lib/i18n';
-import { withNamespaces } from 'react-i18next';
+import { withNamespaces } from '@/modules/core/client/utils/i18n-angular-load';
 import * as references from '../api/references.api';
 import Navigation from './create-reference/Navigation';
 import Interaction from './create-reference/Interaction';
@@ -165,18 +164,10 @@ export class CreateReference extends React.Component {
   }
 }
 
-const CreateReferenceHOC = withNamespaces('reference')(CreateReference);
-
-Object.defineProperty(CreateReferenceHOC, 'name', { value: 'CreateReference' });
-
-CreateReferenceHOC.propTypes = {
-  userFrom: PropTypes.object.isRequired,
-  userTo: PropTypes.object.isRequired
-};
-
 CreateReference.propTypes = {
-  ...CreateReferenceHOC.propTypes,
+  userFrom: PropTypes.object.isRequired,
+  userTo: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired
 };
 
-export default CreateReferenceHOC;
+export default withNamespaces('reference')(CreateReference);

--- a/modules/references/client/components/CreateReference.component.js
+++ b/modules/references/client/components/CreateReference.component.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Tab, Tabs } from 'react-bootstrap';
+import '@/config/lib/i18n';
+import { NamespacesConsumer } from 'react-i18next';
 import * as references from '../api/references.api';
 import Navigation from './create-reference/Navigation';
 import Interaction from './create-reference/Interaction';
 import Recommend from './create-reference/Recommend';
 import { ReferenceToSelfInfo, LoadingInfo, DuplicateInfo, SubmittedInfo } from './create-reference/Info';
-import { Tab, Tabs } from 'react-bootstrap';
 
 const api = { references };
 
@@ -132,7 +134,7 @@ export default class CreateReference extends React.Component {
       return <SubmittedInfo isReported={isReported} isPublic={isPublic} userFrom={this.props.userFrom} userTo={this.props.userTo} />;
     }
 
-    return (
+    return (<NamespacesConsumer ns="reference">{ t => (
       <div>
         <Tabs
           activeKey={this.state.tab}
@@ -142,12 +144,12 @@ export default class CreateReference extends React.Component {
         >
           <Tab
             eventKey={0}
-            title="How do you know them"
+            title={t('How do you know them')}
             disabled
           >{tabs[0]}</Tab>
           <Tab
             eventKey={1}
-            title="Recommendation"
+            title={t('Recommendation')}
             disabled
           >{tabs[1]}</Tab>
         </Tabs>
@@ -162,7 +164,7 @@ export default class CreateReference extends React.Component {
           onSubmit={this.handleSubmit}
         />
       </div>
-    );
+    )}</NamespacesConsumer>);
   }
 }
 

--- a/modules/references/client/components/create-reference/Info.js
+++ b/modules/references/client/components/create-reference/Info.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import '@/config/lib/i18n';
+import { withNamespaces } from 'react-i18next';
 
 // @TODO provide the value from API config endpoint
 const timeToReplyReference = { days: 14 };
@@ -19,16 +21,16 @@ UserLink.propTypes = {
 /**
  * Error message when trying to give a reference to oneself.
  */
-export function ReferenceToSelfInfo() {
-  return (<div className="alert alert-warning">Sorry, you can&apos;t give a reference to yourself.</div>);
-}
+export const ReferenceToSelfInfo = withNamespaces('reference')(function ({ t }) {
+  return (<div className="alert alert-warning">{t('Sorry, you can\'t give a reference to yourself.')}</div>);
+});
 
 /**
  * Info that data are loading.
  */
-export function LoadingInfo() {
-  return (<div>Wait a moment...</div>);
-}
+export const LoadingInfo = withNamespaces('reference')(function ({ t }) {
+  return (<div className="alert alert-warning">{t('Wait a moment...')}</div>);
+});
 
 /**
  * Error message when reference was already given

--- a/modules/references/client/components/create-reference/Info.js
+++ b/modules/references/client/components/create-reference/Info.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import '@/config/lib/i18n';
-import { withNamespaces } from 'react-i18next';
+import { withNamespaces, Trans } from 'react-i18next';
 
 // @TODO provide the value from API config endpoint
-const timeToReplyReference = { days: 14 };
+const daysToReply = 14;
 
 /**
  * Link to a user
@@ -36,9 +36,9 @@ export const LoadingInfo = withNamespaces('reference')(function ({ t }) {
  * Error message when reference was already given
  * @param {User} userTo
  */
-export function DuplicateInfo({ userTo }) {
-  return (<div className="alert alert-warning">You&apos;ve already given a reference to <UserLink user={userTo} />.</div>);
-}
+export const DuplicateInfo = withNamespaces('reference')(function ({ userTo }) {
+  return (<div className="alert alert-warning"><Trans>You&apos;ve already given a reference to <UserLink user={userTo} />.</Trans></div>);
+});
 
 DuplicateInfo.propTypes = {
   userTo: PropTypes.object.isRequired
@@ -47,28 +47,30 @@ DuplicateInfo.propTypes = {
 /**
  * Info after successful submitting of a new reference.
  */
-export function SubmittedInfo({ isReported, isPublic, userFrom, userTo }) {
+export const SubmittedInfo = withNamespaces('reference')(function ({ t, isReported, isPublic, userFrom, userTo }) {
   const name = userTo.displayName || userTo.username;
 
   const isPublicMessage = (isPublic) ?
     (
       <>
-      <div><a href={`/profile/${userTo.username}/references`}>Your reference</a> for <UserLink user={userTo} /> is public now.</div>
-      <div><a href={`/profile/${userFrom.username}/references`}>See the reference from {name} to you.</a></div>
+      <div><Trans><a href={`/profile/${userTo.username}/references`}>Your reference</a> for <UserLink user={userTo} /> is public now.</Trans></div>
+      <div><a href={`/profile/${userFrom.username}/references`}>{t('See the reference from {{name}} to you.', name)}</a></div>
       </>
     ) :
     (
-      <div>Your reference will become public when <UserLink user={userTo} /> gives you a reference back, or in {timeToReplyReference.days} days.</div>
+      <div>
+        <Trans daysToReply={daysToReply}>Your reference will become public when <UserLink user={userTo} /> gives you a reference back, or in {{ daysToReply }} days.</Trans>
+      </div>
     );
 
   return (
     <div className="alert alert-success">
-      <div>Done!</div>
+      <div>{t('Done!')}</div>
       <div>{isPublicMessage}</div>
-      {isReported && <div>Also, <UserLink user={userTo} /> was reported.</div>}
+      {isReported && <div><Trans>Also, <UserLink user={userTo} /> was reported.</Trans></div>}
     </div>
   );
-}
+});
 
 SubmittedInfo.propTypes = {
   userFrom: PropTypes.object.isRequired,

--- a/modules/references/client/components/create-reference/Interaction.js
+++ b/modules/references/client/components/create-reference/Interaction.js
@@ -10,10 +10,10 @@ const Interaction = withNamespaces('reference')(function ({ t, interactions, onC
   return (
     <div className="panel panel-default">
       <div className="panel-heading">
-        <h4 id="howDoYouKnowThemQuestion">{t('How do you know them?')}</h4>
+        <h4 id="how-do-you-know-them-question">{t('How do you know them?')}</h4>
       </div>
       <div className="panel-body">
-        <div role="group" aria-labelledby="howDoYouKnowThemQuestion">
+        <div role="group" aria-labelledby="how-do-you-know-them-question">
           <div className="checkbox">
             <label>
               <input

--- a/modules/references/client/components/create-reference/Interaction.js
+++ b/modules/references/client/components/create-reference/Interaction.js
@@ -1,14 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import '@/config/lib/i18n';
+import { withNamespaces } from 'react-i18next';
 
 /**
  * Presentational component for picking an interaction
  */
-export default function Interaction({ interactions, onChange }) {
+const Interaction = withNamespaces('reference')(function ({ t, interactions, onChange }) {
   return (
     <div className="panel panel-default">
       <div className="panel-heading">
-        <h4 id="howDoYouKnowThemQuestion">How do you know them?</h4>
+        <h4 id="howDoYouKnowThemQuestion">{t('How do you know them?')}</h4>
       </div>
       <div className="panel-body">
         <div role="group" aria-labelledby="howDoYouKnowThemQuestion">
@@ -19,7 +21,7 @@ export default function Interaction({ interactions, onChange }) {
                 checked={interactions.met}
                 onChange={() => onChange('met')}
               />
-              Met in person
+              {t('Met in person')}
             </label>
           </div>
           <div className="checkbox">
@@ -29,7 +31,7 @@ export default function Interaction({ interactions, onChange }) {
                 checked={interactions.hostedThem}
                 onChange={() => onChange('hostedThem')}
               />
-              I hosted them
+              {t('I hosted them')}
             </label>
           </div>
           <div className="checkbox">
@@ -39,16 +41,18 @@ export default function Interaction({ interactions, onChange }) {
                 checked={interactions.hostedMe}
                 onChange={() => onChange('hostedMe')}
               />
-              They hosted me
+              {t('They hosted me')}
             </label>
           </div>
         </div>
       </div>
     </div>
   );
-}
+});
 
 Interaction.propTypes = {
   onChange: PropTypes.func.isRequired,
   interactions: PropTypes.object.isRequired
 };
+
+export default Interaction;

--- a/modules/references/client/components/create-reference/Navigation.js
+++ b/modules/references/client/components/create-reference/Navigation.js
@@ -7,7 +7,7 @@ import { withNamespaces } from 'react-i18next';
  * It can contain three different buttons: Back, Next, Submit.
  * Each of them has a related property onBack, onNext, onSubmit
  */
-const Navigation = withNamespaces('reference')(function ({ t, disabled, tab, tabs, tabDone, onBack, onNext, onSubmit }) {
+export function Navigation({ t, disabled, tab, tabs, tabDone, onBack, onNext, onSubmit }) {
   const backButton = (
     <button
       type="button"
@@ -51,9 +51,10 @@ const Navigation = withNamespaces('reference')(function ({ t, disabled, tab, tab
       {showSubmitButton && submitButton}
     </div>
   );
-});
+}
 
 Navigation.propTypes = {
+  t: PropTypes.func.isRequired,
   onBack: PropTypes.func.isRequired,
   onNext: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
@@ -63,4 +64,4 @@ Navigation.propTypes = {
   tabDone: PropTypes.number.isRequired // which tab is already filled
 };
 
-export default Navigation;
+export default withNamespaces('reference')(Navigation);

--- a/modules/references/client/components/create-reference/Navigation.js
+++ b/modules/references/client/components/create-reference/Navigation.js
@@ -1,20 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { withNamespaces } from 'react-i18next';
 
 /**
  * Navigation is a react component.
- * It can contain three different buttons: Back, Next, Submit. Each of them has a related property onBack, onNext, onSubmit
- *
+ * It can contain three different buttons: Back, Next, Submit.
+ * Each of them has a related property onBack, onNext, onSubmit
  */
-export default function Navigation(props) {
+const Navigation = withNamespaces('reference')(function ({ t, disabled, tab, tabs, tabDone, onBack, onNext, onSubmit }) {
   const backButton = (
     <button
       type="button"
       className="btn btn-action btn-link"
       aria-label="Previous section"
-      onClick={props.onBack}>
+      onClick={onBack}>
       <span className="icon-left"></span>
-      Back
+      {t('Back')}
     </button>
   );
 
@@ -23,9 +24,9 @@ export default function Navigation(props) {
       type="button"
       className="btn btn-action btn-primary"
       aria-label="Next section"
-      onClick={props.onNext}
-      disabled={props.tabDone < props.tab}>
-      Next
+      onClick={onNext}
+      disabled={tabDone < tab}>
+      {t('Next')}
     </button>
   );
 
@@ -33,15 +34,15 @@ export default function Navigation(props) {
     <button
       className="btn btn-action btn-primary"
       aria-label="Submit reference"
-      onClick={props.onSubmit}
-      disabled={props.tabDone < props.tabs - 1 || props.disabled}>
-      Submit
+      onClick={onSubmit}
+      disabled={tabDone < tabs - 1 || disabled}>
+      {t('Submit')}
     </button>
   );
 
-  const showBackButton = props.tab > 0; // not the first tab
-  const showNextButton = props.tab < props.tabs - 1; // not the last tab
-  const showSubmitButton = props.tab === props.tabs - 1; // the last tab
+  const showBackButton = tab > 0; // not the first tab
+  const showNextButton = tab < tabs - 1; // not the last tab
+  const showSubmitButton = tab === tabs - 1; // the last tab
 
   return (
     <div className="text-center">
@@ -50,7 +51,7 @@ export default function Navigation(props) {
       {showSubmitButton && submitButton}
     </div>
   );
-}
+});
 
 Navigation.propTypes = {
   onBack: PropTypes.func.isRequired,
@@ -62,3 +63,4 @@ Navigation.propTypes = {
   tabDone: PropTypes.number.isRequired // which tab is already filled
 };
 
+export default Navigation;

--- a/modules/references/client/components/create-reference/Recommend.js
+++ b/modules/references/client/components/create-reference/Recommend.js
@@ -1,14 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Report from './Report';
 import { ToggleButton, ToggleButtonGroup } from 'react-bootstrap';
+import '@/config/lib/i18n';
+import { withNamespaces } from 'react-i18next';
+import Report from './Report';
 
-export default function Recommend({ primaryInteraction, recommend, report, reportMessage, onChangeRecommend, onChangeReport, onChangeReportMessage }) {
+const Recommend = withNamespaces('reference')(function ({ t, primaryInteraction, recommend, report, reportMessage, onChangeRecommend, onChangeReport, onChangeReportMessage }) {
 
   const recommendQuestions = {
-    hostedMe: 'Would you recommend others to stay with them?',
-    hostedThem: 'Would you recommend others to host them?',
-    met: 'Would you recommend others to meet them?'
+    hostedMe: t('Would you recommend others to stay with them?'),
+    hostedThem: t('Would you recommend others to host them?'),
+    met: t('Would you recommend others to meet them?')
   };
 
   const question = recommendQuestions[primaryInteraction];
@@ -27,29 +29,29 @@ export default function Recommend({ primaryInteraction, recommend, report, repor
           aria-labelledby="recommendationQuestion">
           <ToggleButton
             className="btn btn-lg"
-            aria-checked={ recommend === 'yes' }
+            aria-checked={recommend === 'yes'}
             value="yes"
             bsStyle="success"
             bsSize="large"
           >
-            Yes
+            {t('Yes')}
           </ToggleButton>
           <ToggleButton
             className="btn btn-lg"
-            aria-checked={ recommend === 'no' }
+            aria-checked={recommend === 'no'}
             value="no"
             bsStyle="danger"
             bsSize="large"
           >
-            No
+            {t('No')}
           </ToggleButton>
           <ToggleButton
-            aria-checked={recommend === 'unknown' }
+            aria-checked={recommend === 'unknown'}
             value="unknown"
             bsStyle="default"
             bsSize="large"
           >
-            I don&apos;t know
+            {t('I don\'t know')}
           </ToggleButton>
         </ToggleButtonGroup>
         {recommend === 'no' && (
@@ -63,7 +65,7 @@ export default function Recommend({ primaryInteraction, recommend, report, repor
       </div>
     </div>
   );
-}
+});
 
 Recommend.propTypes = {
   primaryInteraction: PropTypes.string.isRequired,
@@ -74,3 +76,5 @@ Recommend.propTypes = {
   onChangeReport: PropTypes.func.isRequired,
   onChangeReportMessage: PropTypes.func.isRequired
 };
+
+export default Recommend;

--- a/modules/references/client/components/create-reference/Report.js
+++ b/modules/references/client/components/create-reference/Report.js
@@ -3,8 +3,7 @@ import PropTypes from 'prop-types';
 import '@/config/lib/i18n';
 import { withNamespaces } from 'react-i18next';
 
-function Report(props) {
-  const { t } = props;
+const Report = withNamespaces('reference')(function ({ t, report, reportMessage, onChangeReport, onChangeReportMessage }) {
   return (
     <div>
       <br /><br />
@@ -15,20 +14,20 @@ function Report(props) {
         <label>
           <input
             type="checkbox"
-            checked={props.report}
-            onChange={props.onChangeReport}
+            checked={report}
+            onChange={onChangeReport}
           />
           {t('Report this person to moderators')}
         </label>
       </div>
-      {props.report && (
+      {report && (
         <div>
           <label htmlFor="report-message" className="control-label">{t('Message to moderators')}</label>
           <textarea className="form-control input-lg"
             rows="7"
             id="message"
-            onChange={(event) => props.onChangeReportMessage(event.target.value)}
-            value={props.reportMessage}
+            onChange={(event) => onChangeReportMessage(event.target.value)}
+            value={reportMessage}
           ></textarea>
           <span className="help-block">
             {t('Please write in English if possible.')}<br />
@@ -37,14 +36,13 @@ function Report(props) {
       )}
     </div>
   );
-}
+});
 
 Report.propTypes = {
   report: PropTypes.bool.isRequired,
   reportMessage: PropTypes.string.isRequired,
   onChangeReport: PropTypes.func.isRequired,
-  onChangeReportMessage: PropTypes.func.isRequired,
-  t: PropTypes.func.isRequired
+  onChangeReportMessage: PropTypes.func.isRequired
 };
 
-export default withNamespaces('reference')(Report);
+export default Report;

--- a/modules/references/client/components/create-reference/Report.js
+++ b/modules/references/client/components/create-reference/Report.js
@@ -1,12 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import '@/config/lib/i18n';
+import { withNamespaces } from 'react-i18next';
 
-export default function Report(props) {
+function Report(props) {
+  const { t } = props;
   return (
     <div>
       <br /><br />
       <p className="lead">
-        We&apos;re sad to hear you didn&apos;t have great experience using Trustroots! 😞
+        {t('We\'re sad to hear you didn\'t have a great experience using Trustroots!')} 😞
       </p>
       <div className="checkbox">
         <label>
@@ -15,12 +18,12 @@ export default function Report(props) {
             checked={props.report}
             onChange={props.onChangeReport}
           />
-          Report this person to moderators
+          {t('Report this person to moderators')}
         </label>
       </div>
       {props.report && (
         <div>
-          <label htmlFor="report-message" className="control-label">Message to moderators</label>
+          <label htmlFor="report-message" className="control-label">{t('Message to moderators')}</label>
           <textarea className="form-control input-lg"
             rows="7"
             id="message"
@@ -28,7 +31,7 @@ export default function Report(props) {
             value={props.reportMessage}
           ></textarea>
           <span className="help-block">
-            Please write in English if possible.<br />
+            {t('Please write in English if possible.')}<br />
           </span>
         </div>
       )}
@@ -40,5 +43,8 @@ Report.propTypes = {
   report: PropTypes.bool.isRequired,
   reportMessage: PropTypes.string.isRequired,
   onChangeReport: PropTypes.func.isRequired,
-  onChangeReportMessage: PropTypes.func.isRequired
+  onChangeReportMessage: PropTypes.func.isRequired,
+  t: PropTypes.func.isRequired
 };
+
+export default withNamespaces('reference')(Report);

--- a/modules/references/tests/client/CreateReference.client.component.tests.js
+++ b/modules/references/tests/client/CreateReference.client.component.tests.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import CreateReference from '../../client/components/CreateReference.component';
+import { CreateReference } from '../../client/components/CreateReference.component';
 import { ReferenceToSelfInfo, LoadingInfo, DuplicateInfo, SubmittedInfo } from '../../client/components/create-reference/Info';
 import Interaction from '../../client/components/create-reference/Interaction';
 import Navigation from '../../client/components/create-reference/Navigation';
@@ -30,13 +30,15 @@ Enzyme.configure({ adapter: new Adapter() });
       sinon.restore();
     });
 
+    const t = key => key;
+
     it('should not be possible to leave a reference to self', () => {
       const me = {
         _id: '123456',
         username: 'username'
       };
 
-      const wrapper = shallow(<CreateReference userFrom={me} userTo={me} />);
+      const wrapper = shallow(<CreateReference userFrom={me} userTo={me} t={t} />);
       expect(wrapper.find(ReferenceToSelfInfo)).toExist();
     });
 
@@ -47,7 +49,7 @@ Enzyme.configure({ adapter: new Adapter() });
       stub.withArgs({ userFrom: userFrom._id, userTo: userTo._id }).returns(new Promise(() => {}));
 
       expect(stub.callCount).toBe(0);
-      const wrapper = shallow(<CreateReference userFrom={userFrom} userTo={userTo} />);
+      const wrapper = shallow(<CreateReference userFrom={userFrom} userTo={userTo} t={t} />);
       expect(stub.callCount).toBe(1);
       expect(wrapper.find(LoadingInfo)).toExist();
     });
@@ -60,7 +62,7 @@ Enzyme.configure({ adapter: new Adapter() });
         userFrom, userTo, public: false
       }]);
 
-      const wrapper = shallow(<CreateReference userFrom={userFrom} userTo={userTo} />);
+      const wrapper = shallow(<CreateReference userFrom={userFrom} userTo={userTo} t={t} />);
 
       expect(wrapper.find(DuplicateInfo)).not.toExist();
       await null; // wait for the next tick (resolve stubbed API call)
@@ -74,7 +76,7 @@ Enzyme.configure({ adapter: new Adapter() });
       const stub = sinon.stub(api, 'read');
       stub.withArgs({ userFrom: userFrom._id, userTo: userTo._id }).resolves([]);
 
-      const wrapper = shallow(<CreateReference userFrom={userFrom} userTo={userTo} />);
+      const wrapper = shallow(<CreateReference userFrom={userFrom} userTo={userTo} t={t} />);
       expect(wrapper.find(Interaction)).not.toExist();
       await null; // wait for the next tick (resolve stubbed API call)
       expect(wrapper.find(Interaction)).toExist();
@@ -87,7 +89,7 @@ Enzyme.configure({ adapter: new Adapter() });
       const stubRead = sinon.stub(api, 'read');
       stubRead.withArgs({ userFrom: userFrom._id, userTo: userTo._id }).resolves([]);
 
-      const wrapper = shallow(<CreateReference userFrom={userFrom} userTo={userTo} />);
+      const wrapper = shallow(<CreateReference userFrom={userFrom} userTo={userTo} t={t} />);
 
       await null; // wait for the next tick (resolve stubbed API call)
 
@@ -122,7 +124,7 @@ Enzyme.configure({ adapter: new Adapter() });
       stubRead.withArgs({ userFrom: userFrom._id, userTo: userTo._id }).resolves([]);
       stubCreate.resolves();
 
-      const wrapper = shallow(<CreateReference userFrom={userFrom} userTo={userTo} />);
+      const wrapper = shallow(<CreateReference userFrom={userFrom} userTo={userTo} t={t} />);
 
       await null; // wait for the next tick (resolve stubbed API call)
 
@@ -163,7 +165,7 @@ Enzyme.configure({ adapter: new Adapter() });
       const userFrom = { _id: '111111', username: 'userfrom' };
       const userTo = { _id: '222222', username: 'userto' };
 
-      const wrapper = shallow(<CreateReference userFrom={userFrom} userTo={userTo} />);
+      const wrapper = shallow(<CreateReference userFrom={userFrom} userTo={userTo} t={t} />);
 
       wrapper.setState({
         isLoading: false,

--- a/public/locales/cze/reference.json
+++ b/public/locales/cze/reference.json
@@ -1,0 +1,4 @@
+{
+  "Yes": "Ano",
+  "Sorry, you can't give a reference to yourself.": "Promiň, sobě nemůžeš dát referenci."
+}


### PR DESCRIPTION
#### Proposed Changes

* translating create-references-react #827 
* fixing and refactoring tests (figuring out how to [test components with translation](https://react.i18next.com/misc/testing))
* additional refactoring

#### Testing Instructions

* in your `config/env/local.js` enable references and i18n
  ```js
  {
    ...,
    featureFlags: {
      i18n: true,
      reference: true
    },
    ...
  }
  ```
* `npm start`
* go to `localhost:3000/profile/{username}/references/new`
* switch the language button in header from `eng` to other language
* observe the changes
* _Note that most of the translations are not provided. Even after switching the language, most texts will remain in English._

To get the translations working, we'll need...
* a tool which extracts the keys to `/public/locales/{lng}/reference.json`
* to translate

Follow up of #827 
