### PR TITLE
Configs: remove process.env

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -114,6 +114,7 @@ module.exports = {
   }, {
     // overrides for client/react code
     files: [
+      'config/env/**',
       'config/webpack/**',
       'config/lib/i18n.js',
       'modules/core/client/app/config.js',

--- a/config/env/default.js
+++ b/config/env/default.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*
  * Please don't make your own config changes to this file!
  * Copy local.sample.js to local.js and make your changes there. Thanks.
@@ -13,18 +11,14 @@
  */
 
 module.exports = {
+  featureFlags: {
+    reference: false,
+    i18n: false
+  },
   app: {
     title: 'Trustroots',
     description: 'Travellers community for sharing, hosting and getting people together. We want a world that encourages trust and adventure.'
   },
-
-  // Feature flags
-  featureFlags: {
-    // enable references?
-    reference: false,
-    i18n: false
-  },
-
   // Is site invitation only?
   invitations: {
     enabled: false,
@@ -47,16 +41,16 @@ module.exports = {
     // You can access user object like this: `{{app.user.displayName}}`
     message: ''
   },
-  maxUploadSize: process.env.MAX_UPLOAD_SIZE || 10 * 1024 * 1024, // 10MB. Remember to change this to Nginx configs as well
+  maxUploadSize: 10 * 1024 * 1024, // 10MB. Remember to change this to Nginx configs as well
   imageProcessor: 'graphicsmagick', // graphicsmagick|imagemagick
   uploadTmpDir: './tmp/',
   uploadDir: './public/uploads-profile',
-  port: process.env.PORT || 3000,
+  port: 3000,
   host: 'localhost',
-  https: process.env.HTTPS || false,
+  https: false,
   sessionSecret: 'MEAN',
   sessionCollection: 'sessions',
-  domain: process.env.DOMAIN || 'localhost:3000',
+  domain: 'localhost:3000',
   supportEmail: 'support@trustroots.org', // TO-address for support requests
   surveyReactivateHosts: 'https://ideas.trustroots.org/?p=1302#page-1302', // Survey to send with host reactivation emails
   profileMinimumLength: 140, // Require User.profile.description to be >=140 chars to send messages
@@ -68,9 +62,9 @@ module.exports = {
   ],
   // SparkPost webhook API endpoint configuration (`/api/sparkpost/webhook`)
   sparkpostWebhook: {
-    enabled: process.env.SPARKPOST_WEBHOOK_ENABLED || true,
-    username: process.env.SPARKPOST_WEBHOOK_USERNAME || 'sparkpost',
-    password: process.env.SPARKPOST_WEBHOOK_PASSWORD || 'sparkpost'
+    enabled: true,
+    username: 'sparkpost',
+    password: 'sparkpost'
   },
   influxdb: {
     enabled: false,
@@ -121,12 +115,12 @@ module.exports = {
     maxOfferValidFromNow: { days: 30 }
   },
   mailer: {
-    from: process.env.MAILER_FROM || 'trustroots@localhost',
+    from: 'trustroots@localhost',
     options: {
-      service: process.env.MAILER_SERVICE_PROVIDER || false,
+      service: false,
       auth: {
-        user: process.env.MAILER_EMAIL_ID || false,
-        pass: process.env.MAILER_PASSWORD || false
+        user: false,
+        pass: false
       }
     }
   },
@@ -149,44 +143,44 @@ module.exports = {
         legacy: false
       }
     },
-    user: process.env.MAPBOX_USERNAME || '',
-    publicKey: process.env.MAPBOX_ACCESS_TOKEN || ''
+    user: '',
+    publicKey: ''
   },
   facebook: {
-    page: process.env.FACEBOOK_PAGE || '',
-    clientID: process.env.FACEBOOK_ID || false,
-    clientSecret: process.env.FACEBOOK_SECRET || false,
-    clientAccessToken: process.env.FACEBOOK_ACCESS_TOKEN || false,
+    page: '',
+    clientID: false,
+    clientSecret: false,
+    clientAccessToken: false,
     callbackURL: '/api/auth/facebook/callback',
-    notificationsEnabled: process.env.FACEBOOK_NOTIFICATIONS_ENABLED || false
+    notificationsEnabled: false
   },
   twitter: {
-    username: process.env.TWITTER_USERNAME || '',
-    clientID: process.env.TWITTER_KEY || '',
-    clientSecret: process.env.TWITTER_SECRET || '',
+    username: '',
+    clientID: '',
+    clientSecret: '',
     callbackURL: '/api/auth/twitter/callback'
   },
   google: {
-    page: process.env.GOOGLE_PAGE || ''
+    page: ''
   },
   fcm: {
-    senderId: process.env.FCM_SENDER_ID || '',
+    senderId: '',
     serviceAccount: false
   },
   github: {
-    clientID: process.env.GITHUB_ID || '',
-    clientSecret: process.env.GITHUB_SECRET || '',
+    clientID: '',
+    clientSecret: '',
     callbackURL: '/api/auth/github/callback'
   },
   googleAnalytics: {
-    enabled: process.env.GA_ENABLED || false,
-    code: process.env.GA_CODE || ''
+    enabled: false,
+    code: ''
   },
   log: {
     papertrail: {
       // If host & port are false, papertrail is disabled
-      host: process.env.WINSTON_HOST || false,
-      port: process.env.WINSTON_PORT || false,
+      host: false,
+      port: false,
       level: 'debug',
       program: 'production',
       inlineMeta: true

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*
  * Please don't make your own config changes to this file!
  * Copy local.sample.js to local.js and make your changes there. Thanks.
@@ -11,10 +9,9 @@
  */
 
 module.exports = {
-  // Feature flags
   featureFlags: {
-    // enable references?
-    reference: true
+    reference: true,
+    i18n: false
   },
   db: {
     uri: 'mongodb://' + (process.env.DB_1_PORT_27017_TCP_ADDR || 'localhost') + '/trustroots-dev',

--- a/config/env/local.docker.js
+++ b/config/env/local.docker.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * `local.docker.js` is copied to `local.js` by Docker provisioning
  *

--- a/config/env/local.sample.js
+++ b/config/env/local.sample.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Rename this file to local.js for having local configuration variables that
  * will not get commited and pushed to remote repositories.
@@ -12,6 +10,12 @@
  */
 
 module.exports = {
+  /*
+  featureFlags: {
+    ...require('development').featureFlags
+    // List your fature flag modifications here
+  }
+  */
 
   /*
   // Appears on top of every page for authenticated users.

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -24,6 +24,5 @@ module.exports = {
     debug: false,
     // Check for MongoDB version compatibility on start
     checkCompatibility: false
-  },
-  domain: process.env.DOMAIN || 'www.trustroots.org'
+  }
 };

--- a/config/env/test.js
+++ b/config/env/test.js
@@ -11,9 +11,7 @@
  */
 
 module.exports = {
-  // Feature flags
   featureFlags: {
-    // enable references?
     reference: true,
     i18n: true
   },
@@ -55,12 +53,12 @@ module.exports = {
   },
   mapbox: {
     // Mapbox is publicly exposed to the frontend
-    user: process.env.MAPBOX_USERNAME || 'trustroots',
+    user: 'trustroots',
     map: {
-      default: process.env.MAPBOX_MAP_DEFAULT || false,
-      satellite: process.env.MAPBOX_MAP_SATELLITE || false,
-      hitchmap: process.env.MAPBOX_MAP_HITCHMAP || false
+      default: false,
+      satellite: false,
+      hitchmap: false
     },
-    publicKey: process.env.MAPBOX_ACCESS_TOKEN || 'pk.eyJ1IjoidHJ1c3Ryb290cyIsImEiOiJVWFFGa19BIn0.4e59q4-7e8yvgvcd1jzF4g'
+    publicKey: 'pk.eyJ1IjoidHJ1c3Ryb290cyIsImEiOiJVWFFGa19BIn0.4e59q4-7e8yvgvcd1jzF4g'
   }
 };


### PR DESCRIPTION
#### Proposed Changes

Some configs cleanup:
- Remove `process.env.*` variables since they're not used anywhere and just add noise (apart from `process.env.DB_1_PORT_27017_TCP_ADDR` which I think is used in Travis)
- Remove `domain` from production config as it's provided via `local.js` in production and should otherwise default to localhost.
- Add an example of how to override `featureFlags` in `local.sample.js`
- Remove redundant comments around featureFlags and put them on top of the file for clarity
- Add i18n feature flag to the development config
- ES6

#### Testing Instructions

The app should run as usual.