### PR TITLE
Travis CI: run lint and build in the same container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ node_js:
   - 10
   - 11
 env:
-  - RUN=npm run test:client
-  - RUN=npm run test:server:no-lint
-  - RUN=npm run lint && npm run build:prod
+  - $RUN="npm run test:client"
+  - $RUN="npm run test:server:no-lint"
+  - $RUN="npm run lint && npm run build:prod"
 script:
   - $RUN
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,15 @@ node_js:
   - 10
   - 11
 env:
-  - RUN=lint
-  - RUN=test:client
-  - RUN=test:server:no-lint
-  - RUN=build:prod
+  - RUN=npm run test:client
+  - RUN=npm run test:server:no-lint
+  - RUN=npm run lint && npm run build:prod
 script:
-  - npm run $RUN
+  - $RUN
 install:
   - npm ci
 matrix:
-fast_finish: true
+  fast_finish: true
 # https://docs.travis-ci.com/user/reference/overview/#Virtualisation-Environment-vs-Operating-System
 dist: trusty
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ before_script:
 
 cache:
   directories:
+    - "$HOME/.node-gyp"
     - "$HOME/.npm"
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
 env:
   - $RUN="npm run test:client"
   - $RUN="npm run test:server:no-lint"
-  - $RUN="npm run lint && npm run build:prod"
+  - $RUN="npm run travis-ci"
 script:
   - $RUN
 install:

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "test:server:no-lint": "npm run pretest && gulp test:server:no-lint",
     "test:server:watch": "npm run pretest && gulp test:server:watch",
     "test:server": "npm run pretest && gulp test:server",
-    "test": "npm run lint && gulp test"
+    "test": "npm run lint && gulp test",
+    "travis-ci": "concurrently --raw --kill-others --kill-others-on-fail 'npm run lint' 'npm run build:prod'"
   },
   "dependencies": {
     "acl": "~0.4.11",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "test:server:watch": "npm run pretest && gulp test:server:watch",
     "test:server": "npm run pretest && gulp test:server",
     "test": "npm run lint && gulp test",
-    "travis-ci": "concurrently --raw --kill-others --kill-others-on-fail 'npm run lint' 'npm run build:prod'"
+    "travis-ci": "concurrently --raw --kill-others-on-fail 'npm run lint' 'npm run build:prod'"
   },
   "dependencies": {
     "acl": "~0.4.11",


### PR DESCRIPTION
Eliminate one container in Travis by running linter and build in the same one.

Spinning up a container is expensive and linting task itself takes just some seconds.

Additionally, as a Travis free plan users, we cannot have that many containers running concurrently.

This should speed up CI little bit.