### PR TITLE
Refactor email templates to extend email-with-container

### DIFF
--- a/modules/core/server/views/email-templates/confirm-contact.server.view.html
+++ b/modules/core/server/views/email-templates/confirm-contact.server.view.html
@@ -1,72 +1,23 @@
-{% extends './email.server.view.html' %}
+{% extends './email-with-container.server.view.html' %}
 
-{% block content %}
+{% block textcontent %}
+  <p>Hey {{name}}!</p>
 
-  <!-- MODULE ROW // -->
-  <tr>
-    <td align="center" valign="top">
-        <!-- CENTERING TABLE // -->
-          <!--
-            The centering table keeps the content
-              tables centered in the emailBody table,
-              in case its width is set to 100%.
-          -->
-        <table border="0" cellpadding="0" cellspacing="0" width="100%">
-            <tr>
-                <td align="center" valign="top">
-                    <!-- FLEXIBLE CONTAINER // -->
-                      <!--
-                        The flexible container has a set width
-                          that gets overridden by the media query.
-                          Most content tables within can then be
-                          given 100% widths.
-                      -->
-                    <table border="0" cellpadding="0" cellspacing="0" width="600" class="flexibleContainer">
-                        <tr>
-                            <td align="center" valign="top" width="600" class="flexibleContainerCell">
+  <p><a href="{{meURL}}">{{meName}}</a> would like to connect with you on Trustroots.</p>
 
-                                  <!-- CONTENT TABLE // -->
-                                  <!--
-                                    The content table is the first element
-                                      that's entirely separate from the structural
-                                      framework of the email.
-                                  -->
-                                  <table border="0" cellpadding="0" cellspacing="0" width="100%">
-                                      <tr>
-                                          <td valign="top" class="textContent">
+  {% if messageHTML %}
+    <div class="message">
+    {{messageHTML | safe }}
+    </div>
+  {% endif %}
 
-                                              <p>Hey {{name}}!</p>
-                                              <p><a href="{{meURL}}">{{meName}}</a> would like to connect with you on Trustroots.</p>
+  <p>To confirm or discard this connection, please click the link below.</p>
+{% endblock textcontent %}
 
-                                              {% if messageHTML %}
-                                              <div class="message">
-                                                {{messageHTML | safe }}
-                                              </div>
-                                              {% endif %}
-
-                                              <p>To confirm or discard this connection, please click the link below.</p>
-                                          </td>
-                                      </tr>
-                                  </table>
-                                  <!-- // CONTENT TABLE -->
-
-
-                              </td>
-                          </tr>
-                      </table>
-                      <!-- // FLEXIBLE CONTAINER -->
-                  </td>
-              </tr>
-          </table>
-          <!-- // CENTERING TABLE -->
-      </td>
-  </tr>
-  <!-- // MODULE ROW -->
-
+{% block actionbutton %}
   {% from "./partials/button.server.view.html" import button %}
   {{ button(urlConfirm, 'See connection') }}
 
   {% from "./partials/copypasteurl.server.view.html" import copyPasteUrl %}
   {{ copyPasteUrl(urlConfirmPlainText) }}
-
-{% endblock content %}
+{% endblock actionbutton %}

--- a/modules/core/server/views/email-templates/email-confirmation.server.view.html
+++ b/modules/core/server/views/email-templates/email-confirmation.server.view.html
@@ -1,69 +1,17 @@
-{% extends './email.server.view.html' %}
+{% extends './email-with-container.server.view.html' %}
 
-{% block content %}
+{% block textcontent %}
+  <p>Hey {{name}}!</p>
 
-  <!-- MODULE ROW // -->
-  <tr>
-    <td align="center" valign="top">
-        <!-- CENTERING TABLE // -->
-          <!--
-            The centering table keeps the content
-              tables centered in the emailBody table,
-              in case its width is set to 100%.
-          -->
-        <table border="0" cellpadding="0" cellspacing="0" width="100%">
-            <tr>
-                <td align="center" valign="top">
-                    <!-- FLEXIBLE CONTAINER // -->
-                      <!--
-                        The flexible container has a set width
-                          that gets overridden by the media query.
-                          Most content tables within can then be
-                          given 100% widths.
-                      -->
-                    <table border="0" cellpadding="0" cellspacing="0" width="600" class="flexibleContainer">
-                        <tr>
-                            <td align="center" valign="top" width="600" class="flexibleContainerCell">
+  <p>You initiated an email change at Trustroots. Please click the confirmation link below to confirm your new email address: {{email}}</p>
 
+  <p><strong>If you didn't make this request, you can ignore this email.</strong></p>
+{% endblock textcontent %}
 
-                                  <!-- CONTENT TABLE // -->
-                                  <!--
-                                    The content table is the first element
-                                      that's entirely separate from the structural
-                                      framework of the email.
-                                  -->
-                                  <table border="0" cellpadding="0" cellspacing="0" width="100%">
-                                      <tr>
-                                          <td valign="top" class="textContent">
-
-                                              <p>Hey {{name}}!</p>
-
-                                              <p>You initiated an email change at Trustroots. Please click the confirmation link below to confirm your new email address: {{email}}</p>
-
-                                              <p><strong>If you didn't make this request, you can ignore this email.</strong></p>
-
-                                          </td>
-                                      </tr>
-                                  </table>
-                                  <!-- // CONTENT TABLE -->
-
-
-                              </td>
-                          </tr>
-                      </table>
-                      <!-- // FLEXIBLE CONTAINER -->
-                  </td>
-              </tr>
-          </table>
-          <!-- // CENTERING TABLE -->
-      </td>
-  </tr>
-  <!-- // MODULE ROW -->
-
+{% block actionbutton %}
   {% from "./partials/button.server.view.html" import button %}
   {{ button(urlConfirm, 'Confirm') }}
 
   {% from "./partials/copypasteurl.server.view.html" import copyPasteUrl %}
   {{ copyPasteUrl(urlConfirmPlainText) }}
-
-{% endblock content %}
+{% endblock actionbutton %}

--- a/modules/core/server/views/email-templates/messages-unread.server.view.html
+++ b/modules/core/server/views/email-templates/messages-unread.server.view.html
@@ -1,73 +1,22 @@
-{% extends './email.server.view.html' %}
+{% extends './email-with-container.server.view.html' %}
 
-{% block content %}
+{% block textcontent %}
+  <p>Hello {{userToName}}!</p>
 
-  <!-- MODULE ROW // -->
-  <tr>
-    <td align="center" valign="top">
-        <!-- CENTERING TABLE // -->
-          <!--
-            The centering table keeps the content
-              tables centered in the emailBody table,
-              in case its width is set to 100%.
-          -->
-        <table border="0" cellpadding="0" cellspacing="0" width="100%">
-            <tr>
-                <td align="center" valign="top">
-                    <!-- FLEXIBLE CONTAINER // -->
-                      <!--
-                        The flexible container has a set width
-                          that gets overridden by the media query.
-                          Most content tables within can then be
-                          given 100% widths.
-                      -->
-                    <table border="0" cellpadding="0" cellspacing="0" width="600" class="flexibleContainer">
-                        <tr>
-                            <td align="center" valign="top" width="600" class="flexibleContainerCell">
+  {% if messageCount > 1 %}
+    <p>You have {{ messageCount }} unread messages from <strong><a href="{{urlUserFromProfile}}">{{userFromName}}</a></strong> at Trustroots.</p>
+  {% else %}
+    <p>You have one unread message from <strong><a href="{{urlUserFromProfile}}">{{userFromName}}</a></strong> at Trustroots.</p>
+  {% endif %}
 
+  {% from "./partials/message.server.view.html" import messagePreview %}
 
-                                  <!-- CONTENT TABLE // -->
-                                  <!--
-                                    The content table is the first element
-                                      that's entirely separate from the structural
-                                      framework of the email.
-                                  -->
-                                  <table border="0" cellpadding="0" cellspacing="0" width="100%">
-                                      <tr>
-                                          <td valign="top" class="textContent">
+  {% for message in messages %}
+    {{ messagePreview(message.content) }}
+  {% endfor %}
+{% endblock textcontent %}
 
-                                              <p>Hello {{userToName}}!</p>
-
-                                              {% if messageCount > 1 %}
-                                                <p>You have {{ messageCount }} unread messages from <strong><a href="{{urlUserFromProfile}}">{{userFromName}}</a></strong> at Trustroots.</p>
-                                              {% else %}
-                                                <p>You have one unread message from <strong><a href="{{urlUserFromProfile}}">{{userFromName}}</a></strong> at Trustroots.</p>
-                                              {% endif %}
-
-                                              {% from "./partials/message.server.view.html" import messagePreview %}
-                                              {% for message in messages %}
-                                                {{ messagePreview(message.content) }}
-                                              {% endfor %}
-
-                                          </td>
-                                      </tr>
-                                  </table>
-                                  <!-- // CONTENT TABLE -->
-
-
-                              </td>
-                          </tr>
-                      </table>
-                      <!-- // FLEXIBLE CONTAINER -->
-                  </td>
-              </tr>
-          </table>
-          <!-- // CENTERING TABLE -->
-      </td>
-  </tr>
-  <!-- // MODULE ROW -->
-
+{% block actionbutton %}
   {% from "./partials/button.server.view.html" import button %}
   {{ button(urlReply, 'Reply to ' + userFromName) }}
-
-{% endblock content %}
+{% endblock actionbutton %}

--- a/modules/core/server/views/email-templates/reactivate-hosts.server.view.html
+++ b/modules/core/server/views/email-templates/reactivate-hosts.server.view.html
@@ -1,65 +1,15 @@
-{% extends './email.server.view.html' %}
+{% extends './email-with-container.server.view.html' %}
 
-{% block content %}
+{% block textcontent %}
+  <p>Hi {{firstName}},</p>
 
-  <!-- MODULE ROW // -->
-  <tr>
-    <td align="center" valign="top">
-        <!-- CENTERING TABLE // -->
-          <!--
-            The centering table keeps the content
-              tables centered in the emailBody table,
-              in case its width is set to 100%.
-          -->
-        <table border="0" cellpadding="0" cellspacing="0" width="100%">
-            <tr>
-                <td align="center" valign="top">
-                    <!-- FLEXIBLE CONTAINER // -->
-                      <!--
-                        The flexible container has a set width
-                          that gets overridden by the media query.
-                          Most content tables within can then be
-                          given 100% widths.
-                      -->
-                    <table border="0" cellpadding="0" cellspacing="0" width="600" class="flexibleContainer">
-                        <tr>
-                            <td align="center" valign="top" width="600" class="flexibleContainerCell">
+  <p>you haven't been hosting for a while, would you like to host again?<br />
+  <a href="{{urlOffer}}">Change your status here</a>.</p>
 
-                                  <!-- CONTENT TABLE // -->
-                                  <!--
-                                    The content table is the first element
-                                      that's entirely separate from the structural
-                                      framework of the email.
-                                  -->
-                                  <table border="0" cellpadding="0" cellspacing="0" width="100%">
-                                      <tr>
-                                          <td valign="top" class="textContent">
+  {% if urlSurvey %}
+    <p>If you've decided to stop hosting, we'd absolutely love to<br />
+    hear why on <a href="{{urlSurvey}}">this 1 question survey</a>.</p>
+  {% endif %}
 
-                                              <p>Hi {{firstName}},</p>
-                                              <p>you haven't been hosting for a while, would you like to host again?<br>
-                                                <a href="{{urlOffer}}">Change your status here</a>.</p>
-                                              {% if urlSurvey %}
-                                                <p>If you've decided to stop hosting, we'd absolutely love to<br>
-                                                  hear why on <a href="{{urlSurvey}}">this 1 question survey</a>.</p>
-                                              {% endif %}
-                                              <p>Thanks for being part of the Trustroots community!</p>
-
-                                          </td>
-                                      </tr>
-                                  </table>
-                                  <!-- // CONTENT TABLE -->
-
-
-                              </td>
-                          </tr>
-                      </table>
-                      <!-- // FLEXIBLE CONTAINER -->
-                  </td>
-              </tr>
-          </table>
-          <!-- // CENTERING TABLE -->
-      </td>
-  </tr>
-  <!-- // MODULE ROW -->
-
-{% endblock content %}
+  <p>Thanks for being part of the Trustroots community!</p>
+{% endblock textcontent %}

--- a/modules/core/server/views/email-templates/remove-profile-confirmed.server.view.html
+++ b/modules/core/server/views/email-templates/remove-profile-confirmed.server.view.html
@@ -1,62 +1,11 @@
-{% extends './email.server.view.html' %}
+{% extends './email-with-container.server.view.html' %}
 
-{% block content %}
+{% block textcontent %}
+  <p>Hey {{name}}!</p>
 
-  <!-- MODULE ROW // -->
-  <tr>
-    <td align="center" valign="top">
-        <!-- CENTERING TABLE // -->
-          <!--
-            The centering table keeps the content
-              tables centered in the emailBody table,
-              in case its width is set to 100%.
-          -->
-        <table border="0" cellpadding="0" cellspacing="0" width="100%">
-            <tr>
-                <td align="center" valign="top">
-                    <!-- FLEXIBLE CONTAINER // -->
-                      <!--
-                        The flexible container has a set width
-                          that gets overridden by the media query.
-                          Most content tables within can then be
-                          given 100% widths.
-                      -->
-                    <table border="0" cellpadding="0" cellspacing="0" width="600" class="flexibleContainer">
-                        <tr>
-                            <td align="center" valign="top" width="600" class="flexibleContainerCell">
+  <p>Your Trustroots account has been removed.</p>
 
+  <p>Feel free to <a href="{{supportUrl}}">leave us feedback</a>!</p>
 
-                                  <!-- CONTENT TABLE // -->
-                                  <!--
-                                    The content table is the first element
-                                      that's entirely separate from the structural
-                                      framework of the email.
-                                  -->
-                                  <table border="0" cellpadding="0" cellspacing="0" width="100%">
-                                      <tr>
-                                          <td valign="top" class="textContent">
-
-                                              <p>Hey {{name}}!</p>
-                                              <p>Your Trustroots account has been removed.</p>
-                                              <p>Feel free to <a href="{{supportUrl}}">leave us feedback</a>!</p>
-                                              <p>If you think this was a mistake, please <a href="{{supportUrl}}">contact us</a> immediately.</p>
-
-                                          </td>
-                                      </tr>
-                                  </table>
-                                  <!-- // CONTENT TABLE -->
-
-
-                              </td>
-                          </tr>
-                      </table>
-                      <!-- // FLEXIBLE CONTAINER -->
-                  </td>
-              </tr>
-          </table>
-          <!-- // CENTERING TABLE -->
-      </td>
-  </tr>
-  <!-- // MODULE ROW -->
-
-{% endblock content %}
+  <p>If you think this was a mistake, please <a href="{{supportUrl}}">contact us</a> immediately.</p>
+{% endblock textcontent %}

--- a/modules/core/server/views/email-templates/remove-profile.server.view.html
+++ b/modules/core/server/views/email-templates/remove-profile.server.view.html
@@ -1,68 +1,19 @@
-{% extends './email.server.view.html' %}
+{% extends './email-with-container.server.view.html' %}
 
-{% block content %}
+{% block textcontent %}
+  <p>Hey {{name}}!</p>
 
-  <!-- MODULE ROW // -->
-  <tr>
-    <td align="center" valign="top">
-        <!-- CENTERING TABLE // -->
-          <!--
-            The centering table keeps the content
-              tables centered in the emailBody table,
-              in case its width is set to 100%.
-          -->
-        <table border="0" cellpadding="0" cellspacing="0" width="100%">
-            <tr>
-                <td align="center" valign="top">
-                    <!-- FLEXIBLE CONTAINER // -->
-                      <!--
-                        The flexible container has a set width
-                          that gets overridden by the media query.
-                          Most content tables within can then be
-                          given 100% widths.
-                      -->
-                    <table border="0" cellpadding="0" cellspacing="0" width="600" class="flexibleContainer">
-                        <tr>
-                            <td align="center" valign="top" width="600" class="flexibleContainerCell">
+  <p>Someone (probably you) requested removing your Trustroots account.</p>
 
+  <p>If you did not request this, just ignore this email. We'll keep your account safe.</p>
 
-                                  <!-- CONTENT TABLE // -->
-                                  <!--
-                                    The content table is the first element
-                                      that's entirely separate from the structural
-                                      framework of the email.
-                                  -->
-                                  <table border="0" cellpadding="0" cellspacing="0" width="100%">
-                                      <tr>
-                                          <td valign="top" class="textContent">
+  <p>Please click the link below to confirm your profile removal. The link is valid for 24 hours.</p>
+{% endblock textcontent %}
 
-                                              <p>Hey {{name}}!</p>
-                                              <p>Someone (probably you) requested removing your Trustroots account.</p>
-                                              <p>If you did not request this, just ignore this email. We'll keep your account safe.</p>
-                                              <p>Please click the link below to confirm your profile removal. The link is valid for 24 hours.</p>
-
-                                          </td>
-                                      </tr>
-                                  </table>
-                                  <!-- // CONTENT TABLE -->
-
-
-                              </td>
-                          </tr>
-                      </table>
-                      <!-- // FLEXIBLE CONTAINER -->
-                  </td>
-              </tr>
-          </table>
-          <!-- // CENTERING TABLE -->
-      </td>
-  </tr>
-  <!-- // MODULE ROW -->
-
+{% block actionbutton %}
   {% from "./partials/button.server.view.html" import button %}
   {{ button(urlConfirm, 'Confirm removing my profile') }}
 
   {% from "./partials/copypasteurl.server.view.html" import copyPasteUrl %}
   {{ copyPasteUrl(urlConfirmPlainText) }}
-
-{% endblock content %}
+{% endblock actionbutton %}

--- a/modules/core/server/views/email-templates/reset-password-confirm.server.view.html
+++ b/modules/core/server/views/email-templates/reset-password-confirm.server.view.html
@@ -1,61 +1,9 @@
-{% extends './email.server.view.html' %}
+{% extends './email-with-container.server.view.html' %}
 
-{% block content %}
+{% block textcontent %}
+  <p>Hey {{name}}!</p>
 
-  <!-- MODULE ROW // -->
-  <tr>
-    <td align="center" valign="top">
-        <!-- CENTERING TABLE // -->
-          <!--
-            The centering table keeps the content
-              tables centered in the emailBody table,
-              in case its width is set to 100%.
-          -->
-        <table border="0" cellpadding="0" cellspacing="0" width="100%">
-            <tr>
-                <td align="center" valign="top">
-                    <!-- FLEXIBLE CONTAINER // -->
-                      <!--
-                        The flexible container has a set width
-                          that gets overridden by the media query.
-                          Most content tables within can then be
-                          given 100% widths.
-                      -->
-                    <table border="0" cellpadding="0" cellspacing="0" width="600" class="flexibleContainer">
-                        <tr>
-                            <td align="center" valign="top" width="600" class="flexibleContainerCell">
+  <p>Your Trustroots account password has just been changed.</p>
 
-
-                                  <!-- CONTENT TABLE // -->
-                                  <!--
-                                    The content table is the first element
-                                      that's entirely separate from the structural
-                                      framework of the email.
-                                  -->
-                                  <table border="0" cellpadding="0" cellspacing="0" width="100%">
-                                      <tr>
-                                          <td valign="top" class="textContent">
-
-                                              <p>Hey {{name}}!</p>
-                                              <p>Your Trustroots account password has just been changed.</p>
-                                              <p>If you did not change it, please <a href="{{urlResetPassword}}">reset your password now.</a></p>
-
-                                          </td>
-                                      </tr>
-                                  </table>
-                                  <!-- // CONTENT TABLE -->
-
-
-                              </td>
-                          </tr>
-                      </table>
-                      <!-- // FLEXIBLE CONTAINER -->
-                  </td>
-              </tr>
-          </table>
-          <!-- // CENTERING TABLE -->
-      </td>
-  </tr>
-  <!-- // MODULE ROW -->
-
-{% endblock content %}
+  <p>If you did not change it, please <a href="{{urlResetPassword}}">reset your password now.</a></p>
+{% endblock textcontent %}

--- a/modules/core/server/views/email-templates/reset-password.server.view.html
+++ b/modules/core/server/views/email-templates/reset-password.server.view.html
@@ -1,68 +1,19 @@
-{% extends './email.server.view.html' %}
+{% extends './email-with-container.server.view.html' %}
 
-{% block content %}
+{% block textcontent %}
+  <p>Hey {{name}}!</p>
 
-  <!-- MODULE ROW // -->
-  <tr>
-    <td align="center" valign="top">
-        <!-- CENTERING TABLE // -->
-          <!--
-            The centering table keeps the content
-              tables centered in the emailBody table,
-              in case its width is set to 100%.
-          -->
-        <table border="0" cellpadding="0" cellspacing="0" width="100%">
-            <tr>
-                <td align="center" valign="top">
-                    <!-- FLEXIBLE CONTAINER // -->
-                      <!--
-                        The flexible container has a set width
-                          that gets overridden by the media query.
-                          Most content tables within can then be
-                          given 100% widths.
-                      -->
-                    <table border="0" cellpadding="0" cellspacing="0" width="600" class="flexibleContainer">
-                        <tr>
-                            <td align="center" valign="top" width="600" class="flexibleContainerCell">
+  <p>Someone (probably you) requested an account recovery on Trustroots for {{email}}.</p>
 
+  <p>If you did not request this, just ignore this email. We'll keep your account safe.</p>
 
-                                  <!-- CONTENT TABLE // -->
-                                  <!--
-                                    The content table is the first element
-                                      that's entirely separate from the structural
-                                      framework of the email.
-                                  -->
-                                  <table border="0" cellpadding="0" cellspacing="0" width="100%">
-                                      <tr>
-                                          <td valign="top" class="textContent">
+  <p>Please click the reset link below to reset your password.</p>
+{% endblock textcontent %}
 
-                                              <p>Hey {{name}}!</p>
-                                              <p>Someone (probably you) requested an account recovery on Trustroots for {{email}}.</p>
-                                              <p>If you did not request this, just ignore this email. We'll keep your account safe.</p>
-                                              <p>Please click the reset link below to reset your password.</p>
-
-                                          </td>
-                                      </tr>
-                                  </table>
-                                  <!-- // CONTENT TABLE -->
-
-
-                              </td>
-                          </tr>
-                      </table>
-                      <!-- // FLEXIBLE CONTAINER -->
-                  </td>
-              </tr>
-          </table>
-          <!-- // CENTERING TABLE -->
-      </td>
-  </tr>
-  <!-- // MODULE ROW -->
-
+{% block actionbutton %}
   {% from "./partials/button.server.view.html" import button %}
   {{ button(urlConfirm, 'Reset password') }}
 
   {% from "./partials/copypasteurl.server.view.html" import copyPasteUrl %}
   {{ copyPasteUrl(urlConfirmPlainText) }}
-
-{% endblock content %}
+{% endblock actionbutton %}

--- a/modules/core/server/views/email-templates/signup-reminder.server.view.html
+++ b/modules/core/server/views/email-templates/signup-reminder.server.view.html
@@ -1,127 +1,27 @@
-{% extends './email.server.view.html' %}
+{% extends './email-with-container.server.view.html' %}
 
-{% block content %}
+{% block textcontent %}
+  <p>{{name}},</p>
 
-  <!-- MODULE ROW // -->
-  <tr>
-    <td align="center" valign="top">
-        <!-- CENTERING TABLE // -->
-          <!--
-            The centering table keeps the content
-              tables centered in the emailBody table,
-              in case its width is set to 100%.
-          -->
-        <table border="0" cellpadding="0" cellspacing="0" width="100%">
-            <tr>
-                <td align="center" valign="top">
-                    <!-- FLEXIBLE CONTAINER // -->
-                      <!--
-                        The flexible container has a set width
-                          that gets overridden by the media query.
-                          Most content tables within can then be
-                          given 100% widths.
-                      -->
-                    <table border="0" cellpadding="0" cellspacing="0" width="600" class="flexibleContainer">
-                        <tr>
-                            <td align="center" valign="top" width="600" class="flexibleContainerCell">
+  <p>We haven't heard from you since you signed up to Trustroots {{timeAgo}}.</p>
 
+  <p>Your profile will not be visible to others if you don't confirm your email address ({{email}}).</p>
 
-                                  <!-- CONTENT TABLE // -->
-                                  <!--
-                                    The content table is the first element
-                                      that's entirely separate from the structural
-                                      framework of the email.
-                                  -->
-                                  <table border="0" cellpadding="0" cellspacing="0" width="100%">
-                                      <tr>
-                                          <td valign="top" class="textContent">
+  <p>It's easy — just click on the link below.</p>
 
-                                              <p>{{name}},</p>
-                                              <p>We haven't heard from you since you signed up to Trustroots {{timeAgo}}.</p>
-                                              <p>Your profile will not be visible to others if you don't confirm your email address ({{email}}).</p>
-                                              <p>It's easy — just click on the link below.</p>
-                                          </td>
-                                      </tr>
-                                  </table>
-                                  <!-- // CONTENT TABLE -->
+  <p><small><em>
+  {% if reminderCount >= reminderCountMax %}
+    This is our last reminder, after which we will stop sending you emails.
+  {% else %}
+    This is a reminder {{reminderCount}}/{{reminderCountMax}}, after which we will stop sending you emails.
+  {% endif %}
+  </em></small></p>
+{% endblock textcontent %}
 
-
-                              </td>
-                          </tr>
-                      </table>
-                      <!-- // FLEXIBLE CONTAINER -->
-                  </td>
-              </tr>
-          </table>
-          <!-- // CENTERING TABLE -->
-      </td>
-  </tr>
-  <!-- // MODULE ROW -->
-
+{% block actionbutton %}
   {% from "./partials/button.server.view.html" import button %}
   {{ button(urlConfirm, 'Confirm now') }}
 
-  <!-- MODULE ROW // -->
-  <tr>
-    <td align="center" valign="top">
-        <!-- CENTERING TABLE // -->
-          <!--
-            The centering table keeps the content
-              tables centered in the emailBody table,
-              in case its width is set to 100%.
-          -->
-        <table border="0" cellpadding="0" cellspacing="0" width="100%">
-            <tr>
-                <td align="center" valign="top">
-                    <!-- FLEXIBLE CONTAINER // -->
-                      <!--
-                        The flexible container has a set width
-                          that gets overridden by the media query.
-                          Most content tables within can then be
-                          given 100% widths.
-                      -->
-                    <table border="0" cellpadding="0" cellspacing="0" width="600" class="flexibleContainer">
-                        <tr>
-                            <td align="center" valign="top" width="600" class="flexibleContainerCell">
-
-
-                                  <!-- CONTENT TABLE // -->
-                                  <!--
-                                    The content table is the first element
-                                      that's entirely separate from the structural
-                                      framework of the email.
-                                  -->
-                                  <table border="0" cellpadding="0" cellspacing="0" width="100%">
-                                      <tr>
-                                          <td valign="top" class="textContent">
-
-                                              <p><small><em>
-                                              {% if reminderCount >= reminderCountMax %}
-                                                This is our last reminder, after which we will stop sending you emails.
-                                              {% else %}
-                                                This is a reminder {{reminderCount}}/{{reminderCountMax}}, after which we will stop sending you emails.
-                                              {% endif %}
-                                              </em></small></p>
-
-                                          </td>
-                                      </tr>
-                                  </table>
-                                  <!-- // CONTENT TABLE -->
-
-
-                              </td>
-                          </tr>
-                      </table>
-                      <!-- // FLEXIBLE CONTAINER -->
-                  </td>
-              </tr>
-          </table>
-          <!-- // CENTERING TABLE -->
-      </td>
-  </tr>
-  <!-- // MODULE ROW -->
-
   {% from "./partials/copypasteurl.server.view.html" import copyPasteUrl %}
   {{ copyPasteUrl(urlConfirmPlainText) }}
-
-{% endblock content %}
+{% endblock actionbutton %}

--- a/modules/core/server/views/email-templates/signup.server.view.html
+++ b/modules/core/server/views/email-templates/signup.server.view.html
@@ -1,68 +1,19 @@
-{% extends './email.server.view.html' %}
+{% extends './email-with-container.server.view.html' %}
 
-{% block content %}
+{% block textcontent %}
+  <p>{{name}},</p>
 
-  <!-- MODULE ROW // -->
-  <tr>
-    <td align="center" valign="top">
-        <!-- CENTERING TABLE // -->
-          <!--
-            The centering table keeps the content
-              tables centered in the emailBody table,
-              in case its width is set to 100%.
-          -->
-        <table border="0" cellpadding="0" cellspacing="0" width="100%">
-            <tr>
-                <td align="center" valign="top">
-                    <!-- FLEXIBLE CONTAINER // -->
-                      <!--
-                        The flexible container has a set width
-                          that gets overridden by the media query.
-                          Most content tables within can then be
-                          given 100% widths.
-                      -->
-                    <table border="0" cellpadding="0" cellspacing="0" width="600" class="flexibleContainer">
-                        <tr>
-                            <td align="center" valign="top" width="600" class="flexibleContainerCell">
+  <p>Thank you very much for signing up with us.</p>
 
+  <p>Confirm your email address ({{email}}) to complete your Trustroots account.</p>
 
-                                  <!-- CONTENT TABLE // -->
-                                  <!--
-                                    The content table is the first element
-                                      that's entirely separate from the structural
-                                      framework of the email.
-                                  -->
-                                  <table border="0" cellpadding="0" cellspacing="0" width="100%">
-                                      <tr>
-                                          <td valign="top" class="textContent">
+  <p>It's easy — just click on the button below.</p>
+{% endblock textcontent %}
 
-                                              <p>{{name}},</p>
-                                              <p>Thank you very much for signing up with us.</p>
-                                              <p>Confirm your email address ({{email}}) to complete your Trustroots account.</p>
-                                              <p>It's easy — just click on the button below.</p>
-
-                                          </td>
-                                      </tr>
-                                  </table>
-                                  <!-- // CONTENT TABLE -->
-
-
-                              </td>
-                          </tr>
-                      </table>
-                      <!-- // FLEXIBLE CONTAINER -->
-                  </td>
-              </tr>
-          </table>
-          <!-- // CENTERING TABLE -->
-      </td>
-  </tr>
-  <!-- // MODULE ROW -->
-
+{% block actionbutton %}
   {% from "./partials/button.server.view.html" import button %}
   {{ button(urlConfirm, 'Confirm now') }}
 
   {% from "./partials/copypasteurl.server.view.html" import copyPasteUrl %}
   {{ copyPasteUrl(urlConfirmPlainText) }}
-
-{% endblock content %}
+{% endblock actionbutton %}

--- a/modules/core/server/views/email-templates/welcome-sequence-first.server.view.html
+++ b/modules/core/server/views/email-templates/welcome-sequence-first.server.view.html
@@ -1,66 +1,14 @@
-{% extends './email.server.view.html' %}
+{% extends './email-with-container.server.view.html' %}
 
-{% block content %}
+{% block textcontent %}
+  <p>Hi {{name}}!</p>
 
-  <!-- MODULE ROW // -->
-  <tr>
-    <td align="center" valign="top">
-        <!-- CENTERING TABLE // -->
-          <!--
-            The centering table keeps the content
-              tables centered in the emailBody table,
-              in case its width is set to 100%.
-          -->
-        <table border="0" cellpadding="0" cellspacing="0" width="100%">
-            <tr>
-                <td align="center" valign="top">
-                    <!-- FLEXIBLE CONTAINER // -->
-                      <!--
-                        The flexible container has a set width
-                          that gets overridden by the media query.
-                          Most content tables within can then be
-                          given 100% widths.
-                      -->
-                    <table border="0" cellpadding="0" cellspacing="0" width="600" class="flexibleContainer">
-                        <tr>
-                            <td align="center" valign="top" width="600" class="flexibleContainerCell">
+  <p>This is {{from.name}} from the Trustroots Foundation. Trustroots is an open, transparent, fun, and international sharing community. We believe in a world where people can trust each other.</p>
 
+  <p>Please take a few minutes to <a href="{{urlEditProfile}}">fill out your profile</a>. That is the foundation of your experience in Trustroots.</p>
 
-                                  <!-- CONTENT TABLE // -->
-                                  <!--
-                                    The content table is the first element
-                                      that's entirely separate from the structural
-                                      framework of the email.
-                                  -->
-                                  <table border="0" cellpadding="0" cellspacing="0" width="100%">
-                                      <tr>
-                                          <td valign="top" class="textContent">
+  <p>If you have any issues using Trustroots, check our <a href="{{urlFAQ}}">frequently asked questions</a> or simply reply this email.</p>
 
-                                              <p>Hi {{name}}!</p>
-                                              <p>This is {{from.name}} from the Trustroots Foundation. Trustroots is an open, transparent, fun, and international sharing community. We believe in a world where people can trust each other.</p>
-                                              <p>Please take a few minutes to <a href="{{urlEditProfile}}">fill out your profile</a>. That is the foundation of your experience in Trustroots.</p>
-                                              <p>If you have any issues using Trustroots, check our <a href="{{urlFAQ}}">frequently asked questions</a> or simply reply this email.
-                                              <p>
-                                                Happy trails!<br>
-                                                {{from.name}}
-                                              </p>
-
-                                          </td>
-                                      </tr>
-                                  </table>
-                                  <!-- // CONTENT TABLE -->
-
-
-                              </td>
-                          </tr>
-                      </table>
-                      <!-- // FLEXIBLE CONTAINER -->
-                  </td>
-              </tr>
-          </table>
-          <!-- // CENTERING TABLE -->
-      </td>
-  </tr>
-  <!-- // MODULE ROW -->
-
-{% endblock content %}
+  <p>Happy trails!<br />
+  {{from.name}}</p>
+{% endblock textcontent %}

--- a/modules/core/server/views/email-templates/welcome-sequence-second.server.view.html
+++ b/modules/core/server/views/email-templates/welcome-sequence-second.server.view.html
@@ -1,72 +1,13 @@
-{% extends './email.server.view.html' %}
+{% extends './email-with-container.server.view.html' %}
 
-{% block content %}
+{% block textcontent %}
+  <p>Hi {{name}}!</p>
 
-  <!-- MODULE ROW // -->
-  <tr>
-    <td align="center" valign="top">
-        <!-- CENTERING TABLE // -->
-          <!--
-            The centering table keeps the content
-              tables centered in the emailBody table,
-              in case its width is set to 100%.
-          -->
-        <table border="0" cellpadding="0" cellspacing="0" width="100%">
-            <tr>
-                <td align="center" valign="top">
-                    <!-- FLEXIBLE CONTAINER // -->
-                      <!--
-                        The flexible container has a set width
-                          that gets overridden by the media query.
-                          Most content tables within can then be
-                          given 100% widths.
-                      -->
-                    <table border="0" cellpadding="0" cellspacing="0" width="600" class="flexibleContainer">
-                        <tr>
-                            <td align="center" valign="top" width="600" class="flexibleContainerCell">
+  <p>I'm {{from.name}} from the Trustroots Foundation. How are your first impressions from Trustroots — anything missing? If you have any feedback for us, you can simply reply to this email.</p>
 
+  <p>Trustroots is not only about hosting others but also about meeting community members. To make it easier for others to find you, you can <a href="{{urlMeetup}}">create a meetup</a>.</p>
 
-                                  <!-- CONTENT TABLE // -->
-                                  <!--
-                                    The content table is the first element
-                                      that's entirely separate from the structural
-                                      framework of the email.
-                                  -->
-                                  <table border="0" cellpadding="0" cellspacing="0" width="100%">
-                                      <tr>
-                                          <td valign="top" class="textContent">
+  {% include "./partials/socialmedia.server.view.html" %}
 
-                                              <p>Hi {{name}}!</p>
-                                              <p>
-                                                I'm {{from.name}} from the Trustroots Foundation.
-                                                How are your first impressions from Trustroots — anything missing?
-                                                If you have any feedback for us, you can simply reply to this email.
-                                              </p>
-                                              <p>
-                                                Trustroots is not only about hosting others but also about meeting community members.
-                                                To make it easier for others to find you, you can <a href="{{urlMeetup}}">create a meetup</a>.
-                                              </p>
-                                              {% include "./partials/socialmedia.server.view.html" %}
-                                              <p>
-                                                Have a good one!
-                                                {{from.name}}
-                                              </p>
-                                          </td>
-                                      </tr>
-                                  </table>
-                                  <!-- // CONTENT TABLE -->
-
-
-                              </td>
-                          </tr>
-                      </table>
-                      <!-- // FLEXIBLE CONTAINER -->
-                  </td>
-              </tr>
-          </table>
-          <!-- // CENTERING TABLE -->
-      </td>
-  </tr>
-  <!-- // MODULE ROW -->
-
-{% endblock content %}
+  <p>Have a good one! {{from.name}}</p>
+{% endblock textcontent %}

--- a/modules/core/server/views/email-templates/welcome-sequence-third.server.view.html
+++ b/modules/core/server/views/email-templates/welcome-sequence-third.server.view.html
@@ -1,75 +1,18 @@
-{% extends './email.server.view.html' %}
+{% extends './email-with-container.server.view.html' %}
 
-{% block content %}
+{% block textcontent %}
+  <p>Hi {{name}}!</p>
 
-  <!-- MODULE ROW // -->
-  <tr>
-    <td align="center" valign="top">
-        <!-- CENTERING TABLE // -->
-          <!--
-            The centering table keeps the content
-              tables centered in the emailBody table,
-              in case its width is set to 100%.
-          -->
-        <table border="0" cellpadding="0" cellspacing="0" width="100%">
-            <tr>
-                <td align="center" valign="top">
-                    <!-- FLEXIBLE CONTAINER // -->
-                      <!--
-                        The flexible container has a set width
-                          that gets overridden by the media query.
-                          Most content tables within can then be
-                          given 100% widths.
-                      -->
-                    <table border="0" cellpadding="0" cellspacing="0" width="600" class="flexibleContainer">
-                        <tr>
-                            <td align="center" valign="top" width="600" class="flexibleContainerCell">
+  <p>This is {{from.name}} from Trustroots Foundation. You signed up a little while ago, and I just wanted to check back.</p>
 
+  {% if topic === 'fill-profile' %}
+    <p>Your profile seems to be quite empty. It would be very easy to take a short time to <a href="{{urlEditProfile}}">fill it out</a>, and it would make it easier for you to connect with people on Trustroots.</p>
+  {% else %}
+    <p>How has your experience with Trustroots been for you so far? I would be happy to hear any feedback. You can simply reply to this email.</p>
+  {% endif %}
 
-                                  <!-- CONTENT TABLE // -->
-                                  <!--
-                                    The content table is the first element
-                                      that's entirely separate from the structural
-                                      framework of the email.
-                                  -->
-                                  <table border="0" cellpadding="0" cellspacing="0" width="100%">
-                                      <tr>
-                                          <td valign="top" class="textContent">
+  {% include "./partials/socialmedia.server.view.html" %}
 
-                                            <p>Hi {{name}}!</p>
-                                            <p>This is {{from.name}} from Trustroots Foundation. You signed up a little while ago, and I just wanted to check back.</p>
-                                            {% if topic === 'fill-profile' %}
-                                              <p>
-                                                Your profile seems to be quite empty.
-                                                It would be very easy to take a short time to <a href="{{urlEditProfile}}">fill it out</a>, and it would make it easier for you to connect with people on Trustroots.
-                                              </p>
-                                            {% else %}
-                                              <p>
-                                                How has your experience with Trustroots been for you so far? I would be happy to hear any feedback. You can simply reply to this email.
-                                              </p>
-                                            {% endif %}
-
-                                            {% include "./partials/socialmedia.server.view.html" %}
-                                            <p>
-                                              Happy traveling!<br/>
-                                              {{from.name}}
-                                            </p>
-                                          </td>
-                                      </tr>
-                                  </table>
-                                  <!-- // CONTENT TABLE -->
-
-
-                              </td>
-                          </tr>
-                      </table>
-                      <!-- // FLEXIBLE CONTAINER -->
-                  </td>
-              </tr>
-          </table>
-          <!-- // CENTERING TABLE -->
-      </td>
-  </tr>
-  <!-- // MODULE ROW -->
-
-{% endblock content %}
+  <p>Happy traveling!<br/>
+  {{from.name}}</p>
+{% endblock textcontent %}


### PR DESCRIPTION
Hi, I gave this #966 refactor a shot while trying to bring up the dev environment :)

The commit message:

Almost all of `email-templates/*.html` hade very much in common with the
`email-with-container.server.view.html` that the new reference-templates use.
The table-hell was the same, just the message differed. I made all these use
the new container-template.

In the case of `signup-reminder.server.view.html`, the match was not perfect.
The small-font paragraph which counts the number of remaining reminders was
placed in the middle of the two buttons (urlconfirm & urlconfirmplaintext). I
took the liberty to join this paragraph to the main one. The two buttons then
lie at the end, like in other templates.
