### PR TITLE
Validate capital letters in tribe name

### DIFF
--- a/modules/tribes/server/models/tribe.server.model.js
+++ b/modules/tribes/server/models/tribe.server.model.js
@@ -34,7 +34,7 @@ function randomHex() {
  */
 var validateLabel = function (label) {
   return (label &&
-          label.match(/[a-z]/) && // Should have at least one a-zA-Z (non case-insensitive regex)
+          label.match(/[a-zA-Z]/) && // Should have at least one a-zA-Z (non case-insensitive regex)
           config.illegalStrings.indexOf(label.trim().toLowerCase()) < 0 &&
           label.charAt(0) !== '.' && // Don't start with `.`
           label.slice(-1) !== '.' // Don't end with `.`

--- a/modules/tribes/tests/server/tribes.server.model.tests.js
+++ b/modules/tribes/tests/server/tribes.server.model.tests.js
@@ -215,6 +215,16 @@ describe('Tribe Model Unit Tests:', function () {
       });
     });
 
+    it('should save label with all capital letters', function (done) {
+      var _tribe = new Tribe(tribe1);
+
+      _tribe.label = 'LABEL';
+      _tribe.save(function (err) {
+        should.not.exist(err);
+        done();
+      });
+    });
+
     it('should be able to show an error when trying to save a label without at least one alpha character', function (done) {
       var _tribe = new Tribe(tribe1);
 


### PR DESCRIPTION
#### Proposed Changes

* This adds A-Z validation to tribe label validation.
* It also adds a test case to that all capital tribe names validate successfully

#### Testing Instructions

* Run the automated server tests
* Since we are not currently adding tribes via an admin panel, this cannot currently be tested manually

Fixes #
This fixes an error during tribe seeding where all capital names are being generated. 
