### PR TITLE
remove tagline from meet search results

### DIFF
--- a/modules/search/client/views/search-sidebar-results.client.view.html
+++ b/modules/search/client/views/search-sidebar-results.client.view.html
@@ -64,6 +64,7 @@
         </span>
       </div>
       <div class="search-result-tagline"
+           ng-if="search.offer.type != 'meet'"
            ng-if="::search.offer.user.tagline"
            ng-bind="::search.offer.user.tagline"></div>
       <div class="search-result-hosting">


### PR DESCRIPTION
#### Proposed Changes

* Remove tagline from meet search results - many profile taglines are simply confusing when they show at these meet results


#### Testing Instructions

* http://localhost:3000/search




(also showing the github workflow to @kenflannery)