### PR TITLE
Only update tribes in db after all users have been added during seeding

### DIFF
--- a/bin/fillTestData/Users.js
+++ b/bin/fillTestData/Users.js
@@ -69,7 +69,7 @@ function random(max) {
 /**
  * Generates a random float value for locations
  *
- * @returns {float} 
+ * @returns {float}
  */
 function randomizeLocation() {
   let random = Math.random();

--- a/bin/fillTestData/Users.js
+++ b/bin/fillTestData/Users.js
@@ -141,8 +141,7 @@ const addUsers = function () {
           const getTribes = Tribe.find();
 
           Promise.all([getUsers, getTribes]).then((results) => {
-            users = results[0];
-            tribes = results[1];
+            [users, tribes] = results;
             done(null);
           }).catch(function (err) {
             console.log(err);

--- a/bin/fillTestData/Users.js
+++ b/bin/fillTestData/Users.js
@@ -136,27 +136,12 @@ var addUsers = function () {
       async.waterfall([
 
         function getUsersAndTribes(done) {
-          var getUsers = new Promise(function (resolve, reject) {
-            User.find(function (err, foundUsers) {
-              if (err) {
-                reject(err);
-              }
-              users = foundUsers;
-              resolve();
-            });
-          });
+          const getUsers = User.find();
+          const getTribes = Tribe.find();
 
-          var getTribes = new Promise(function (resolve, reject) {
-            Tribe.find(function (err, foundTribes) {
-              if (err) {
-                reject(err);
-              }
-              tribes = foundTribes;
-              resolve();
-            });
-          });
-
-          Promise.all([getUsers, getTribes]).then(function () {
+          Promise.all([getUsers, getTribes]).then(function (results) {
+            users = results[0];
+            tribes = results[1];
             done(null);
           }).catch(function (err) {
             console.log(err);

--- a/bin/fillTestData/Users.js
+++ b/bin/fillTestData/Users.js
@@ -86,7 +86,7 @@ const addOffer = function (id, index, max, usersLength, limit, callback) {
   offer.location = location;
   offer.locationFuzzy = location;
 
-  offer.save(function (err) {
+  offer.save((err) => {
     if (err != null) console.log(err);
     else {
       savedOffers++;
@@ -129,8 +129,8 @@ const addUsers = function () {
   config.db.debug = debug;
 
   // Bootstrap db connection
-  mongooseService.connect(function () {
-    mongooseService.loadModels(function () {
+  mongooseService.connect(() => {
+    mongooseService.loadModels(() => {
       const Tribe = mongoose.model('Tribe');
       const User = mongoose.model('User');
 
@@ -140,7 +140,7 @@ const addUsers = function () {
           const getUsers = User.find();
           const getTribes = Tribe.find();
 
-          Promise.all([getUsers, getTribes]).then(function (results) {
+          Promise.all([getUsers, getTribes]).then((results) => {
             users = results[0];
             tribes = results[1];
             done(null);
@@ -264,7 +264,7 @@ const addUsers = function () {
           } else {
             // Update tribes
             for (let j = 0; j < tribes.length; j++) {
-              Tribe.findByIdAndUpdate(tribes[j]._id, tribes[j], function (err) {
+              Tribe.findByIdAndUpdate(tribes[j]._id, tribes[j], (err) => {
                 if (err) {
                   console.error(err);
                 }
@@ -280,7 +280,7 @@ const addUsers = function () {
 
         // disconnect from mongo
         function disconnect(done) {
-          mongooseService.disconnect(function () {
+          mongooseService.disconnect(() => {
             done(null);
           });
         }

--- a/bin/fillTestData/Users.js
+++ b/bin/fillTestData/Users.js
@@ -322,7 +322,7 @@ function addUsers() {
           let numTribesUpdated = 0;
 
           // If we didn't add any users, tribes do not need to be updated
-          if (savedUsers === 0) {
+          if (savedUsers === 0 || tribes.length === 0) {
             resolve();
           } else {
             // Update tribes

--- a/bin/fillTestData/Users.js
+++ b/bin/fillTestData/Users.js
@@ -135,7 +135,7 @@ function addUsers() {
       let userCount = 0;
       let tribes = null;
 
-     /**
+      /**
       * Gets the users and tribes from the database and saves them into the
       * global variables
       *

--- a/bin/fillTestData/Users.js
+++ b/bin/fillTestData/Users.js
@@ -169,7 +169,7 @@ function addUsers() {
           if (index >= max) {
             console.log(chalk.green(userCount + ' users already exist. No users created!'));
             console.log(chalk.white('')); // Reset to white
-            done(null);
+            resolve();
             return;
           }
 

--- a/bin/fillTestData/Users.js
+++ b/bin/fillTestData/Users.js
@@ -1,25 +1,26 @@
 'use strict';
 
-var _ = require('lodash'),
-    path = require('path'),
-    mongooseService = require(path.resolve('./config/lib/mongoose')),
-    chalk = require('chalk'),
-    yargs = require('yargs'),
-    faker = require('faker'),
-    fs = require('fs'),
-    moment = require('moment'),
-    mongoose = require('mongoose'),
-    async = require('async'),
-    config = require(path.resolve('./config/config')),
-    cities = JSON.parse(fs.readFileSync(path.resolve('./bin/fillTestData/data/Cities.json'), 'utf8')),
-    users = null,
+const _ = require('lodash'),
+      path = require('path'),
+      mongooseService = require(path.resolve('./config/lib/mongoose')),
+      chalk = require('chalk'),
+      yargs = require('yargs'),
+      faker = require('faker'),
+      fs = require('fs'),
+      moment = require('moment'),
+      mongoose = require('mongoose'),
+      async = require('async'),
+      config = require(path.resolve('./config/config')),
+      cities = JSON.parse(fs.readFileSync(path.resolve('./bin/fillTestData/data/Cities.json'), 'utf8'));
+
+let users = null,
     tribes = null,
     savedUsers = 0,
     savedOffers = 0;
 
 require(path.resolve('./modules/offers/server/models/offer.server.model'));
 
-var argv = yargs.usage('$0 <numberOfUsers>', 'Seed database with number of tribes', function (yargs) {
+const argv = yargs.usage('$0 <numberOfUsers>', 'Seed database with number of tribes', function (yargs) {
   return yargs
     .positional('numberOfUsers', {
       describe: 'Number of users to add',
@@ -45,14 +46,14 @@ var argv = yargs.usage('$0 <numberOfUsers>', 'Seed database with number of tribe
     .yargs;
 }).argv;
 
-var Offer = mongoose.model('Offer');
+const Offer = mongoose.model('Offer');
 
-var random = function (max) {
+const random = function (max) {
   return Math.floor(Math.random() * max);
 };
 
-var randomizeLoaction = function () {
-  var random = Math.random();
+const randomizeLoaction = function () {
+  let random = Math.random();
   if (random > 0.98) {
     random = ((Math.random() - 0.5) * Math.random() * 4) - 1;
   } else {
@@ -61,7 +62,7 @@ var randomizeLoaction = function () {
   return parseFloat(random.toFixed(5));
 };
 
-var printSummary = function (countExisting, countSaved) {
+const printSummary = function (countExisting, countSaved) {
   console.log('');
   console.log(chalk.green(countExisting + ' users existed in the database.'));
   console.log(chalk.green(countSaved + ' users successfully added.'));
@@ -69,13 +70,13 @@ var printSummary = function (countExisting, countSaved) {
   console.log(chalk.white(''));
 };
 
-var addOffer = function (id, index, max, usersLength, limit, callback) {
-  var offer = new Offer();
+const addOffer = function (id, index, max, usersLength, limit, callback) {
+  let offer = new Offer();
 
-  var city = cities[random(cities.length)];
-  var lat = city.lat + randomizeLoaction();
-  var lon = city.lon + randomizeLoaction();
-  var location = [lat, lon];
+  let city = cities[random(cities.length)];
+  let lat = city.lat + randomizeLoaction();
+  let lon = city.lon + randomizeLoaction();
+  let location = [lat, lon];
 
   offer.type = 'host';
   offer.status = _.sample(['yes', 'maybe']);
@@ -99,13 +100,13 @@ var addOffer = function (id, index, max, usersLength, limit, callback) {
   });
 };
 
-var addUsers = function () {
-  var index = 0;
-  var numAdminUsers;
-  var debug = (argv.debug === true);
-  var limit = (argv.limit === true);
-  var max = argv.numberOfUsers;
-  var adminUsers = argv.userNames;
+const addUsers = function () {
+  let index = 0;
+  let numAdminUsers;
+  let debug = (argv.debug === true);
+  let limit = (argv.limit === true);
+  let max = argv.numberOfUsers;
+  let adminUsers = argv.userNames;
 
   if (adminUsers === null || adminUsers === undefined) {
     numAdminUsers = 0;
@@ -113,7 +114,7 @@ var addUsers = function () {
     numAdminUsers = adminUsers.length;
   }
 
-  var printWarning = function printWarning() {
+  const printWarning = function printWarning() {
     console.log('Generating ' + max + ' users...');
     if (max > 2000) {
       console.log('...this might really take a while... go grab some coffee!');
@@ -130,8 +131,8 @@ var addUsers = function () {
   // Bootstrap db connection
   mongooseService.connect(function () {
     mongooseService.loadModels(function () {
-      var Tribe = mongoose.model('Tribe');
-      var User = mongoose.model('User');
+      const Tribe = mongoose.model('Tribe');
+      const User = mongoose.model('User');
 
       async.waterfall([
 
@@ -167,8 +168,8 @@ var addUsers = function () {
 
           while (index < max) {
             (function addNextUser(){
-              var user = new User();
-              var admin;
+              let user = new User();
+              let admin;
 
               // Check if this is an admin user
               if (numAdminUsers > 0) {
@@ -204,18 +205,18 @@ var addUsers = function () {
 
               // Add the user to tribes
               if (tribes.length > 0) {
-                var userNumTribes = random(tribes.length);
+                const userNumTribes = random(tribes.length);
 
                 // Randomize indecies
-                var randomTribes = [];
-                for (var i = 0; i < tribes.length; i++) {
+                let randomTribes = [];
+                for (let i = 0; i < tribes.length; i++) {
                   randomTribes[i] = i;
                 }
                 randomTribes = _.shuffle(randomTribes);
 
                 // Add the tribes using the random indecies
-                for (var j = 0; j < userNumTribes; j++) {
-                  var rand = randomTribes[j];
+                for (let j = 0; j < userNumTribes; j++) {
+                  let rand = randomTribes[j];
                   user.member.push({ tribe: tribes[rand]._id, since: Date.now() });
                   tribes[rand].count += 1;
                 }
@@ -255,14 +256,14 @@ var addUsers = function () {
 
         // Update tribes with the new tribe counts once all users have been  added
         function updateTribes(done) {
-          var numTribesUpdated = 0;
+          let numTribesUpdated = 0;
 
           // If we didn't add any users, tribes do not need to be updated
           if (savedUsers === 0) {
             done(null);
           } else {
             // Update tribes
-            for (var j = 0; j < tribes.length; j++) {
+            for (let j = 0; j < tribes.length; j++) {
               Tribe.findByIdAndUpdate(tribes[j]._id, tribes[j], function (err) {
                 if (err) {
                   console.error(err);

--- a/bin/fillTestData/Users.js
+++ b/bin/fillTestData/Users.js
@@ -151,17 +151,17 @@ function addUsers() {
         }).catch(function (err) {
           console.log(err);
         });
-      } //getUsersAndTribes()
+      } // getUsersAndTribes()
 
 
-     /**
+      /**
       * Adds the number of users using the options specified by the user
       *
       * @returns {Promise} Promise that completes when all users have
       *  successfully been added.
       */
       function addAllUsers() {
-        return new Promise ((resolve) => {
+        return new Promise((resolve) => {
           if (limit) {
             index = userCount;
           }
@@ -264,10 +264,10 @@ function addUsers() {
             index++;
           }
         });
-      } //addAllUsers()
+      } // addAllUsers()
 
 
-     /**
+      /**
       * Update tribes with the new tribe counts once all users have been  added
       *
       * @returns {Promise} Promise that completes when all the tribes have
@@ -296,7 +296,7 @@ function addUsers() {
             }
           }
         });
-      } //updateTribes()
+      } // updateTribes()
 
 
       // This is the main sequence to add all the users.

--- a/bin/fillTestData/Users.js
+++ b/bin/fillTestData/Users.js
@@ -172,7 +172,8 @@ var addUsers = function () {
           if (index >= max) {
             console.log(chalk.green(users.length + ' users already exist. No users created!'));
             console.log(chalk.white('')); // Reset to white
-            process.exit(0);
+            done(null);
+            return;
           }
 
           console.log(chalk.white('--'));
@@ -269,16 +270,35 @@ var addUsers = function () {
 
         // Update tribes with the new tribe counts once all users have been  added
         function updateTribes(done) {
-          for (var j = 0; j < tribes.length; j++) {
-            Tribe.findByIdAndUpdate(tribes[j]._id, tribes[j], function (err) {
-              if (err) {
-                console.error(err);
-              }
-            });
+          var numTribesUpdated = 0;
+
+          // If we didn't add any users, tribes do not need to be updated
+          if (savedUsers === 0) {
+            done(null);
+          } else {
+            // Update tribes
+            for (var j = 0; j < tribes.length; j++) {
+              Tribe.findByIdAndUpdate(tribes[j]._id, tribes[j], function (err) {
+                if (err) {
+                  console.error(err);
+                }
+
+                numTribesUpdated += 1;
+                if (tribes.length === numTribesUpdated) {
+                  done(null);
+                }
+              });
+            }
           }
-          done(null);
-          process.exit(0);
+        },
+
+        // disconnect from mongo
+        function disconnect(done) {
+          mongooseService.disconnect(function () {
+            done(null);
+          });
         }
+
       ]); // asyc.waterfall
 
     });

--- a/bin/fillTestData/Users.js
+++ b/bin/fillTestData/Users.js
@@ -12,8 +12,7 @@ const _ = require('lodash'),
       config = require(path.resolve('./config/config')),
       cities = JSON.parse(fs.readFileSync(path.resolve('./bin/fillTestData/data/Cities.json'), 'utf8'));
 
-let tribes = null,
-    savedUsers = 0,
+let savedUsers = 0,
     savedOffers = 0;
 
 require(path.resolve('./modules/offers/server/models/offer.server.model'));
@@ -132,7 +131,9 @@ function addUsers() {
     mongooseService.loadModels(async () => {
       const Tribe = mongoose.model('Tribe');
       const User = mongoose.model('User');
+
       let userCount = 0;
+      let tribes = null;
 
      /**
       * Gets the users and tribes from the database and saves them into the

--- a/bin/fillTestData/Users.js
+++ b/bin/fillTestData/Users.js
@@ -72,10 +72,10 @@ const printSummary = function (countExisting, countSaved) {
 const addOffer = function (id, index, max, usersLength, limit, callback) {
   let offer = new Offer();
 
-  let city = cities[random(cities.length)];
-  let lat = city.lat + randomizeLocation();
-  let lon = city.lon + randomizeLocation();
-  let location = [lat, lon];
+  const city = cities[random(cities.length)];
+  const lat = city.lat + randomizeLocation();
+  const lon = city.lon + randomizeLocation();
+  const location = [lat, lon];
 
   offer.type = 'host';
   offer.status = _.sample(['yes', 'maybe']);
@@ -102,10 +102,11 @@ const addOffer = function (id, index, max, usersLength, limit, callback) {
 function addUsers() {
   let index = 0;
   let numAdminUsers;
-  let debug = (argv.debug === true);
-  let limit = (argv.limit === true);
-  let max = argv.numberOfUsers;
-  let adminUsers = argv.userNames;
+
+  const debug = (argv.debug === true);
+  const limit = (argv.limit === true);
+  const max = argv.numberOfUsers;
+  const adminUsers = argv.userNames;
 
   if (adminUsers === null || adminUsers === undefined) {
     numAdminUsers = 0;

--- a/bin/fillTestData/Users.js
+++ b/bin/fillTestData/Users.js
@@ -6,11 +6,10 @@ const _ = require('lodash'),
       chalk = require('chalk'),
       yargs = require('yargs'),
       faker = require('faker'),
-      fs = require('fs'),
       moment = require('moment'),
       mongoose = require('mongoose'),
       config = require(path.resolve('./config/config')),
-      cities = JSON.parse(fs.readFileSync(path.resolve('./bin/fillTestData/data/Cities.json'), 'utf8'));
+      cities = require(path.resolve('./bin/fillTestData/data/Cities.json'));
 
 let savedUsers = 0,
     savedOffers = 0;

--- a/bin/fillTestData/Users.js
+++ b/bin/fillTestData/Users.js
@@ -52,7 +52,7 @@ const random = function (max) {
   return Math.floor(Math.random() * max);
 };
 
-const randomizeLoaction = function () {
+const randomizeLocation = function () {
   let random = Math.random();
   if (random > 0.98) {
     random = ((Math.random() - 0.5) * Math.random() * 4) - 1;
@@ -74,8 +74,8 @@ const addOffer = function (id, index, max, usersLength, limit, callback) {
   let offer = new Offer();
 
   let city = cities[random(cities.length)];
-  let lat = city.lat + randomizeLoaction();
-  let lon = city.lon + randomizeLoaction();
+  let lat = city.lat + randomizeLocation();
+  let lon = city.lon + randomizeLocation();
   let location = [lat, lon];
 
   offer.type = 'host';

--- a/bin/fillTestData/Users.js
+++ b/bin/fillTestData/Users.js
@@ -12,8 +12,7 @@ const _ = require('lodash'),
       config = require(path.resolve('./config/config')),
       cities = JSON.parse(fs.readFileSync(path.resolve('./bin/fillTestData/data/Cities.json'), 'utf8'));
 
-let users = null,
-    tribes = null,
+let tribes = null,
     savedUsers = 0,
     savedOffers = 0;
 
@@ -133,6 +132,7 @@ function addUsers() {
     mongooseService.loadModels(async () => {
       const Tribe = mongoose.model('Tribe');
       const User = mongoose.model('User');
+      let userCount = 0;
 
      /**
       * Gets the users and tribes from the database and saves them into the
@@ -141,12 +141,12 @@ function addUsers() {
       * @returns {Promise} Promise that completes when user and tribe data
       *  have successfully loaded into global variables.
       */
-      function getUsersAndTribes() {
-        const getUsers = User.find();
+      function getUserCountAndTribes() {
+        const getUserCount = User.countDocuments();
         const getTribes = Tribe.find();
 
-        return Promise.all([getUsers, getTribes]).then((results) => {
-          [users, tribes] = results;
+        return Promise.all([getUserCount, getTribes]).then((results) => {
+          [userCount, tribes] = results;
         }).catch(function (err) {
           console.log(err);
         });
@@ -162,11 +162,11 @@ function addUsers() {
       function addAllUsers() {
         return new Promise ((resolve) => {
           if (limit) {
-            index = users.length;
+            index = userCount;
           }
 
           if (index >= max) {
-            console.log(chalk.green(users.length + ' users already exist. No users created!'));
+            console.log(chalk.green(userCount + ' users already exist. No users created!'));
             console.log(chalk.white('')); // Reset to white
             done(null);
             return;
@@ -246,7 +246,7 @@ function addUsers() {
                   console.log(err);
                 }
 
-                addOffer(user._id, index, max, users.length, limit, resolve);
+                addOffer(user._id, index, max, userCount, limit, resolve);
               });
 
 
@@ -299,11 +299,11 @@ function addUsers() {
 
 
       // This is the main sequence to add all the users.
-      //    * First get the current user and tribe data
+      //    * First get the current number of users and tribe data
       //    * Then seed all the new users
       //    * Lastly update the number of users that were added to each tribe
       try {
-        await getUsersAndTribes();
+        await getUserCountAndTribes();
         await addAllUsers();
         await updateTribes();
 

--- a/bin/fillTestData/Users.js
+++ b/bin/fillTestData/Users.js
@@ -221,11 +221,6 @@ var addUsers = function () {
                     var rand = randomTribes[j];
                     user.member.push({ tribe: tribes[rand]._id, since: Date.now() });
                     tribes[rand].count += 1;
-                    Tribe.findByIdAndUpdate(tribes[rand]._id, tribes[rand], function (err) {
-                      if (err) {
-                        console.error(err);
-                      }
-                    });
                   }
                 }
 
@@ -233,6 +228,19 @@ var addUsers = function () {
                 user.save(function (err) {
                   savedUsers++;
                   process.stdout.write('.');
+
+                  // Update tribes with the new tribe counts once all users have been  added
+                  if ((limit && (savedUsers + users.length >= max))
+                        || (!limit && (savedUsers >= max))) {
+                    for (var j = 0; j < tribes.length; j++) {
+                      Tribe.findByIdAndUpdate(tribes[j]._id, tribes[j], function (err) {
+                        if (err) {
+                          console.error(err);
+                        }
+                      });
+                    }
+                  }
+
                   if (!err && admin!== undefined) {
                     console.log('Created admin user. Login with: ' + admin + ' / password');
                   } else if (err && admin !== undefined) {


### PR DESCRIPTION
#### Proposed Changes

* Previously the new tribe count was updated in the DB on every user addition to the tribe. This change waits until all the users have been added and then updates the tribe counts for all the tribes in the DB. (eg. saving a ton of database calls)

#### Testing Instructions

* Verify the script works as previously. 
* Test with Docker 

Fixes #994 
