### PR TITLE
Helper to wire up react-i18next and react-to-angular components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -183,6 +183,7 @@ module.exports = {
       'modules/core/client/app/config.js',
       'modules/**/client/components/**',
       'modules/**/client/api/**',
+      'modules/**/client/utils/**',
       'modules/core/client/directives/tr-boards.client.directive.js',
       'modules/core/client/services/photos.service.js',
       'modules/references/tests/client/**'

--- a/modules/core/client/utils/i18n-angular-load.js
+++ b/modules/core/client/utils/i18n-angular-load.js
@@ -1,0 +1,28 @@
+import '@/config/lib/i18n';
+import { withNamespaces as withNamespacesOriginal } from 'react-i18next';
+
+/**
+ * This wires up react component with i18n.
+ * It sets up withNamespaces, propTypes and Component.name for React component.
+ * So it can be used in Angular.
+ *
+ * When we move everything to react, this won't be needed and should be removed.
+ * This helper should be used only with react components which need to be imported to angular.
+ */
+export function withNamespaces(namespaces) {
+  return (Component) => {
+    // add namespaces to Component
+    const ComponentHOC = withNamespacesOriginal(namespaces)(Component);
+
+    // clone propTypes and delete t function
+    const hocPropTypes = { ...Component.propTypes };
+    delete hocPropTypes.t;
+    // set propTypes for HOC
+    ComponentHOC.propTypes = hocPropTypes;
+
+    // change the name of the ComponentHOC
+    Object.defineProperty(ComponentHOC, 'name', { value: Component.name });
+
+    return ComponentHOC;
+  };
+}

--- a/modules/users/client/components/Avatar.component.js
+++ b/modules/users/client/components/Avatar.component.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import has from 'lodash/has';
-import '@/config/lib/i18n';
-import { withNamespaces } from 'react-i18next';
+import { withNamespaces } from '@/modules/core/client/utils/i18n-angular-load';
 
 /**
  * User's avatar
@@ -41,23 +40,15 @@ export function Avatar({ t, user, size=256, source='', link=true }) {
   );
 }
 
-const AvatarHOC = withNamespaces('user')(Avatar);
-
-AvatarHOC.propTypes = {
+Avatar.propTypes = {
+  t: PropTypes.func.isRequired,
   user: PropTypes.object.isRequired,
   size: PropTypes.number,
   source: PropTypes.string,
   link: PropTypes.bool
 };
 
-Avatar.propTypes = {
-  ...AvatarHOC.propTypes,
-  t: PropTypes.func.isRequired
-};
-
-Object.defineProperty(AvatarHOC, 'name', { value: 'Avatar' });
-
-export default AvatarHOC;
+export default withNamespaces('user')(Avatar);
 
 
 /**


### PR DESCRIPTION
#### Proposed Changes

* wraps `withNamespaces` with a helper which also sets up `HigherOrderComponent.propTypes` and `HigherOrderComponent.name`

#### Testing Instructions

* Open a user's profile and see that it works. The avatar gets loaded. (Open your React developer tools if you want a proof that the Avatar is a react component wrapped in react-i18next components).

Depends on #997 (Avatar as an example)
