### PR TITLE
Include user._id in user search API results

### DIFF
--- a/modules/users/server/controllers/users.profile.server.controller.js
+++ b/modules/users/server/controllers/users.profile.server.controller.js
@@ -89,7 +89,7 @@ exports.userMiniProfileFields = [
 
 // Mini + a few fields we'll need at listings
 exports.userListingProfileFields = exports.userMiniProfileFields + ' member birthdate gender tagline';
-exports.userSearchProfileFields = exports.userMiniProfileFields + ' gender locationFrom locationLiving -_id';
+exports.userSearchProfileFields = exports.userMiniProfileFields + ' gender locationFrom locationLiving';
 
 /**
  * Middleware to validate+process avatar upload field

--- a/modules/users/tests/server/search-users.server.routes.tests.js
+++ b/modules/users/tests/server/search-users.server.routes.tests.js
@@ -307,7 +307,9 @@ describe('Search users: GET /users?search=string', function () {
 
             should(foundUsers).length(1);
 
-            var expectedFields = userHandler.userSearchProfileFields.split(' ');
+            // _id is not specified in userSearchProfileFields, but gets included anyways
+            // that's just how mongo works
+            var expectedFields = userHandler.userSearchProfileFields.split(' ').concat(['_id']);
             var actualFields = _.keys(foundUsers[0]);
 
             var unexpectedFields = _.difference(actualFields, expectedFields);


### PR DESCRIPTION
User ID was listed out from User search API results.

Since it's needed to show avatars, we'll need to include it.

Rest of the fields required by avatars are included in `userMiniProfileFields`.