### PR TITLE
Ensure stable NPM version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ before_script:
   - 'sh -e /etc/init.d/xvfb start'
   - sleep 3 # give xvfb some time to start
 
+  # Ensure stable NPM version (avoids `-next.0` tags)
+  - 'npm install -g npm'
 cache:
   directories:
     - "$HOME/.node-gyp"


### PR DESCRIPTION
Travis is currently failing for all branches due semver check failing for NPM `6.5.0-next.0` version that gets installed on Travis containers for Node.js 11.

This should fix it. 🤞 