### PR TITLE
Gulp: remove Fontello config watch

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -182,7 +182,6 @@ gulp.task('watch', function watch(done) {
   plugins.refresh.listen();
 
   // Watch and generate app files
-  gulp.watch(defaultAssets.server.fontelloConfig, fontello);
   gulp.watch(defaultAssets.server.views).on('change', plugins.refresh.changed);
   gulp.watch(defaultAssets.client.less, gulp.series('clean:css', 'build:styles')).on('change', plugins.refresh.changed);
 


### PR DESCRIPTION
Removes watch+rebuild of Fontello config (icon fonts) which just causes trouble as files are re-generated on each branch change around the time when config has been updated in `master`.

Changes to icon font files are committed these days directly to master so there's no need to generate these files during watching, the process  is fully manual: https://developers.trustroots.org/Icons.html