### PR TITLE
Mongoose: add logging for autoindexing and indexing errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -171,10 +171,11 @@ module.exports = {
     // overrides for server code
     // ES 2018 - specify migrated files and folders here
     files: [
-      'testutils/data.server.testutils.js',
+      'bin/db-maintenance/ensure-indexes.js',
       'modules/references/server/**',
       'modules/references/tests/server/**',
-      'modules/users/tests/server/user-change-locale.server.routes.tests.js'
+      'modules/users/tests/server/user-change-locale.server.routes.tests.js',
+      'testutils/data.server.testutils.js'
     ],
     parserOptions: {
       ecmaVersion: 2018

--- a/bin/db-maintenance/ensure-indexes.js
+++ b/bin/db-maintenance/ensure-indexes.js
@@ -36,9 +36,6 @@ mongooseService.connect(async (connection) => {
 
   const modelNamesToIndex = predefinedModel ? [predefinedModel] : modelNames;
 
-  await mongooseService.ensureIndexes(modelNamesToIndex);
+  await mongooseService.ensureIndexes(modelNamesToIndex).catch(console.error);
   await mongooseService.disconnect();
 });
-
-
-console.log('Done!');

--- a/bin/db-maintenance/ensure-indexes.js
+++ b/bin/db-maintenance/ensure-indexes.js
@@ -28,13 +28,17 @@ if (process.argv[2]) {
 
 mongooseService.connect(async (connection) => {
   await mongooseService.loadModels();
-  const allModels = connection.modelNames();
-  if (!allModels.includes(predefinedModel)) {
-    console.error(`"${predefinedModel}" is not a valid model name. Models: ${allModels.join(', ')}`);
+  const modelNames = connection.modelNames();
+
+  // Validate manually defined model
+  if (predefinedModel && !modelNames.includes(predefinedModel)) {
+    console.error(`"${predefinedModel}" is not a valid model name. Models: ${modelNames.join(', ')}`);
     process.exit(1);
   }
-  const models = predefinedModel ? [predefinedModel] : allModels;
-  await mongooseService.ensureIndexes(connection, models);
+
+  const modelNamesToIndex = predefinedModel ? [predefinedModel] : modelNames;
+
+  await mongooseService.ensureIndexes(connection, modelNamesToIndex);
   await mongooseService.disconnect();
 });
 

--- a/bin/db-maintenance/ensure-indexes.js
+++ b/bin/db-maintenance/ensure-indexes.js
@@ -14,8 +14,6 @@
  * Example:
  *  npm run ensure-indexes -- User
  */
-
-const config = require('../../config/config');
 const mongooseService = require('../../config/lib/mongoose');
 
 let predefinedModel;
@@ -38,7 +36,7 @@ mongooseService.connect(async (connection) => {
 
   const modelNamesToIndex = predefinedModel ? [predefinedModel] : modelNames;
 
-  await mongooseService.ensureIndexes(connection, modelNamesToIndex);
+  await mongooseService.ensureIndexes(modelNamesToIndex);
   await mongooseService.disconnect();
 });
 

--- a/bin/db-maintenance/ensure-indexes.js
+++ b/bin/db-maintenance/ensure-indexes.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+/**
+ * Ensure DB indices are generated. Note that this is a heavy action for the DB.
+ *
+ * Usage:
+ *
+ *  npm run ensure-indexes
+ *
+ * Ensure indexes only for specific Mongoose Model
+ *
+ *  npm run ensure-indexes -- ModelName
+ *
+ * Example:
+ *  npm run ensure-indexes -- User
+ */
+
+const config = require('../../config/config');
+const mongooseService = require('../../config/lib/mongoose');
+
+let predefinedModel;
+if (process.argv[2] === 'reverse') {
+  console.log(`Ensuring indexes only for Mongo collection ${process.argv[2]}`);
+  predefinedModel = process.argv[2];
+} else {
+  console.log('Ensuring indexes for all Mongo collections');
+};
+
+mongooseService.connect(async (connection) => {
+  await mongooseService.loadModels();
+  const models = predefinedModel ? [predefinedModel] : connection.modelNames();
+  await mongooseService.ensureIndexes(connection, models);
+  await mongooseService.disconnect();
+});
+
+
+console.log('Done!');

--- a/bin/db-maintenance/ensure-indexes.js
+++ b/bin/db-maintenance/ensure-indexes.js
@@ -19,8 +19,8 @@ const config = require('../../config/config');
 const mongooseService = require('../../config/lib/mongoose');
 
 let predefinedModel;
-if (process.argv[2] === 'reverse') {
-  console.log(`Ensuring indexes only for Mongo collection ${process.argv[2]}`);
+if (process.argv[2]) {
+  console.log(`Ensuring indexes only for Mongo collection "${process.argv[2]}"`);
   predefinedModel = process.argv[2];
 } else {
   console.log('Ensuring indexes for all Mongo collections');
@@ -28,7 +28,12 @@ if (process.argv[2] === 'reverse') {
 
 mongooseService.connect(async (connection) => {
   await mongooseService.loadModels();
-  const models = predefinedModel ? [predefinedModel] : connection.modelNames();
+  const allModels = connection.modelNames();
+  if (!allModels.includes(predefinedModel)) {
+    console.error(`"${predefinedModel}" is not a valid model name. Models: ${allModels.join(', ')}`);
+    process.exit(1);
+  }
+  const models = predefinedModel ? [predefinedModel] : allModels;
   await mongooseService.ensureIndexes(connection, models);
   await mongooseService.disconnect();
 });

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -26,7 +26,7 @@ module.exports = {
     debug: true,
     // Autoindex indexes
     // Mongoose calls createIndex on each Model's index when staring the app
-    autoIndex: false,
+    autoIndex: true,
     // Check for MongoDB version compatibility on start
     checkCompatibility: true
   },

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -25,7 +25,8 @@ module.exports = {
     // Mongoose debug mode
     debug: true,
     // Autoindex indexes
-    autoIndex: true,
+    // Mongoose calls createIndex on each Model's index when staring the app
+    autoIndex: false,
     // Check for MongoDB version compatibility on start
     checkCompatibility: true
   },

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -24,6 +24,8 @@ module.exports = {
     },
     // Mongoose debug mode
     debug: true,
+    // Autoindex indexes
+    autoIndex: true,
     // Check for MongoDB version compatibility on start
     checkCompatibility: true
   },

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -23,6 +23,7 @@ module.exports = {
     // Mongoose debug mode
     debug: false,
     // Autoindex indexes
+    // Mongoose calls createIndex on each Model's index when staring the app
     autoIndex: false,
     // Check for MongoDB version compatibility on start
     checkCompatibility: false

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -22,6 +22,8 @@ module.exports = {
     },
     // Mongoose debug mode
     debug: false,
+    // Autoindex indexes
+    autoIndex: false,
     // Check for MongoDB version compatibility on start
     checkCompatibility: false
   }

--- a/config/env/test.js
+++ b/config/env/test.js
@@ -26,6 +26,8 @@ module.exports = {
     },
     // Mongoose debug mode
     debug: false,
+    // Autoindex indexes
+    autoIndex: true,
     // Check for MongoDB version compatibility on start
     checkCompatibility: false
   },

--- a/config/env/test.js
+++ b/config/env/test.js
@@ -27,7 +27,7 @@ module.exports = {
     // Mongoose debug mode
     debug: false,
     // Autoindex indexes
-    autoIndex: true,
+    autoIndex: false,
     // Check for MongoDB version compatibility on start
     checkCompatibility: false
   },

--- a/config/env/test.js
+++ b/config/env/test.js
@@ -27,7 +27,8 @@ module.exports = {
     // Mongoose debug mode
     debug: false,
     // Autoindex indexes
-    autoIndex: false,
+    // Mongoose calls createIndex on each Model's index when staring the app
+    autoIndex: true,
     // Check for MongoDB version compatibility on start
     checkCompatibility: false
   },

--- a/config/lib/app.js
+++ b/config/lib/app.js
@@ -39,6 +39,7 @@ module.exports.start = function start(callback) {
       console.log(chalk.green(new Date()));
       console.log(chalk.green('Environment:\t\t' + process.env.NODE_ENV));
       console.log(chalk.green('Database:\t\t' + config.db.uri));
+      console.log(chalk.green('Database autoindexing:\t\t' + (config.db.autoIndex ? 'on' : 'off')));
       console.log(chalk.green('HTTPS:\t\t\t' + (config.https ? 'on' : 'off')));
       console.log(chalk.green('Port:\t\t\t' + config.port));
       console.log(chalk.green('Image processor:\t' + config.imageProcessor));

--- a/config/lib/app.js
+++ b/config/lib/app.js
@@ -39,7 +39,7 @@ module.exports.start = function start(callback) {
       console.log(chalk.green(new Date()));
       console.log(chalk.green('Environment:\t\t' + process.env.NODE_ENV));
       console.log(chalk.green('Database:\t\t' + config.db.uri));
-      console.log(chalk.green('Database autoindexing:\t\t' + (config.db.autoIndex ? 'on' : 'off')));
+      console.log(chalk.green('Database autoindexing:\t' + (config.db.autoIndex ? 'on' : 'off')));
       console.log(chalk.green('HTTPS:\t\t\t' + (config.https ? 'on' : 'off')));
       console.log(chalk.green('Port:\t\t\t' + config.port));
       console.log(chalk.green('Image processor:\t' + config.imageProcessor));

--- a/config/lib/mongoose.js
+++ b/config/lib/mongoose.js
@@ -156,3 +156,33 @@ module.exports.dropDatabase = function (connection, callback) {
     }
   });
 };
+
+module.exports.ensureIndexes = function (connection, modelNames) {
+  return new Promise(function (resolve) {
+    // assuming openFiles is an array of file names
+    async.each(modelNames, function (modelName, callback) {
+      connection.model(modelName).ensureIndexes(function (error) {
+        if (error) {
+          log('error', 'Indexing Mongoose Schema failed', {
+            model: modelName,
+            error: error
+          });
+          callback(error);
+        } else {
+          log('info', 'Indexed Mongoose Schema ' + modelName);
+          callback();
+        }
+      });
+    }, function (error) {
+      // if any of the file processing produced an error
+      if (error) {
+        // One of the iterations produced an error.
+        // All processing will now stop.
+        log('error', 'A Schema failed to index.');
+      } else {
+        log('info', 'All Schemas have been indexed successfully.');
+      }
+      resolve();
+    });
+  });
+};

--- a/config/lib/mongoose.js
+++ b/config/lib/mongoose.js
@@ -67,7 +67,7 @@ module.exports.connect = function (callback) {
     useFindAndModify: false,
     // Mongoose-specific option. Set to false to disable automatic index
     // creation for all models associated with this connection.
-    // Ensure indexes manually by running `npm run ensure-indexes`
+    autoIndex: Boolean(config.db.autoindex)
   };
 
   async.waterfall([

--- a/config/lib/mongoose.js
+++ b/config/lib/mongoose.js
@@ -175,7 +175,7 @@ module.exports.ensureIndexes = function (modelNames) {
       });
     }, function (error) {
       // if any of the file processing produced an error
-      if (true || error) {
+      if (error) {
         // One of the iterations produced an error.
         // All processing will now stop.
         log('error', 'A Schema failed to index.', {

--- a/config/lib/mongoose.js
+++ b/config/lib/mongoose.js
@@ -25,12 +25,12 @@ module.exports.loadModels = function (callback) {
   models.forEach(function (model) {
     mongoose.model(model).on('index', function (error) {
       if (error) {
-        log('error', 'Indexing Mongoose Schema failed', {
+        log('error', 'Calling createIndex failed for Mongoose Schema', {
           error: error,
           model: model
         });
       } else {
-        log('info', 'Indexed Mongoose Schema', {
+        log('info', 'Calling createIndex succeeded for Mongoose Schema', {
           model: model
         });
       }

--- a/config/lib/mongoose.js
+++ b/config/lib/mongoose.js
@@ -52,7 +52,6 @@ module.exports.connect = function (callback) {
 
   // Enabling mongoose debug mode if required
   mongoose.set('debug', Boolean(config.db.debug));
-  mongoose.set('useCreateIndex', true);
 
   // Options for Native MongoDB connection
   // https://mongodb.github.io/node-mongodb-native/2.1/api/Server.html

--- a/config/lib/mongoose.js
+++ b/config/lib/mongoose.js
@@ -157,11 +157,11 @@ module.exports.dropDatabase = function (connection, callback) {
   });
 };
 
-module.exports.ensureIndexes = function (connection, modelNames) {
+module.exports.ensureIndexes = function (modelNames) {
   return new Promise(function (resolve) {
     // assuming openFiles is an array of file names
     async.each(modelNames, function (modelName, callback) {
-      connection.model(modelName).ensureIndexes(function (error) {
+      mongoose.connection.model(modelName).ensureIndexes(function (error) {
         if (error) {
           log('error', 'Indexing Mongoose Schema failed', {
             model: modelName,
@@ -180,7 +180,7 @@ module.exports.ensureIndexes = function (connection, modelNames) {
         // All processing will now stop.
         log('error', 'A Schema failed to index.');
       } else {
-        log('info', 'All Schemas have been indexed successfully.');
+        log('info', modelNames.length + ' Schemas have been indexed successfully:\n - ' + modelNames.join('\n - '));
       }
       resolve();
     });

--- a/config/lib/mongoose.js
+++ b/config/lib/mongoose.js
@@ -10,9 +10,12 @@ var config = require('../config'),
     mongoose = require('mongoose'),
     semver = require('semver');
 
-// Options for Native MongoDB connection
-// https://mongodb.github.io/node-mongodb-native/2.1/api/Server.html
-// http://mongoosejs.com/docs/connections.html
+/**
+ * Options for Native MongoDB connection
+ *
+ * @link https://mongodb.github.io/node-mongodb-native/2.1/api/Server.html
+ * @link https://mongoosejs.com/docs/connections.html
+ */
 var mongoConnectionOptions = {
   server: {
     // Never stop reconnecting

--- a/config/lib/mongoose.js
+++ b/config/lib/mongoose.js
@@ -67,7 +67,7 @@ module.exports.connect = function (callback) {
     useFindAndModify: false,
     // Mongoose-specific option. Set to false to disable automatic index
     // creation for all models associated with this connection.
-    autoIndex: Boolean(config.db.autoindex)
+    autoIndex: Boolean(config.db.autoIndex)
   };
 
   async.waterfall([

--- a/config/lib/mongoose.js
+++ b/config/lib/mongoose.js
@@ -158,7 +158,7 @@ module.exports.dropDatabase = function (connection, callback) {
 };
 
 module.exports.ensureIndexes = function (modelNames) {
-  return new Promise(function (resolve) {
+  return new Promise(function (resolve, reject) {
     // assuming openFiles is an array of file names
     async.each(modelNames, function (modelName, callback) {
       mongoose.connection.model(modelName).ensureIndexes(function (error) {
@@ -175,10 +175,13 @@ module.exports.ensureIndexes = function (modelNames) {
       });
     }, function (error) {
       // if any of the file processing produced an error
-      if (error) {
+      if (true || error) {
         // One of the iterations produced an error.
         // All processing will now stop.
-        log('error', 'A Schema failed to index.');
+        log('error', 'A Schema failed to index.', {
+          error: error
+        });
+        reject(error);
       } else {
         log('info', modelNames.length + ' Schemas have been indexed successfully:\n - ' + modelNames.join('\n - '));
       }

--- a/config/lib/mongoose.js
+++ b/config/lib/mongoose.js
@@ -16,7 +16,7 @@ var config = require('../config'),
 var mongoConnectionOptions = {
   server: {
     // Never stop reconnecting
-    reconnectTries: Number.MAX_VALUE
+    reconnectTries: Number.MAX_SAFE_INTEGER
   },
   // https://mongoosejs.com/docs/deprecations.html#-ensureindex-
   useCreateIndex: true,

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "test:server:watch": "npm run pretest && gulp test:server:watch",
     "test:server": "npm run pretest && gulp test:server",
     "test": "npm run lint && gulp test",
-    "travis-ci": "concurrently --kill-others-on-fail 'npm:lint' 'npm:build:prod'"
+    "travis-ci": "concurrently --kill-others-on-fail 'npm:lint' 'npm:build:prod'",
+    "ensure-indexes": "node ./bin/db-maintenance/ensure-indexes.js"
   },
   "dependencies": {
     "acl": "~0.4.11",


### PR DESCRIPTION
#### Proposed Changes

* Add logging for indexing events in Mongoose models
* Add config to turn autoindexing on or off easily
* Move a couple `mongoose.set` settings directly to the connection config
* Add `ensure-indexes` NPM script to manually ensure indexes in MongoDB
* Add more logging to Mongoose process in general

### Testing

- Run `npm start` in dev mode; you should see lines logged about indexing
- Switch `autoIndex` to ``false` in `config/env/development.js` and you should see _less_ autoindexing events. Some still pop up somehow before the app boots. I'm not sure what causes these — I suspect either Worker or Agenda on their own somehow. Good for another PR another time I'd say.
- Run `npm run ensure-indexes` to index all the schemas, run `npm run ensure-indexes User` to index only User Schema