### PR TITLE
Linting: remove dublicate linting config from `bin/`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -214,5 +214,14 @@ module.exports = {
       'no-console': 0,
       'no-process-exit': 0,
     }
+  },{
+    // overrides for CLI scripts and application config
+    files: [
+      'bin/**',
+      'scripts/**',
+    ],
+    parserOptions: {
+      ecmaVersion: 2018
+    }
   }]
 };

--- a/bin/.eslintrc.js
+++ b/bin/.eslintrc.js
@@ -1,6 +1,0 @@
-module.exports = {
-  parserOptions: {
-    ecmaVersion: 6,
-    sourceType: 'module'
-  }
-};


### PR DESCRIPTION
## Changes
- The folder is already covered by linter config exception in the root folder.
- No need to limit to ecmaVersion 6 here

## Testing
- Linters pass?
- ES6 available in files under `bin/` when added to exception list at root config?