### PR TITLE
Docs: Add F-Droid repository instructions

### DIFF
--- a/docs/Fdroid.md
+++ b/docs/Fdroid.md
@@ -1,0 +1,23 @@
+# Trustroots App on F-Droid
+
+F-Droid users can manually add additional repositories in order to receive applications. Below repository provides the Trustroots app to F-Droid users who wish to avoid the Play Store version.
+
+## Issue
+
+We don't have resources yet to build a separate "native app" for Android so we're using Expo.io framework instead.
+
+Using Expo seems to block inclusion to the official F-Droid repository. As an alternative, a private repository has been set up to serve F-Droid users with the latest Trustroots Android mobile app.
+
+## Repository details
+
+```html
+Repository address: https://platschi.net/fdroid/repo
+Fingerprint: 2740 3908 C610 6BAC BF26 9C4F 94C7 21D7 8E45 EE81 EFA3 71CB 7D3C 069D 0D6C D6E5
+
+Archive address: https://platschi.net/fdroid/Archive
+Fingerprint: 2740 3908 C610 6BAC BF26 9C4F 94C7 21D7 8E45 EE81 EFA3 71CB 7D3C 069D 0D6C D6E5
+```
+
+## More
+* [F-Droid on Trustroots](https://platschi.net/f-droid-repository-for-trustroots.html) - a detailed blog post on adding and verifying the Trustroots app using Platschis Repository.
+* [Issue on Github](https://github.com/Trustroots/trustroots-expo-mobile/issues/3)

--- a/docs/Fdroid.md
+++ b/docs/Fdroid.md
@@ -10,7 +10,7 @@ Using Expo seems to block inclusion to the official F-Droid repository. As an al
 
 ## Repository details
 
-```html
+```
 Repository address: https://platschi.net/fdroid/repo
 Fingerprint: 2740 3908 C610 6BAC BF26 9C4F 94C7 21D7 8E45 EE81 EFA3 71CB 7D3C 069D 0D6C D6E5
 


### PR DESCRIPTION
#### Proposed Changes

* Add Info for F-Droid repository with Trustroots mobile app

#### Testing Instructions

* Add repository to your F-Droid installation, search for Trustroots, install app. Verify fingerprints.

Fixes https://github.com/Trustroots/trustroots-expo-mobile/issues/3