### PR TITLE
Travis CI: run only server tests in Node.js 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,19 @@
 language: node_js
 node_js:
   - 10
-  - 11
 env:
   - $RUN="npm run test:client"
   - $RUN="npm run test:server"
-  - $RUN="npm run travis-ci"
+  - $RUN="npm run lint-and-build-prod"
 script:
   - $RUN
 install:
   - npm ci
 matrix:
   fast_finish: true
+  include:
+    - node_js: 11
+      env: $RUN="npm run test:server"
 # https://docs.travis-ci.com/user/reference/overview/#Virtualisation-Environment-vs-Operating-System
 dist: trusty
 services:

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "test:server:watch": "npm run pretest && gulp test:server:watch",
     "test:server": "npm run pretest && gulp test:server",
     "test": "npm run lint && gulp test",
-    "travis-ci": "concurrently --kill-others-on-fail 'npm:lint' 'npm:build:prod'",
+    "lint-and-build-prod": "concurrently --kill-others-on-fail 'npm:lint' 'npm:build:prod'",
     "ensure-indexes": "node ./bin/db-maintenance/ensure-indexes.js"
   },
   "dependencies": {


### PR DESCRIPTION
- Since we're running on Node.js 11 containers only to ensure future versions compatibility, we don't need to run linters and client tests in it.
- Rename "travis-ci" NPM script to "lint-and-build-prod" for clarity

This should speed up CI tests a bit since we'll run two containers less.

https://github.com/nodejs/Release