### PR TITLE
Fix "dublicate track by id" Angular JS error

### DIFF
--- a/modules/pages/client/views/home.client.view.html
+++ b/modules/pages/client/views/home.client.view.html
@@ -95,7 +95,7 @@
 </section>
 
 <!-- Tribes -->
-<section class="home-how">
+<section class="home-how" nf-if="home.tribes.length">
   <div class="container">
     <div class="row">
       <div class="col-xs-10 col-xs-push-1 col-sm-3 col-sm-push-6">
@@ -111,7 +111,7 @@
       <div class="col-xs-12 visible-xs tribes-xs">
         <a ui-sref="tribes.tribe({tribe: tribe.slug})"
            class="img-circle tribe-xs tribe-image"
-           ng-repeat="tribe in home.tribes | limitTo:3 track by tribe._id"
+           ng-repeat="tribe in home.tribes | limitTo:3 track by $index"
            tr-tribe-styles="{{::tribe}}"
            tr-tribe-styles-dimensions="520x520"
            tr-tribe-styles-quality="lightest"
@@ -121,7 +121,7 @@
       </div>
       <div class="col-sm-3 hidden-xs"
            ng-class="{ 'col-sm-pull-3': !$last }"
-           ng-repeat="tribe in home.tribes | limitTo:3 track by tribe._id">
+           ng-repeat="tribe in home.tribes | limitTo:3 track by $index">
         <div class="img-circle tribe tribe-image"
              tr-tribe-styles="{{::tribe}}">
           <a ui-sref="tribes.tribe({tribe: tribe.slug})" class="tribe-link">


### PR DESCRIPTION
...when opening page with query arg "?tribe=tribe-name".

Not entirely sure why this was happening since _id should be unique, but since we don't reload home.tribes, it's safe to use $index.

https://docs.angularjs.org/api/ng/directive/ngRepeat

### Testing

- Open `http://localhost:3000/?tribe=tribe-slug-that-exists`
- Before: you'll see error in console
- After: all good :thumbsup: