### PR TITLE
Create endpoint for saving missing translations

### DIFF
--- a/config/client/i18n.js
+++ b/config/client/i18n.js
@@ -75,7 +75,7 @@ i18n
     // allow keys to be phrases having `:`, `.`
     nsSeparator: false,
     keySeparator: false, // we do not use keys in form messages.welcome
-    saveMissing: true, // @TODO send not translated keys to endpoint
+    saveMissing: true, // send not translated keys to endpoint
     saveMissingTo: 'current',
     returnEmptyString: false,
     interpolation: {
@@ -94,7 +94,7 @@ i18n
       addPath: '/api/locales/{{lng}}/{{ns}}',
     },
     saveMissingPlurals: true,
-    debug: true, // show missing translation keys in console.log
+    // debug: true, // show missing translation keys in console.log
   });
 
 export default i18n;

--- a/config/client/i18n.js
+++ b/config/client/i18n.js
@@ -71,7 +71,7 @@ i18n
         en: {},
       },
     } : {}),
-    fallbackLng: 'en', // a default app locale
+    // fallbackLng: 'en', // a default app locale
     // allow keys to be phrases having `:`, `.`
     nsSeparator: false,
     keySeparator: false, // we do not use keys in form messages.welcome

--- a/config/client/i18n.js
+++ b/config/client/i18n.js
@@ -4,6 +4,7 @@ import { initReactI18next } from 'react-i18next';
 import Backend from 'i18next-xhr-backend';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import moment from 'moment';
+import locales from '@/config/shared/locales';
 
 const isTest = process.env.NODE_ENV === 'test';
 
@@ -51,6 +52,18 @@ function format(value, format, languageCode) {
   return value;
 }
 
+const defaultLanguageDetector = {
+  name: 'default',
+
+  lookup({ detection={} }) {
+    return detection.defaultLng || 'en';
+  },
+};
+
+const languageDetector = new LanguageDetector();
+languageDetector.addDetector(defaultLanguageDetector);
+
+
 if (!isTest) {
   // load translation using xhr -> see /public/locales
   // learn more: https://github.com/i18next/i18next-xhr-backend
@@ -60,7 +73,7 @@ if (!isTest) {
 i18n
   // detect user language
   // learn more: https://github.com/i18next/i18next-browser-languageDetector
-  .use(LanguageDetector)
+  .use(languageDetector)
   // pass the i18n instance to react-i18next.
   .use(initReactI18next)
   // init i18next
@@ -71,7 +84,7 @@ i18n
         en: {},
       },
     } : {}),
-    // fallbackLng: 'en', // a default app locale
+    fallbackLng: false, // a default app locale
     // allow keys to be phrases having `:`, `.`
     nsSeparator: false,
     keySeparator: false, // we do not use keys in form messages.welcome
@@ -84,7 +97,7 @@ i18n
     },
     detection: {
       lookupCookie: 'i18n',
-      order: ['cookie'],
+      order: ['cookie', 'default'],
       caches: ['cookie'],
     },
     react: {
@@ -94,6 +107,7 @@ i18n
       addPath: '/api/locales/{{lng}}/{{ns}}',
     },
     saveMissingPlurals: true,
+    whitelist: locales.map(({ code }) => code),
     // debug: true, // show missing translation keys in console.log
   });
 

--- a/config/client/i18n.js
+++ b/config/client/i18n.js
@@ -75,7 +75,9 @@ i18n
     // allow keys to be phrases having `:`, `.`
     nsSeparator: false,
     keySeparator: false, // we do not use keys in form messages.welcome
-    // saveMissing: true, // @TODO send not translated keys to endpoint
+    saveMissing: true, // @TODO send not translated keys to endpoint
+    saveMissingTo: 'current',
+    returnEmptyString: false,
     interpolation: {
       escapeValue: false, // react already safes from xss
       format,
@@ -88,8 +90,11 @@ i18n
     react: {
       useSuspense: false,
     },
-    // saveMissingPlurals: true,
-    // debug: true // show missing translation keys in console.log
+    backend: {
+      addPath: '/api/locales/{{lng}}/{{ns}}',
+    },
+    saveMissingPlurals: true,
+    debug: true, // show missing translation keys in console.log
   });
 
 export default i18n;

--- a/config/client/i18n.js
+++ b/config/client/i18n.js
@@ -75,7 +75,7 @@ i18n
     // allow keys to be phrases having `:`, `.`
     nsSeparator: false,
     keySeparator: false, // we do not use keys in form messages.welcome
-    saveMissing: true, // send not translated keys to endpoint
+    saveMissing: process.env.NODE_ENV === 'development', // send not translated keys to endpoint
     saveMissingTo: 'current',
     returnEmptyString: false,
     interpolation: {

--- a/config/env/default.js
+++ b/config/env/default.js
@@ -187,4 +187,5 @@ module.exports = {
       inlineMeta: true,
     },
   },
+  i18nBackend: false,
 };

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -48,4 +48,5 @@ module.exports = {
       pool: true,
     },
   },
+  i18nBackend: true,
 };

--- a/modules/i18n/server/controllers/backend.server.controller.js
+++ b/modules/i18n/server/controllers/backend.server.controller.js
@@ -12,6 +12,12 @@ function enqueue(func, ...args) {
 }
 
 /**
+ * Object property order matters since ES2015
+ * So we can sort it alphabetically by keys
+ */
+const sortObject = object => Object.fromEntries(Object.entries(object).sort(([a], [b]) => a > b ? 1 : -1));
+
+/**
  * Here we execute the standard request, not concerned with waiting
  */
 async function processRequest(req, res) {
@@ -27,11 +33,12 @@ async function processRequest(req, res) {
     await fs.ensureFile(file);
 
     // read current translations or set a default
-    const rawContent = await fs.readFile(file, 'utf8') || '{}';
-    const content = JSON.parse(rawContent);
+    const content = await fs.readJson(file, 'utf8') || '{}';
+
+    const newContent = sortObject({ [key]: value, ...content });
 
     // save the new translation
-    await fs.writeJSON(file, { ...{ [key]: value }, ...content }, { spaces: 2 });
+    await fs.writeJSON(file, newContent, { spaces: 2 });
   } catch (e) {
     // clean up in case of an error
     await fs.writeJSON(file, {}, { spaces: 2 });

--- a/modules/i18n/server/controllers/backend.server.controller.js
+++ b/modules/i18n/server/controllers/backend.server.controller.js
@@ -22,11 +22,11 @@ const sortObject = object => Object.fromEntries(Object.entries(object).sort(([a]
  */
 async function processRequest(req, res) {
   // get the needed variables
-  const { lng, ns } = req.params;
+  const { language, namespace } = req.params;
   const [key] = Object.keys(req.body).filter(key => key !== '_t');
-  const value = (lng === 'en') ? req.body[key] : '';
+  const value = (language === 'en') ? req.body[key] : '';
 
-  const file = path.resolve(`./public/locales/${lng}/${ns}.json`);
+  const file = path.resolve(`./public/locales/${language}/${namespace}.json`);
 
   try {
     // create file if it doesn't exist

--- a/modules/i18n/server/controllers/backend.server.controller.js
+++ b/modules/i18n/server/controllers/backend.server.controller.js
@@ -33,7 +33,8 @@ async function processRequest(req, res) {
     await fs.ensureFile(file);
 
     // read current translations or set a default
-    const content = await fs.readJson(file, 'utf8') || '{}';
+    const rawContent = await fs.readFile(file, 'utf8') || '{}';
+    const content = JSON.parse(rawContent);
 
     const newContent = sortObject({ [key]: value, ...content });
 

--- a/modules/i18n/server/controllers/backend.server.controller.js
+++ b/modules/i18n/server/controllers/backend.server.controller.js
@@ -1,0 +1,46 @@
+const path = require('path');
+const fs = require('fs-extra');
+
+/**
+ * We want to process only one unsaved translation at the time.
+ * Otherwise the output files will be inconsistent.
+ * We make a promise chain: The next promise will start executing after the previous one finished
+ */
+const queue = { promise: Promise.resolve() };
+function enqueue(func, ...args) {
+  queue.promise = queue.promise.then(() => func(...args));
+}
+
+/**
+ * Here we execute the standard request, not concerned with waiting
+ */
+async function processRequest(req, res) {
+  // get the needed variables
+  const { lng, ns } = req.params;
+  const [key] = Object.keys(req.body).filter(key => key !== '_t');
+  const value = (lng === 'en') ? req.body[key] : '';
+
+  const file = path.resolve(`./public/locales/${lng}/${ns}.json`);
+
+  try {
+    // create file if it doesn't exist
+    await fs.ensureFile(file);
+
+    // read current translations or set a default
+    const rawContent = await fs.readFile(file, 'utf8') || '{}';
+    const content = JSON.parse(rawContent);
+
+    // save the new translation
+    await fs.writeJSON(file, { ...{ [key]: value }, ...content }, { spaces: 2 });
+  } catch (e) {
+    // clean up in case of an error
+    await fs.writeJSON(file, {}, { spaces: 2 });
+  } finally {
+    await res.status(200).end();
+  }
+}
+
+module.exports = (req, res) => {
+  return enqueue(processRequest, req, res);
+};
+

--- a/modules/i18n/server/routes/backend.server.routes.js
+++ b/modules/i18n/server/routes/backend.server.routes.js
@@ -1,0 +1,11 @@
+
+
+const path = require('path');
+const backend = require('../controllers/backend.server.controller');
+const config = require(path.resolve('./config/config'));
+
+module.exports = (app) => {
+  if (config.i18nBackend) {
+    app.route('/api/locales/:lng/:ns').post(backend);
+  }
+};

--- a/modules/i18n/server/routes/backend.server.routes.js
+++ b/modules/i18n/server/routes/backend.server.routes.js
@@ -1,5 +1,3 @@
-
-
 const path = require('path');
 const backend = require('../controllers/backend.server.controller');
 const config = require(path.resolve('./config/config'));

--- a/modules/i18n/server/routes/backend.server.routes.js
+++ b/modules/i18n/server/routes/backend.server.routes.js
@@ -4,6 +4,6 @@ const config = require(path.resolve('./config/config'));
 
 module.exports = (app) => {
   if (config.i18nBackend) {
-    app.route('/api/locales/:lng/:ns').post(backend);
+    app.route('/api/locales/:language/:namespace').post(backend);
   }
 };

--- a/modules/i18n/tests/server/backend.server.routes.tests.js
+++ b/modules/i18n/tests/server/backend.server.routes.tests.js
@@ -1,5 +1,3 @@
-
-
 const should = require('should');
 const request = require('supertest');
 const fs = require('fs-extra');
@@ -14,10 +12,9 @@ describe('Save a missing translation', () => {
   const dirFoo = path.resolve('./public/locales/foo/');
   const fileEn = path.resolve('./public/locales/en/bar.json');
 
-  const body = {
-    'A bcde f': 'A bcde f',
-    '_t': Date(),
-  };
+  const text = 'Send us suggestions!';
+
+  const body = { [text]: text };
 
   afterEach(async () => {
     await fs.remove(dirFoo);
@@ -46,7 +43,7 @@ describe('Save a missing translation', () => {
           .expect(200);
         const output = await fs.readJSON(fileEn);
 
-        should(output).deepEqual({ 'A bcde f': 'A bcde f' });
+        should(output).deepEqual({ [text]: text });
       });
 
       it('[not en] save key, but value will be an empty string', async () => {
@@ -55,7 +52,7 @@ describe('Save a missing translation', () => {
           .expect(200);
         const output = await fs.readJSON(fileFoo);
 
-        should(output).deepEqual({ 'A bcde f': '' });
+        should(output).deepEqual({ [text]: '' });
       });
     });
 
@@ -79,20 +76,20 @@ describe('Save a missing translation', () => {
           .expect(200);
         const output = await fs.readJSON(fileEn);
 
-        should(output).deepEqual({ 'A bcde f': 'A bcde f' });
+        should(output).deepEqual({ [text]: text });
       });
 
       it('[translation exists] don\'t save it', async () => {
 
         // create the file with a different translation
-        await fs.outputJson(fileEn, { 'A bcde f': 'gggggg' });
+        await fs.outputJson(fileEn, { [text]: 'gggggg' });
 
         await agent.post('/api/locales/en/bar')
           .send(body)
           .expect(200);
 
         const output = await fs.readJSON(fileEn);
-        should(output).deepEqual({ 'A bcde f': 'gggggg' });
+        should(output).deepEqual({ [text]: 'gggggg' });
       });
 
       it('[other translation exists] save the new one, keep the old one', async () => {
@@ -105,7 +102,7 @@ describe('Save a missing translation', () => {
           .expect(200);
 
         const output = await fs.readJSON(fileFoo);
-        should(output).deepEqual({ 'A bcde f': '', foo: 'bar' });
+        should(output).deepEqual({ [text]: '', foo: 'bar' });
       });
     });
 

--- a/modules/i18n/tests/server/backend.server.routes.tests.js
+++ b/modules/i18n/tests/server/backend.server.routes.tests.js
@@ -1,0 +1,132 @@
+
+
+const should = require('should');
+const request = require('supertest');
+const fs = require('fs-extra');
+const path = require('path');
+const mongoose = require('mongoose');
+const sinon = require('sinon');
+const config = require(path.resolve('./config/config'));
+
+describe('Save a missing translation', () => {
+
+  const fileFoo = path.resolve('./public/locales/foo/bar.json');
+  const dirFoo = path.resolve('./public/locales/foo/');
+  const fileEn = path.resolve('./public/locales/en/bar.json');
+
+  const body = {
+    'A bcde f': 'A bcde f',
+    '_t': Date(),
+  };
+
+  afterEach(async () => {
+    await fs.remove(dirFoo);
+    await fs.remove(fileEn);
+  });
+
+  after(() => {
+    sinon.restore();
+  });
+
+  context('activated in config', () => {
+
+    let agent;
+
+    before(async () => {
+      sinon.stub(config, 'i18nBackend').value(true);
+      const express = require(path.resolve('./config/lib/express'));
+      const app = express.init(mongoose.connection);
+      agent = request.agent(app);
+    });
+
+    context('different languages', () => {
+      it('[en] save key and value', async () => {
+        await agent.post('/api/locales/en/bar')
+          .send(body)
+          .expect(200);
+        const output = await fs.readJSON(fileEn);
+
+        should(output).deepEqual({ 'A bcde f': 'A bcde f' });
+      });
+
+      it('[not en] save key, but value will be an empty string', async () => {
+        await agent.post('/api/locales/foo/bar')
+          .send(body)
+          .expect(200);
+        const output = await fs.readJSON(fileFoo);
+
+        should(output).deepEqual({ 'A bcde f': '' });
+      });
+    });
+
+    context('file doesn\'t exist', () => {
+      it('create a new translation file', async () => {
+
+        await fs.access(fileFoo).should.be.rejected();
+
+        await agent.post('/api/locales/foo/bar')
+          .send(body)
+          .expect(200);
+
+        await fs.access(fileFoo).should.not.be.rejected();
+      });
+    });
+
+    context('file exists', () => {
+      it('[translation doesn\'t exist] save it', async () => {
+        await agent.post('/api/locales/en/bar')
+          .send(body)
+          .expect(200);
+        const output = await fs.readJSON(fileEn);
+
+        should(output).deepEqual({ 'A bcde f': 'A bcde f' });
+      });
+
+      it('[translation exists] don\'t save it', async () => {
+
+        // create the file with a different translation
+        await fs.outputJson(fileEn, { 'A bcde f': 'gggggg' });
+
+        await agent.post('/api/locales/en/bar')
+          .send(body)
+          .expect(200);
+
+        const output = await fs.readJSON(fileEn);
+        should(output).deepEqual({ 'A bcde f': 'gggggg' });
+      });
+
+      it('[other translation exists] save the new one, keep the old one', async () => {
+
+        // create the file with a different translation
+        await fs.outputJson(fileFoo, { 'foo': 'bar' });
+
+        await agent.post('/api/locales/foo/bar')
+          .send(body)
+          .expect(200);
+
+        const output = await fs.readJSON(fileFoo);
+        should(output).deepEqual({ 'A bcde f': '', foo: 'bar' });
+      });
+    });
+
+  });
+
+  context('desactivated in config', () => {
+    let agent;
+
+    before(async () => {
+      sinon.stub(config, 'i18nBackend').value(false);
+      const express = require(path.resolve('./config/lib/express'));
+      const app = express.init(mongoose.connection);
+      agent = request.agent(app);
+    });
+
+    it('404', async () => {
+      await agent.post('/api/locales/en/bar')
+        .send(body)
+        .expect(404);
+    });
+
+  });
+
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -6113,7 +6113,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
       "integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
-      "optional": true,
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
@@ -6129,7 +6128,6 @@
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
           "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
-          "optional": true,
           "requires": {
             "normalize-path": "^3.0.0",
             "picomatch": "^2.0.4"
@@ -6138,14 +6136,12 @@
         "binary-extensions": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-          "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
-          "optional": true
+          "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
         },
         "braces": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
           "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-          "optional": true,
           "requires": {
             "fill-range": "^7.0.1"
           }
@@ -6160,7 +6156,6 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
           "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
-          "optional": true,
           "requires": {
             "is-glob": "^4.0.1"
           }
@@ -6169,7 +6164,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
           "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-          "optional": true,
           "requires": {
             "binary-extensions": "^2.0.0"
           }
@@ -6177,14 +6171,12 @@
         "normalize-path": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-          "optional": true
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
         },
         "readdirp": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
           "integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
-          "optional": true,
           "requires": {
             "picomatch": "^2.0.7"
           }
@@ -8952,51 +8944,10 @@
         "source-map-support": "^0.5.13"
       },
       "dependencies": {
-        "anymatch": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-          "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
-          "dev": true,
-          "requires": {
-            "normalize-path": "^3.0.0",
-            "picomatch": "^2.0.4"
-          }
-        },
-        "binary-extensions": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-          "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
-          "dev": true
-        },
-        "braces": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-          "dev": true,
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "chokidar": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.2.1.tgz",
-          "integrity": "sha512-/j5PPkb5Feyps9e+jo07jUZGvkB5Aj953NrI4s8xSVScrAo/RHeILrtdb4uzR7N6aaFFxxJ+gt8mA8HfNpw76w==",
-          "dev": true,
-          "requires": {
-            "anymatch": "~3.1.1",
-            "braces": "~3.0.2",
-            "fsevents": "~2.1.0",
-            "glob-parent": "~5.1.0",
-            "is-binary-path": "~2.1.0",
-            "is-glob": "~4.0.1",
-            "normalize-path": "~3.0.0",
-            "readdirp": "~3.1.3"
-          }
-        },
         "core-js": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
-          "integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw==",
+          "version": "3.6.4",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
+          "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
           "dev": true
         },
         "cross-spawn": {
@@ -9045,40 +8996,10 @@
             "pump": "^3.0.0"
           }
         },
-        "glob-parent": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-          "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
-          "dev": true,
-          "requires": {
-            "is-glob": "^4.0.1"
-          }
-        },
-        "is-binary-path": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-          "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-          "dev": true,
-          "requires": {
-            "binary-extensions": "^2.0.0"
-          }
-        },
         "is-stream": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
           "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-          "dev": true
-        },
-        "mimic-fn": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-          "dev": true
-        },
-        "normalize-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
           "dev": true
         },
         "npm-run-path": {
@@ -9090,15 +9011,6 @@
             "path-key": "^3.0.0"
           }
         },
-        "onetime": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^2.1.0"
-          }
-        },
         "p-finally": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
@@ -9106,9 +9018,9 @@
           "dev": true
         },
         "path-key": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
-          "integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==",
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
           "dev": true
         },
         "pump": {
@@ -9119,15 +9031,6 @@
           "requires": {
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
-          }
-        },
-        "readdirp": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.1.3.tgz",
-          "integrity": "sha512-ZOsfTGkjO2kqeR5Mzr5RYDbTGYneSkdNKX2fOX2P5jF7vMrd/GNnIAUtDldeHHumHUCQ3V05YfWUdxMPAsRu9Q==",
-          "dev": true,
-          "requires": {
-            "picomatch": "^2.0.4"
           }
         },
         "shebang-command": {
@@ -9145,26 +9048,10 @@
           "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
           "dev": true
         },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "source-map-support": {
-          "version": "0.5.13",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-          "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-          "dev": true,
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "source-map": "^0.6.0"
-          }
-        },
         "which": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.1.tgz",
-          "integrity": "sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -11223,6 +11110,16 @@
         "readable-stream": "^2.0.0"
       }
     },
+    "fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
     "fs-mkdirp-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
@@ -11286,13 +11183,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "fsevents": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.0.tgz",
-      "integrity": "sha512-+iXhW3LuDQsno8dOIrCIT/CBjeBWuP7PXe8w9shnj9Lebny/Gx1ZjVBYwexLz36Ri2jKuXMNpV6CYNh8lHHgrQ==",
-      "dev": true,
-      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -18325,7 +18215,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -28080,8 +27969,7 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "fbgraph": "~1.4.4",
     "firebase": "~3.7.5",
     "firebase-admin": "~4.2.0",
+    "fs-extra": "~7.0.1",
     "git-rev": "~0.2.1",
     "glob": "~7.1.6",
     "gm": "~1.23.1",

--- a/public/locales/cs/tribes.json
+++ b/public/locales/cs/tribes.json
@@ -1,0 +1,18 @@
+{
+  "Cancel": "",
+  "Discover Tribes": "",
+  "Do you want to leave \"{{label}}\"?": "",
+  "Join": "",
+  "Join ({{label}})": "",
+  "Join Trustroots to find members behind Tribes.": "",
+  "Joined": "",
+  "Joining Tribes helps you find likeminded Trustroots members.": "",
+  "Leave Tribe": "",
+  "Leave this Tribe?": "",
+  "Missing your Tribe?": "",
+  "Send us suggestions!": "",
+  "Sign up with Trustroots": "",
+  "{{count, number}} members_0": "",
+  "{{count, number}} members_1": "",
+  "{{count, number}} members_2": ""
+}

--- a/public/locales/en/tribes.json
+++ b/public/locales/en/tribes.json
@@ -4,6 +4,7 @@
   "Do you want to leave \"{{label}}\"?": "Do you want to leave \"{{label}}\"?",
   "Join": "Join",
   "Join ({{label}})": "Join ({{label}})",
+  "Join Trustroots to find members behind Tribes.": "Join Trustroots to find members behind Tribes.",
   "Joined": "Joined",
   "Joining Tribes helps you find likeminded Trustroots members.": "Joining Tribes helps you find likeminded Trustroots members.",
   "Leave Tribe": "Leave Tribe",
@@ -11,6 +12,7 @@
   "Missing your Tribe?": "Missing your Tribe?",
   "No members yet": "No members yet",
   "Send us suggestions!": "Send us suggestions!",
+  "Sign up with Trustroots": "Sign up with Trustroots",
   "{{count, number}} members": "One member",
   "{{count, number}} members_plural": "{{count, number}} members"
 }

--- a/public/locales/en/tribes.json
+++ b/public/locales/en/tribes.json
@@ -1,5 +1,16 @@
 {
+  "Cancel": "Cancel",
+  "Discover Tribes": "Discover Tribes",
+  "Do you want to leave \"{{label}}\"?": "Do you want to leave \"{{label}}\"?",
+  "Join": "Join",
+  "Join ({{label}})": "Join ({{label}})",
+  "Joined": "Joined",
+  "Joining Tribes helps you find likeminded Trustroots members.": "Joining Tribes helps you find likeminded Trustroots members.",
+  "Leave Tribe": "Leave Tribe",
+  "Leave this Tribe?": "Leave this Tribe?",
+  "Missing your Tribe?": "Missing your Tribe?",
   "No members yet": "No members yet",
+  "Send us suggestions!": "Send us suggestions!",
   "{{count, number}} members": "One member",
   "{{count, number}} members_plural": "{{count, number}} members"
 }


### PR DESCRIPTION
#### Proposed Changes
Save missing translations in translation files.

[Runtime extraction](https://react.i18next.com/guides/extracting-translations#3-runtime-extraction) of translations.

Alternative is [using an extraction tool](https://react.i18next.com/guides/extracting-translations#2-using-an-extraction-tool), e.g. [babel-plugin-i18next-extract](https://github.com/gilbsgilbs/babel-plugin-i18next-extract).

_Note: I have an impression that @nicksellen was researching into the babel extraction plugin, but I haven't found the relevant discussion. Anyways, let's have this PR as a temporary solution which will help us up and running, but will be likely replaced by another (e.g. more convenient) solution later._

When the running app in development mode encounters an untranslated text, it sends a request
```
POST /api/locales/:language/:namespace` with body `{ "Translated Sentence": "Translated Sentence", _t: Time }
```
The backend then adds the missing text to the translation file in `/public/locales/{language}/{namespace}.json`.

The text still needs to be translated. That is not a concern of this PR.

This endpoint is not safe in production! It's intended for development use only. It is enabled in development environment. `config.i18nBackend: Boolean`

#### Testing Instructions

* `git switch save-translations`
* See that the translation strings get saved
  * Run the app in development mode (`npm start`)
  * Switch the language (e.g. to `suomi`)
  * Open some non-localized page e.g. http://localhost:3000/volunteering
  * Observe that the files in `/public/locales/{language}/{namespace}` have changed.
* Run the server tests with `npm run test:server`. The tests should pass.

#### Issues

How to deal with the outdated translation strings? They keep hanging around