### PR TITLE
Migrate avatar, name, tagline in Overview for small screens to React

### DIFF
--- a/modules/users/client/components/AvatarNameMobile.component.js
+++ b/modules/users/client/components/AvatarNameMobile.component.js
@@ -17,7 +17,7 @@ export default function AvatarNameMobile({ profile }) {
 
       {/* Avatar */}
       <a
-        onClick={() => setIsBiggerAvatar(!isBiggerAvatar)}
+        onClick={() => setIsBiggerAvatar(prevState => !prevState)}
         className={classNames('visible-xs-block', 'avatar-circle', { 'profile-avatar-lg': isBiggerAvatar })}
         aria-hidden={true}>
         <Avatar

--- a/modules/users/client/components/AvatarNameMobile.component.js
+++ b/modules/users/client/components/AvatarNameMobile.component.js
@@ -1,0 +1,51 @@
+/**
+ * The AvatarNameMobile component displays user's avatar, name, username and tagline.
+ * @param {Object} profile - the user's profile
+ */
+
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import Avatar from './Avatar.component';
+
+export default function AvatarNameMobile({ profile }) {
+  const [isBiggerAvatar, setIsBiggerAvatar] = useState(false);
+
+  return (
+    <div className="text-center visible-xs-block" role="dialog">
+
+      {/* Avatar */}
+      <a
+        onClick={() => setIsBiggerAvatar(!isBiggerAvatar)}
+        className={classNames('visible-xs-block', 'avatar-circle', { 'profile-avatar-lg': isBiggerAvatar })}
+        aria-hidden={true}>
+        <Avatar
+          user={profile}
+          size={512}
+          link={false}
+        />
+      </a>
+
+      {/* Name */}
+      {profile.displayName && <h2 className="profile-name">{profile.displayName}</h2>}
+
+      <br />
+
+      {/* Username */}
+      <h4 className="profile-username">
+        @{profile.displayUsername || profile.username}
+      </h4>
+
+      <br />
+
+      {/* Tagline */}
+      {profile.tagline && <p className="profile-tagline">{profile.tagline}</p>}
+
+    </div>
+  );
+}
+
+AvatarNameMobile.propTypes = {
+  profile: PropTypes.object.isRequired
+};

--- a/modules/users/client/views/profile/profile-view-basics.client.view.html
+++ b/modules/users/client/views/profile/profile-view-basics.client.view.html
@@ -1,25 +1,5 @@
 <!-- Avatar+Name for mobile screens -->
-<div class="text-center visible-xs-block" role="dialog">
-  <a tr-avatar
-     data-user="profileCtrl.profile"
-     data-size="512"
-     data-link="false"
-     class="visible-xs-block avatar-circle"
-     ng-click="profileCtrl.biggerAvatar = !profileCtrl.biggerAvatar"
-     ng-class="{'profile-avatar-lg': profileCtrl.biggerAvatar}"
-     aria-hidden="true"></a>
-  <h2 class="profile-name"
-      ng-show="profileCtrl.profile.displayName"
-      ng-bind="profileCtrl.profile.displayName"></h2>
-  <br>
-  <h4 class="profile-username">
-    @{{ profileCtrl.profile.username }}
-  </h4>
-  <br>
-  <p class="profile-tagline"
-     ng-show="profileCtrl.profile.tagline"
-     ng-bind="profileCtrl.profile.tagline"></p>
-</div>
+<avatar-name-mobile profile="profileCtrl.profile"></avatar-name-mobile>
 
 <profile-overview profile="profileCtrl.profile">
 </profile-overview>


### PR DESCRIPTION
#### Proposed Changes

* Migrate the top div in `./modules/users/client/views/profile/profile-view-basics.client.view.html` to React. It is displayed only in mobile view in User Profile Overview tab. It contains Avatar, name, username, tagline.

![image](https://user-images.githubusercontent.com/7449720/68675852-07d74c80-0559-11ea-862d-ad6cf8d1ee2d.png)

#### Testing Instructions
* Set your browser to a small screen
* Go to some user's profile Overview
* See that the circular avatar, name, username and tagline are displayed as before
* Additionally the avatar should toggle larger/smaller size when clicked.

Continued work on #1019 