### PR TITLE
Top user profile navigation for small screens - migrate to React

### DIFF
--- a/modules/users/client/components/TopNavigationSmall.component.js
+++ b/modules/users/client/components/TopNavigationSmall.component.js
@@ -1,0 +1,142 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { OverlayTrigger, Tooltip } from 'react-bootstrap';
+
+export default function TopNavigationSmall({ isSelf, username, contact, areReferences, isResolved }) {
+
+  let links;
+  console.log('*********************************', isSelf, username, contact, areReferences, isResolved);
+
+  if (isSelf) {
+    links = [
+      {
+        label: 'Edit your profile',
+        link: '/profile/edit'
+      }
+    ];
+  } else {
+    links = [
+      {
+        label: 'Send a message',
+        link: `/messages/${username}`
+      }
+    ];
+
+    if (areReferences) {
+      links.push({
+        label: 'Write a reference',
+        link: `/profile/${username}/references/new`
+      });
+    }
+
+    if (isResolved) {
+      const contactLink = (!contact._id) ?
+        {
+          label: 'Add contact',
+          link: `/messages/${username}`
+        }
+        :
+        (contact.confirmed) ?
+          {
+            label: labelWithTooltip({ label: 'Remove contact', tooltip: 'Contacts since {{ ::profileCtrl.contact.created | date:\'mediumDate\''}),
+            link: `/messages/${username}`,
+            tooltip: 'Contacts since {{ ::profileCtrl.contact.created | date:\'mediumDate\''
+          }
+          :
+          {
+            label: 'Delete contact request',
+            link: `/messages/${username}`,
+            tooltip: 'Request sent {{ ::profileCtrl.contact.created | date:\'mediumDate\' }}'
+          };
+
+      links.push(contactLink);
+    }
+  }
+
+
+
+  return (
+    <nav className="navbar navbar-white navbar-fixed-top navbar-fixed-top-below visible-xs-block">
+      <div className="container">
+        <ul className="nav navbar-nav" role="navigation">
+          {links.map(({ label, link }, index) => (
+            <li key={index}><a href={link}>{label}</a></li>
+          )
+          )}
+        </ul>
+      </div>
+    </nav>
+  );
+}
+
+function labelWithTooltip({ label, tooltip }) {
+  return (
+    <OverlayTrigger
+      placement="bottom"
+      overlay={<Tooltip>{tooltip}</Tooltip>}
+    >
+        <span>{label}</span>
+    </OverlayTrigger>
+  );
+}
+
+TopNavigationSmall.propTypes = {
+  isSelf: PropTypes.bool.isRequired,
+  username: PropTypes.string.isRequired,
+  contact: PropTypes.object.isRequired,
+  areReferences: PropTypes.bool.isRequired,
+  isResolved: PropTypes.bool.isRequired
+};
+
+
+/*
+<!-- Top Navigation for small screens -->
+<!-- When looking at own profile -->
+<nav className="navbar navbar-white navbar-fixed-top navbar-fixed-top-below visible-xs-block"
+     ng-if="app.user._id === profileCtrl.profile._id">
+  <div className="container">
+    <ul className="nav navbar-nav" role="navigation">
+      <li><a ui-sref="profile-edit.about">Edit your profile</a></li>
+    </ul>
+  </div>
+</nav>
+
+<!-- Top Navigation for small screens -->
+<!-- When looking at somebody else's profile -->
+<nav className="navbar navbar-white navbar-fixed-top navbar-fixed-top-below visible-xs-block"
+     ng-if="app.user._id !== profileCtrl.profile._id">
+  <div className="container">
+    <ul className="nav navbar-nav" role="toolbar" aria-label="Profile actions">
+      <li>
+        <a ui-sref="messageThread({username: profileCtrl.profile.username})">
+          Send a message
+        </a>
+      </li>
+      <li ng-if="app.appSettings.referencesEnabled">
+        <a ui-sref="profile.references.new({username: profileCtrl.profile.username})">
+          Write a reference
+        </a>
+      </li>
+      <li>
+        <a ui-sref="contactAdd({userId: profileCtrl.profile._id})"
+           ng-if="profileCtrl.contact.$resolved && !profileCtrl.contact._id">
+          Add contact
+        </a>
+        <a ng-if="profileCtrl.contact.$resolved && profileCtrl.contact._id"
+           tr-contact-remove="profileCtrl.contact">
+          <span ng-if="profileCtrl.contact.confirmed"
+                uib-tooltip="Contacts since {{ ::profileCtrl.contact.created | date:'mediumDate' }}"
+                tooltip-placement="bottom">
+            Remove contact
+          </span>
+          <span ng-if="!profileCtrl.contact.confirmed"
+                uib-tooltip="Request sent {{ ::profileCtrl.contact.created | date:'mediumDate' }}"
+                tooltip-placement="bottom">
+            Delete contact request
+          </span>
+        </a>
+      </li>
+    </ul>
+  </div>
+</nav>
+*/

--- a/modules/users/client/components/TopNavigationSmall.component.js
+++ b/modules/users/client/components/TopNavigationSmall.component.js
@@ -1,30 +1,47 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
+import { useTranslation } from 'react-i18next';
+import RemoveContact from '../../../contacts/client/components/RemoveContactContainer';
 
-export default function TopNavigationSmall({ isSelf, username, contact, areReferences, isResolved }) {
+// @TODO isResolved can be removed when migration is finished
+export default function TopNavigationSmall({ username, contact, areReferences, isResolved, selfId, userId }) {
+
+  // @TODO this hacky fix should be removed and the data should be consistent
+  if (contact) {
+    if (typeof contact.userFrom === 'object') {
+      contact.userFrom = contact.userFrom._id;
+    }
+    if (typeof contact.userTo === 'object') {
+      contact.userTo = contact.userTo._id;
+    }
+  }
+
+  const [showRemoveModal, setShowRemoveModal] = useState(false);
+
+  const { t } = useTranslation('user');
+
+  const isSelf = selfId === userId;
 
   let links;
-  console.log('*********************************', isSelf, username, contact, areReferences, isResolved);
-
   if (isSelf) {
     links = [
       {
-        label: 'Edit your profile',
+        label: t('Edit your profile'),
         link: '/profile/edit'
       }
     ];
   } else {
     links = [
       {
-        label: 'Send a message',
+        label: t('Send a message'),
         link: `/messages/${username}`
       }
     ];
 
     if (areReferences) {
       links.push({
-        label: 'Write a reference',
+        label: t('Write a reference'),
         link: `/profile/${username}/references/new`
       });
     }
@@ -32,57 +49,95 @@ export default function TopNavigationSmall({ isSelf, username, contact, areRefer
     if (isResolved) {
       const contactLink = (!contact._id) ?
         {
-          label: 'Add contact',
-          link: `/messages/${username}`
+          label: t('Add contact'),
+          link: `/contact-add/${userId}`
         }
         :
         (contact.confirmed) ?
           {
-            label: labelWithTooltip({ label: 'Remove contact', tooltip: 'Contacts since {{ ::profileCtrl.contact.created | date:\'mediumDate\''}),
-            link: `/messages/${username}`,
-            tooltip: 'Contacts since {{ ::profileCtrl.contact.created | date:\'mediumDate\''
+            label: t('Remove contact'),
+            tooltip: t('Contacts since {{created, MMM DD, YYYY}}', { created: new Date(contact.created) }),
+            onClick: () => setShowRemoveModal(true)
           }
           :
           {
-            label: 'Delete contact request',
-            link: `/messages/${username}`,
-            tooltip: 'Request sent {{ ::profileCtrl.contact.created | date:\'mediumDate\' }}'
+            label: t('Delete contact request'),
+            tooltip: t('Request sent {{created, MMM DD, YYYY}}', { created: new Date(contact.created) }),
+            onClick: () => setShowRemoveModal(true)
           };
 
       links.push(contactLink);
     }
   }
 
+  function handleRemoveSuccess() {
+    setShowRemoveModal(false);
 
+    // @TODO!!!!!!!!!!!! broadcast the removal to angular
+    // onContactRemoved(contact);
+  }
 
   return (
-    <nav className="navbar navbar-white navbar-fixed-top navbar-fixed-top-below visible-xs-block">
-      <div className="container">
-        <ul className="nav navbar-nav" role="navigation">
-          {links.map(({ label, link }, index) => (
-            <li key={index}><a href={link}>{label}</a></li>
-          )
-          )}
-        </ul>
-      </div>
-    </nav>
+    <>
+      {contact && <RemoveContact
+        selfId={selfId}
+        contact={contact}
+        show={showRemoveModal}
+        onSuccess={handleRemoveSuccess}
+        onCancel={() => setShowRemoveModal(false)}
+      />}
+      <nav className="navbar navbar-white navbar-fixed-top navbar-fixed-top-below visible-xs-block">
+        <div className="container">
+          <ul className="nav navbar-nav" role="navigation">
+            {links.map(({ label, link, tooltip, onClick }, index) => (
+              <li key={index}>
+                <NavButton label={label} link={link} tooltip={tooltip} onClick={onClick} />
+              </li>
+            )
+            )}
+          </ul>
+        </div>
+      </nav>
+    </>
   );
 }
 
-function labelWithTooltip({ label, tooltip }) {
+function LabelWithTooltip({ label, tooltip }) {
   return (
     <OverlayTrigger
       placement="bottom"
       overlay={<Tooltip>{tooltip}</Tooltip>}
     >
-        <span>{label}</span>
+      <span>{label}</span>
     </OverlayTrigger>
   );
 }
 
+function NavButton({ label, link, tooltip, onClick }) {
+
+  const labelWithTooltip = (tooltip) ? <LabelWithTooltip label={label} tooltip={tooltip} /> : label;
+
+  return (link)
+    ? <a href={link}>{labelWithTooltip}</a>
+    : <a onClick={onClick}>{labelWithTooltip}</a>;
+}
+
+NavButton.propTypes = {
+  label: PropTypes.any.isRequired,
+  link: PropTypes.string,
+  tooltip: PropTypes.string,
+  onClick: PropTypes.func
+};
+
+LabelWithTooltip.propTypes = {
+  label: PropTypes.string.isRequired,
+  tooltip: PropTypes.string.isRequired
+};
+
 TopNavigationSmall.propTypes = {
-  isSelf: PropTypes.bool.isRequired,
   username: PropTypes.string.isRequired,
+  selfId: PropTypes.string.isRequired,
+  userId: PropTypes.string.isRequired,
   contact: PropTypes.object.isRequired,
   areReferences: PropTypes.bool.isRequired,
   isResolved: PropTypes.bool.isRequired

--- a/modules/users/client/components/TopNavigationSmall.component.js
+++ b/modules/users/client/components/TopNavigationSmall.component.js
@@ -4,9 +4,15 @@ import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { useTranslation } from 'react-i18next';
 import RemoveContact from '../../../contacts/client/components/RemoveContactContainer';
 
-// @TODO isResolved can be removed when migration is finished
-export default function TopNavigationSmall({ username, contact, areReferences, isResolved, selfId, userId }) {
-
+export default function TopNavigationSmall({
+  username,
+  contact,
+  referencesEnabled,
+  isResolved,
+  selfId,
+  userId,
+  onContactRemoved,
+}) {
   // @TODO this hacky fix should be removed and the data should be consistent
   if (contact) {
     if (typeof contact.userFrom === 'object') {
@@ -28,42 +34,44 @@ export default function TopNavigationSmall({ username, contact, areReferences, i
     links = [
       {
         label: t('Edit your profile'),
-        link: '/profile/edit'
-      }
+        link: '/profile/edit',
+      },
     ];
   } else {
     links = [
       {
         label: t('Send a message'),
-        link: `/messages/${username}`
-      }
+        link: `/messages/${username}`,
+      },
     ];
 
-    if (areReferences) {
+    if (referencesEnabled) {
       links.push({
         label: t('Write a reference'),
-        link: `/profile/${username}/references/new`
+        link: `/profile/${username}/references/new`,
       });
     }
 
     if (isResolved) {
-      const contactLink = (!contact._id) ?
-        {
-          label: t('Add contact'),
-          link: `/contact-add/${userId}`
-        }
-        :
-        (contact.confirmed) ?
-          {
-            label: t('Remove contact'),
-            tooltip: t('Contacts since {{created, MMM DD, YYYY}}', { created: new Date(contact.created) }),
-            onClick: () => setShowRemoveModal(true)
+      const contactLink = !contact._id
+        ? {
+            label: t('Add contact'),
+            link: `/contact-add/${userId}`,
           }
-          :
-          {
+        : contact.confirmed
+        ? {
+            label: t('Remove contact'),
+            tooltip: t('Contacts since {{created, MMM DD, YYYY}}', {
+              created: new Date(contact.created),
+            }),
+            onClick: () => setShowRemoveModal(true),
+          }
+        : {
             label: t('Delete contact request'),
-            tooltip: t('Request sent {{created, MMM DD, YYYY}}', { created: new Date(contact.created) }),
-            onClick: () => setShowRemoveModal(true)
+            tooltip: t('Request sent {{created, MMM DD, YYYY}}', {
+              created: new Date(contact.created),
+            }),
+            onClick: () => setShowRemoveModal(true),
           };
 
       links.push(contactLink);
@@ -73,28 +81,34 @@ export default function TopNavigationSmall({ username, contact, areReferences, i
   function handleRemoveSuccess() {
     setShowRemoveModal(false);
 
-    // @TODO!!!!!!!!!!!! broadcast the removal to angular
-    // onContactRemoved(contact);
+    // broadcast the removal to angular
+    onContactRemoved(contact);
   }
 
   return (
     <>
-      {contact && <RemoveContact
-        selfId={selfId}
-        contact={contact}
-        show={showRemoveModal}
-        onSuccess={handleRemoveSuccess}
-        onCancel={() => setShowRemoveModal(false)}
-      />}
+      {contact && (
+        <RemoveContact
+          selfId={selfId}
+          contact={contact}
+          show={showRemoveModal}
+          onSuccess={handleRemoveSuccess}
+          onCancel={() => setShowRemoveModal(false)}
+        />
+      )}
       <nav className="navbar navbar-white navbar-fixed-top navbar-fixed-top-below visible-xs-block">
         <div className="container">
           <ul className="nav navbar-nav" role="navigation">
             {links.map(({ label, link, tooltip, onClick }, index) => (
               <li key={index}>
-                <NavButton label={label} link={link} tooltip={tooltip} onClick={onClick} />
+                <NavButton
+                  label={label}
+                  link={link}
+                  tooltip={tooltip}
+                  onClick={onClick}
+                />
               </li>
-            )
-            )}
+            ))}
           </ul>
         </div>
       </nav>
@@ -104,34 +118,36 @@ export default function TopNavigationSmall({ username, contact, areReferences, i
 
 function LabelWithTooltip({ label, tooltip }) {
   return (
-    <OverlayTrigger
-      placement="bottom"
-      overlay={<Tooltip>{tooltip}</Tooltip>}
-    >
+    <OverlayTrigger placement="bottom" overlay={<Tooltip>{tooltip}</Tooltip>}>
       <span>{label}</span>
     </OverlayTrigger>
   );
 }
 
 function NavButton({ label, link, tooltip, onClick }) {
+  const labelWithTooltip = tooltip ? (
+    <LabelWithTooltip label={label} tooltip={tooltip} />
+  ) : (
+    label
+  );
 
-  const labelWithTooltip = (tooltip) ? <LabelWithTooltip label={label} tooltip={tooltip} /> : label;
-
-  return (link)
-    ? <a href={link}>{labelWithTooltip}</a>
-    : <a onClick={onClick}>{labelWithTooltip}</a>;
+  return link ? (
+    <a href={link}>{labelWithTooltip}</a>
+  ) : (
+    <a onClick={onClick}>{labelWithTooltip}</a>
+  );
 }
 
 NavButton.propTypes = {
   label: PropTypes.any.isRequired,
   link: PropTypes.string,
   tooltip: PropTypes.string,
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
 };
 
 LabelWithTooltip.propTypes = {
   label: PropTypes.string.isRequired,
-  tooltip: PropTypes.string.isRequired
+  tooltip: PropTypes.string.isRequired,
 };
 
 TopNavigationSmall.propTypes = {
@@ -139,59 +155,7 @@ TopNavigationSmall.propTypes = {
   selfId: PropTypes.string.isRequired,
   userId: PropTypes.string.isRequired,
   contact: PropTypes.object.isRequired,
-  areReferences: PropTypes.bool.isRequired,
-  isResolved: PropTypes.bool.isRequired
+  referencesEnabled: PropTypes.bool.isRequired,
+  isResolved: PropTypes.bool.isRequired,
+  onContactRemoved: PropTypes.func.isRequired,
 };
-
-
-/*
-<!-- Top Navigation for small screens -->
-<!-- When looking at own profile -->
-<nav className="navbar navbar-white navbar-fixed-top navbar-fixed-top-below visible-xs-block"
-     ng-if="app.user._id === profileCtrl.profile._id">
-  <div className="container">
-    <ul className="nav navbar-nav" role="navigation">
-      <li><a ui-sref="profile-edit.about">Edit your profile</a></li>
-    </ul>
-  </div>
-</nav>
-
-<!-- Top Navigation for small screens -->
-<!-- When looking at somebody else's profile -->
-<nav className="navbar navbar-white navbar-fixed-top navbar-fixed-top-below visible-xs-block"
-     ng-if="app.user._id !== profileCtrl.profile._id">
-  <div className="container">
-    <ul className="nav navbar-nav" role="toolbar" aria-label="Profile actions">
-      <li>
-        <a ui-sref="messageThread({username: profileCtrl.profile.username})">
-          Send a message
-        </a>
-      </li>
-      <li ng-if="app.appSettings.referencesEnabled">
-        <a ui-sref="profile.references.new({username: profileCtrl.profile.username})">
-          Write a reference
-        </a>
-      </li>
-      <li>
-        <a ui-sref="contactAdd({userId: profileCtrl.profile._id})"
-           ng-if="profileCtrl.contact.$resolved && !profileCtrl.contact._id">
-          Add contact
-        </a>
-        <a ng-if="profileCtrl.contact.$resolved && profileCtrl.contact._id"
-           tr-contact-remove="profileCtrl.contact">
-          <span ng-if="profileCtrl.contact.confirmed"
-                uib-tooltip="Contacts since {{ ::profileCtrl.contact.created | date:'mediumDate' }}"
-                tooltip-placement="bottom">
-            Remove contact
-          </span>
-          <span ng-if="!profileCtrl.contact.confirmed"
-                uib-tooltip="Request sent {{ ::profileCtrl.contact.created | date:'mediumDate' }}"
-                tooltip-placement="bottom">
-            Delete contact request
-          </span>
-        </a>
-      </li>
-    </ul>
-  </div>
-</nav>
-*/

--- a/modules/users/client/components/TopNavigationSmall.component.js
+++ b/modules/users/client/components/TopNavigationSmall.component.js
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { useTranslation } from 'react-i18next';
-import RemoveContact from '../../../contacts/client/components/RemoveContactContainer';
+import RemoveContact from '@/modules/contacts/client/components/RemoveContactContainer';
 
 export default function TopNavigationSmall({
   username,
@@ -66,17 +65,11 @@ export default function TopNavigationSmall({
         ? {
             id: 'remove-contact',
             label: t('Remove contact'),
-            tooltip: t('Contacts since {{created, MMM DD, YYYY}}', {
-              created: new Date(contact.created),
-            }),
             onClick: () => setShowRemoveModal(true),
           }
         : {
             id: 'delete-contact-request',
             label: t('Delete contact request'),
-            tooltip: t('Request sent {{created, MMM DD, YYYY}}', {
-              created: new Date(contact.created),
-            }),
             onClick: () => setShowRemoveModal(true),
           };
 
@@ -105,15 +98,11 @@ export default function TopNavigationSmall({
       <nav className="navbar navbar-white navbar-fixed-top navbar-fixed-top-below visible-xs-block">
         <div className="container">
           <ul className="nav navbar-nav" role="navigation">
-            {links.map(({ id, label, link, tooltip, onClick }) => (
+            {links.map(({ id, label, link, onClick }) => (
               <li key={id}>
-                <NavButton
-                  id={id}
-                  label={label}
-                  link={link}
-                  tooltip={tooltip}
-                  onClick={onClick}
-                />
+                <a href={link} onClick={onClick}>
+                  {label}
+                </a>
               </li>
             ))}
           </ul>
@@ -131,43 +120,4 @@ TopNavigationSmall.propTypes = {
   referencesEnabled: PropTypes.bool.isRequired,
   isResolved: PropTypes.bool.isRequired,
   onContactRemoved: PropTypes.func.isRequired,
-};
-
-function LabelWithTooltip({ id, label, tooltip }) {
-  return (
-    <OverlayTrigger
-      placement="bottom"
-      overlay={<Tooltip id={`tooltip-${id}`}>{tooltip}</Tooltip>}
-    >
-      <span>{label}</span>
-    </OverlayTrigger>
-  );
-}
-
-LabelWithTooltip.propTypes = {
-  id: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
-  tooltip: PropTypes.string.isRequired,
-};
-
-function NavButton({ id, label, link, tooltip, onClick }) {
-  const labelWithTooltip = tooltip ? (
-    <LabelWithTooltip id={id} label={label} tooltip={tooltip} />
-  ) : (
-    label
-  );
-
-  return link ? (
-    <a href={link}>{labelWithTooltip}</a>
-  ) : (
-    <a onClick={onClick}>{labelWithTooltip}</a>
-  );
-}
-
-NavButton.propTypes = {
-  id: PropTypes.string.isRequired,
-  label: PropTypes.any.isRequired,
-  link: PropTypes.string,
-  tooltip: PropTypes.string,
-  onClick: PropTypes.func,
 };

--- a/modules/users/client/components/TopNavigationSmall.component.js
+++ b/modules/users/client/components/TopNavigationSmall.component.js
@@ -33,6 +33,7 @@ export default function TopNavigationSmall({
   if (isSelf) {
     links = [
       {
+        id: 'edit-profile',
         label: t('Edit your profile'),
         link: '/profile/edit',
       },
@@ -40,6 +41,7 @@ export default function TopNavigationSmall({
   } else {
     links = [
       {
+        id: 'send-message',
         label: t('Send a message'),
         link: `/messages/${username}`,
       },
@@ -47,6 +49,7 @@ export default function TopNavigationSmall({
 
     if (referencesEnabled) {
       links.push({
+        id: 'write-reference',
         label: t('Write a reference'),
         link: `/profile/${username}/references/new`,
       });
@@ -55,11 +58,13 @@ export default function TopNavigationSmall({
     if (isResolved) {
       const contactLink = !contact._id
         ? {
+            id: 'add-contact',
             label: t('Add contact'),
             link: `/contact-add/${userId}`,
           }
         : contact.confirmed
         ? {
+            id: 'remove-contact',
             label: t('Remove contact'),
             tooltip: t('Contacts since {{created, MMM DD, YYYY}}', {
               created: new Date(contact.created),
@@ -67,6 +72,7 @@ export default function TopNavigationSmall({
             onClick: () => setShowRemoveModal(true),
           }
         : {
+            id: 'delete-contact-request',
             label: t('Delete contact request'),
             tooltip: t('Request sent {{created, MMM DD, YYYY}}', {
               created: new Date(contact.created),
@@ -99,9 +105,10 @@ export default function TopNavigationSmall({
       <nav className="navbar navbar-white navbar-fixed-top navbar-fixed-top-below visible-xs-block">
         <div className="container">
           <ul className="nav navbar-nav" role="navigation">
-            {links.map(({ label, link, tooltip, onClick }, index) => (
-              <li key={index}>
+            {links.map(({ id, label, link, tooltip, onClick }) => (
+              <li key={id}>
                 <NavButton
+                  id={id}
                   label={label}
                   link={link}
                   tooltip={tooltip}
@@ -116,17 +123,20 @@ export default function TopNavigationSmall({
   );
 }
 
-function LabelWithTooltip({ label, tooltip }) {
+function LabelWithTooltip({ id, label, tooltip }) {
   return (
-    <OverlayTrigger placement="bottom" overlay={<Tooltip>{tooltip}</Tooltip>}>
+    <OverlayTrigger
+      placement="bottom"
+      overlay={<Tooltip id={`tooltip-${id}`}>{tooltip}</Tooltip>}
+    >
       <span>{label}</span>
     </OverlayTrigger>
   );
 }
 
-function NavButton({ label, link, tooltip, onClick }) {
+function NavButton({ id, label, link, tooltip, onClick }) {
   const labelWithTooltip = tooltip ? (
-    <LabelWithTooltip label={label} tooltip={tooltip} />
+    <LabelWithTooltip id={id} label={label} tooltip={tooltip} />
   ) : (
     label
   );
@@ -139,6 +149,7 @@ function NavButton({ label, link, tooltip, onClick }) {
 }
 
 NavButton.propTypes = {
+  id: PropTypes.string.isRequired,
   label: PropTypes.any.isRequired,
   link: PropTypes.string,
   tooltip: PropTypes.string,
@@ -146,6 +157,7 @@ NavButton.propTypes = {
 };
 
 LabelWithTooltip.propTypes = {
+  id: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   tooltip: PropTypes.string.isRequired,
 };

--- a/modules/users/client/components/TopNavigationSmall.component.js
+++ b/modules/users/client/components/TopNavigationSmall.component.js
@@ -123,6 +123,16 @@ export default function TopNavigationSmall({
   );
 }
 
+TopNavigationSmall.propTypes = {
+  username: PropTypes.string.isRequired,
+  selfId: PropTypes.string.isRequired,
+  userId: PropTypes.string.isRequired,
+  contact: PropTypes.object,
+  referencesEnabled: PropTypes.bool.isRequired,
+  isResolved: PropTypes.bool.isRequired,
+  onContactRemoved: PropTypes.func.isRequired,
+};
+
 function LabelWithTooltip({ id, label, tooltip }) {
   return (
     <OverlayTrigger
@@ -133,6 +143,12 @@ function LabelWithTooltip({ id, label, tooltip }) {
     </OverlayTrigger>
   );
 }
+
+LabelWithTooltip.propTypes = {
+  id: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  tooltip: PropTypes.string.isRequired,
+};
 
 function NavButton({ id, label, link, tooltip, onClick }) {
   const labelWithTooltip = tooltip ? (
@@ -154,20 +170,4 @@ NavButton.propTypes = {
   link: PropTypes.string,
   tooltip: PropTypes.string,
   onClick: PropTypes.func,
-};
-
-LabelWithTooltip.propTypes = {
-  id: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
-  tooltip: PropTypes.string.isRequired,
-};
-
-TopNavigationSmall.propTypes = {
-  username: PropTypes.string.isRequired,
-  selfId: PropTypes.string.isRequired,
-  userId: PropTypes.string.isRequired,
-  contact: PropTypes.object,
-  referencesEnabled: PropTypes.bool.isRequired,
-  isResolved: PropTypes.bool.isRequired,
-  onContactRemoved: PropTypes.func.isRequired,
 };

--- a/modules/users/client/components/TopNavigationSmall.component.js
+++ b/modules/users/client/components/TopNavigationSmall.component.js
@@ -166,7 +166,7 @@ TopNavigationSmall.propTypes = {
   username: PropTypes.string.isRequired,
   selfId: PropTypes.string.isRequired,
   userId: PropTypes.string.isRequired,
-  contact: PropTypes.object.isRequired,
+  contact: PropTypes.object,
   referencesEnabled: PropTypes.bool.isRequired,
   isResolved: PropTypes.bool.isRequired,
   onContactRemoved: PropTypes.func.isRequired,

--- a/modules/users/client/controllers/profile.client.controller.js
+++ b/modules/users/client/controllers/profile.client.controller.js
@@ -23,11 +23,22 @@ function ProfileController(
   vm.contact = contact;
   vm.contacts = contacts;
 
-  // Exposed to the view
-  vm.hasConnectedAdditionalSocialAccounts = hasConnectedAdditionalSocialAccounts;
-  vm.isConnectedSocialAccount = isConnectedSocialAccount;
-  vm.socialAccountLink = socialAccountLink;
-  vm.isWarmshowersId = isWarmshowersId;
+  /**
+   * Remove contact via React RemoveContact component
+   */
+  vm.removeContact = function(contact) {
+    vm.contacts.splice(vm.contacts.indexOf(contact), 1);
+
+    // @TODO a hacky solution to remove the contact from vm.contact and keep its "promise" resolved
+    // if we just delete vm.contact, the angular app will be confused
+    if (vm.contact && vm.contact._id === contact._id) {
+      Object.keys(contact).forEach(function(key) {
+        if (!(key === '$promise' || key === '$resolved')) {
+          delete contact[key];
+        }
+      });
+    }
+  };
 
   /**
    * Remove contact via React RemoveContact component
@@ -78,53 +89,5 @@ function ProfileController(
         delete vm.contact._id;
       }
     });
-  }
-
-  /**
-   * Determine if given user handle for Warmshowers is an id or username
-   * @link https://github.com/Trustroots/trustroots/issues/308
-   */
-  function isWarmshowersId() {
-    let x;
-    return isNaN(vm.profile.extSitesWS)
-      ? !1
-      : ((x = parseFloat(vm.profile.extSitesWS)), (0 | x) === x);
-  }
-
-  /**
-   * Check if there are additional accounts
-   */
-  function hasConnectedAdditionalSocialAccounts() {
-    return (
-      vm.profile.additionalProvidersData &&
-      Object.keys(vm.profile.additionalProvidersData).length
-    );
-  }
-
-  /**
-   * Check if provider is already in use with profile
-   */
-  function isConnectedSocialAccount(provider) {
-    return (
-      vm.profile.provider === provider ||
-      (vm.profile.additionalProvidersData &&
-        vm.profile.additionalProvidersData[provider])
-    );
-  }
-
-  /**
-   * Return an URL for user's social media profiles
-   * Ensure these values are published at users.profile.server.controller.js
-   */
-  function socialAccountLink(providerName, providerData) {
-    if (providerName === 'facebook' && providerData.id) {
-      return 'https://www.facebook.com/app_scoped_user_id/' + providerData.id;
-    } else if (providerName === 'twitter' && providerData.screen_name) {
-      return 'https://twitter.com/' + providerData.screen_name;
-    } else if (providerName === 'github' && providerData.login) {
-      return 'https://github.com/' + providerData.login;
-    } else {
-      return '#';
-    }
   }
 }

--- a/modules/users/client/controllers/profile.client.controller.js
+++ b/modules/users/client/controllers/profile.client.controller.js
@@ -40,13 +40,6 @@ function ProfileController(
     }
   };
 
-  /**
-   * Remove contact via React RemoveContact component
-   */
-  vm.removeContact = function(contact) {
-    vm.contacts.splice(vm.contacts.indexOf(contact), 1);
-  };
-
   activate();
 
   /**

--- a/modules/users/client/views/profile/profile-view.client.view.html
+++ b/modules/users/client/views/profile/profile-view.client.view.html
@@ -62,6 +62,14 @@
   </div>
 </nav>
 
+<top-navigation-small
+  isSelf="app.user._id === profileCtrl.profile._id"
+  username="profileCtrl.profile.username"
+  contact="profileCtrl.contact"
+  areReferences="app.appSettings.referencesEnabled"
+  isResolved="profileCtrl.contact.$resolved"
+></top-navigation-small>
+
 <!-- Bottom Navigation for small screens -->
 <!-- react component -->
 <bottom-navigation-small

--- a/modules/users/client/views/profile/profile-view.client.view.html
+++ b/modules/users/client/views/profile/profile-view.client.view.html
@@ -1,74 +1,12 @@
 <!-- Top Navigation for small screens -->
-<!-- When looking at own profile -->
-<nav
-  class="navbar navbar-white navbar-fixed-top navbar-fixed-top-below visible-xs-block"
-  ng-if="app.user._id === profileCtrl.profile._id"
->
-  <div class="container">
-    <ul class="nav navbar-nav" role="navigation">
-      <li><a ui-sref="profile-edit.about">Edit your profile</a></li>
-    </ul>
-  </div>
-</nav>
-
-<!-- Top Navigation for small screens -->
-<!-- When looking at somebody else's profile -->
-<nav
-  class="navbar navbar-white navbar-fixed-top navbar-fixed-top-below visible-xs-block"
-  ng-if="app.user._id !== profileCtrl.profile._id"
->
-  <div class="container">
-    <ul class="nav navbar-nav" role="toolbar" aria-label="Profile actions">
-      <li>
-        <a ui-sref="messageThread({username: profileCtrl.profile.username})">
-          Send a message
-        </a>
-      </li>
-      <li ng-if="app.appSettings.referencesEnabled">
-        <a
-          ui-sref="profile.references.new({username: profileCtrl.profile.username})"
-        >
-          Write a reference
-        </a>
-      </li>
-      <li>
-        <a
-          ui-sref="contactAdd({userId: profileCtrl.profile._id})"
-          ng-if="profileCtrl.contact.$resolved && !profileCtrl.contact._id"
-        >
-          Add contact
-        </a>
-        <a
-          ng-if="profileCtrl.contact.$resolved && profileCtrl.contact._id"
-          tr-contact-remove="profileCtrl.contact"
-        >
-          <span
-            ng-if="profileCtrl.contact.confirmed"
-            uib-tooltip="Contacts since {{ ::profileCtrl.contact.created | date:'mediumDate' }}"
-            tooltip-placement="bottom"
-          >
-            Remove contact
-          </span>
-          <span
-            ng-if="!profileCtrl.contact.confirmed"
-            uib-tooltip="Request sent {{ ::profileCtrl.contact.created | date:'mediumDate' }}"
-            tooltip-placement="bottom"
-          >
-            Delete contact request
-          </span>
-        </a>
-      </li>
-    </ul>
-  </div>
-</nav>
-
 <top-navigation-small
   username="profileCtrl.profile.username"
   selfId="app.user._id"
   userId="profileCtrl.profile._id"
   contact="profileCtrl.contact"
-  areReferences="app.appSettings.referencesEnabled"
+  referencesEnabled="app.appSettings.referencesEnabled"
   isResolved="profileCtrl.contact.$resolved"
+  onContactRemoved="profileCtrl.removeContact"
 ></top-navigation-small>
 
 <!-- Bottom Navigation for small screens -->

--- a/modules/users/client/views/profile/profile-view.client.view.html
+++ b/modules/users/client/views/profile/profile-view.client.view.html
@@ -63,8 +63,9 @@
 </nav>
 
 <top-navigation-small
-  isSelf="app.user._id === profileCtrl.profile._id"
   username="profileCtrl.profile.username"
+  selfId="app.user._id"
+  userId="profileCtrl.profile._id"
   contact="profileCtrl.contact"
   areReferences="app.appSettings.referencesEnabled"
   isResolved="profileCtrl.contact.$resolved"

--- a/modules/users/client/views/profile/profile-view.client.view.html
+++ b/modules/users/client/views/profile/profile-view.client.view.html
@@ -1,11 +1,24 @@
 <!-- Top Navigation for small screens -->
 <top-navigation-small
+  ng-if="profileCtrl.contact.$resolved"
   username="profileCtrl.profile.username"
   selfId="app.user._id"
   userId="profileCtrl.profile._id"
   contact="profileCtrl.contact"
   referencesEnabled="app.appSettings.referencesEnabled"
-  isResolved="profileCtrl.contact.$resolved"
+  isResolved="true"
+  onContactRemoved="profileCtrl.removeContact"
+></top-navigation-small>
+<!-- a hack for isResolved to contain a correct value -->
+<!-- @TODO this should be removed as migration to React continues -->
+<top-navigation-small
+  ng-if="!profileCtrl.contact.$resolved"
+  username="profileCtrl.profile.username"
+  selfId="app.user._id"
+  userId="profileCtrl.profile._id"
+  contact="profileCtrl.contact"
+  referencesEnabled="app.appSettings.referencesEnabled"
+  isResolved="false"
   onContactRemoved="profileCtrl.removeContact"
 ></top-navigation-small>
 


### PR DESCRIPTION
#### Proposed Changes

* Migrate top profile navigation for small screens to React.

![top-navigation-small](https://user-images.githubusercontent.com/7449720/68628647-7b3d7780-04e1-11ea-9f3b-aa572de01700.png)

#### Testing Instructions

* Go to somebody's profile
* Make the browser smaller
* Check that the top profile navigation hasn't changed in looks and behaviour.
  - especially check that the correct links are displayed and that they behave as they did before
    - own profile: Edit your profile
    - not a contact: Send a message | Add contact
    - some of my contacts: Send a message | Remove contact
    - a contact request I sent: Send a message | Delete contact request
    - a contact request I received: Send a message | Delete contact request
    - additionally, when not own profile && references are enabled: Write a reference


Work on #1019