### PR TITLE
remove displayUsername

### DIFF
--- a/modules/contacts/server/controllers/contacts.server.controller.js
+++ b/modules/contacts/server/controllers/contacts.server.controller.js
@@ -456,7 +456,6 @@ exports.contactListByUser = function (req, res, next, listUserId) {
           updated: '$user.updated',
           displayName: '$user.displayName',
           username: '$user.username',
-          displayUsername: '$user.displayUsername',
           avatarSource: '$user.avatarSource',
           avatarUploaded: '$user.avatarUploaded',
           locationFrom: '$user.locationFrom',

--- a/modules/core/tests/server/core.server.config.tests.js
+++ b/modules/core/tests/server/core.server.config.tests.js
@@ -46,7 +46,6 @@ describe('Configuration Tests:', function () {
         displayName: 'Full Name A',
         email: 'user_a@example.com',
         username: credentials.username,
-        displayUsername: credentials.username,
         password: credentials.password,
         provider: 'local'
       };

--- a/modules/messages/client/views/thread.client.view.html
+++ b/modules/messages/client/views/thread.client.view.html
@@ -29,7 +29,7 @@
                   {{ thread.userTo.displayName }}
                 </h4>
                 <small class="text-muted">
-                  @{{ thread.userTo.displayUsername || thread.userTo.username }}
+                  @{{ thread.userTo.username }}
                 </small>
               </a>
             </div>

--- a/modules/messages/tests/server/jobs/message-unread.server.job.tests.js
+++ b/modules/messages/tests/server/jobs/message-unread.server.job.tests.js
@@ -44,7 +44,6 @@ describe('Job: message unread', function () {
       displayName: 'FullFrom NameFrom',
       email: 'userfrom@test.com',
       username: 'userfrom',
-      displayUsername: 'userfrom',
       password: 'M3@n.jsI$Aw3$0m4',
       provider: 'local'
     };
@@ -68,7 +67,6 @@ describe('Job: message unread', function () {
       displayName: 'FullTo NameTo',
       email: 'userto@test.com',
       username: 'userto',
-      displayUsername: 'userto',
       password: 'M3@n.jsI$Aw3$0m4',
       provider: 'local'
     };
@@ -168,7 +166,6 @@ describe('Job: message unread', function () {
       displayName: 'Full3 Name3',
       email: 'user3@test.com',
       username: 'user3',
-      displayUsername: 'user3',
       password: 'M3@n.jsI$Aw3$0m4',
       provider: 'local'
     };

--- a/modules/offers/tests/server/jobs/reactivate-hosts.server.job.tests.js
+++ b/modules/offers/tests/server/jobs/reactivate-hosts.server.job.tests.js
@@ -40,7 +40,6 @@ describe('Job: reactivate members with hosting offer status set to "no"', functi
       displayName: 'Full Name',
       email: 'test@test.com',
       username: 'jobtester',
-      displayUsername: 'jobtester',
       password: 'M3@n.jsI$Aw3$0m3',
       provider: 'local'
     };

--- a/modules/search/client/views/search-sidebar-results.client.view.html
+++ b/modules/search/client/views/search-sidebar-results.client.view.html
@@ -52,7 +52,7 @@
       <h4>
         {{ ::search.offer.user.displayName }}
         <small class="text-muted">
-          @{{ ::search.offer.user.displayUsername || search.offer.user.username }}
+          @{{ ::search.offer.user.username }}
         </small>
       </h4>
       <div class="search-result-meta">

--- a/modules/tribes/tests/server/tribes.server.routes.test.js
+++ b/modules/tribes/tests/server/tribes.server.routes.test.js
@@ -48,7 +48,6 @@ describe('Tribe CRUD tests', function () {
       displayName: 'Full Name',
       email: 'test@test.com',
       username: credentials.username,
-      displayUsername: credentials.username,
       password: credentials.password,
       provider: 'local',
       public: true

--- a/modules/users/client/views/profile/profile-view-basics.client.view.html
+++ b/modules/users/client/views/profile/profile-view-basics.client.view.html
@@ -13,7 +13,7 @@
       ng-bind="profileCtrl.profile.displayName"></h2>
   <br>
   <h4 class="profile-username">
-    @{{ profileCtrl.profile.displayUsername || profileCtrl.profile.username }}
+    @{{ profileCtrl.profile.username }}
   </h4>
   <br>
   <p class="profile-tagline"

--- a/modules/users/client/views/profile/profile-view.client.view.html
+++ b/modules/users/client/views/profile/profile-view.client.view.html
@@ -147,7 +147,7 @@
 
             <h4 class="text-muted profile-username"
                 ng-if="profileCtrl.profile.username">
-              @{{ profileCtrl.profile.displayUsername || profileCtrl.profile.username }}
+              @{{ profileCtrl.profile.username }}
             </h4>
 
             <a ui-sref="profile-edit.about"

--- a/modules/users/server/controllers/users.authentication.server.controller.js
+++ b/modules/users/server/controllers/users.authentication.server.controller.js
@@ -61,7 +61,6 @@ exports.signup = function (req, res) {
       user.public = false;
       user.provider = 'local';
       user.displayName = user.firstName.trim() + ' ' + user.lastName.trim();
-      user.displayUsername = req.body.username;
 
       // Just to simplify email confirm process later
       // This field is normally needed when changing email after the signup process

--- a/modules/users/server/controllers/users.profile.server.controller.js
+++ b/modules/users/server/controllers/users.profile.server.controller.js
@@ -48,7 +48,6 @@ exports.userProfileFields = [
   'id',
   'displayName',
   'username',
-  'displayUsername',
   'gender',
   'tagline',
   'description',
@@ -80,7 +79,6 @@ exports.userMiniProfileFields = [
   'updated', // Used as local-avatar cache buster
   'displayName',
   'username',
-  'displayUsername',
   'avatarSource',
   'avatarUploaded',
   'emailHash',
@@ -393,7 +391,6 @@ exports.update = function (req, res) {
       delete req.body.emailToken;
       delete req.body.emailTemporary;
       delete req.body.provider;
-      delete req.body.displayUsername;
       delete req.body.usernameUpdated;
       delete req.body.salt;
       delete req.body.password;

--- a/modules/users/server/models/user.server.model.js
+++ b/modules/users/server/models/user.server.model.js
@@ -178,12 +178,6 @@ var UserSchema = new Schema({
   usernameUpdated: {
     type: Date
   },
-  // Stores unaltered original username
-  displayUsername: {
-    type: String,
-    trim: true,
-    set: setPlainTextField
-  },
   // Bewelcome.org username
   extSitesBW: {
     type: String,

--- a/modules/users/tests/server/jobs/user-finish-signup.server.job.tests.js
+++ b/modules/users/tests/server/jobs/user-finish-signup.server.job.tests.js
@@ -42,7 +42,6 @@ describe('Job: user finish signup', function () {
       emailTemporary: 'test@test.com', // unconfirmed users have this set
       emailToken: 'initial email token',
       username: 'user_unconfirmed',
-      displayUsername: 'user_unconfirmed',
       password: 'M3@n.jsI$Aw3$0m3',
       provider: 'local',
       created: moment().subtract(moment.duration({ 'hours': 4 }))
@@ -64,7 +63,6 @@ describe('Job: user finish signup', function () {
       displayName: 'Full Name',
       email: 'confirmed-test@test.com',
       username: 'user_confirmed',
-      displayUsername: 'user_confirmed',
       password: 'M3@n.jsI$Aw3$0m4',
       provider: 'local',
       created: moment().subtract(moment.duration({ 'hours': 4 }))
@@ -259,7 +257,6 @@ describe('Job: user finish signup', function () {
     for (var i = 1; i <= config.limits.maxProcessSignupReminders + 1; i++) {
       var loopVars = {
         username: 'l' + i + _unConfirmedUser.username,
-        displayUsername: 'l' + i + _unConfirmedUser.displayUsername,
         emailToken: 'l' + i + _unConfirmedUser.emailToken,
         emailTemporary: 'l' + i + _unConfirmedUser.emailTemporary,
         email: 'l' + i + _unConfirmedUser.email

--- a/modules/users/tests/server/jobs/user-welcome-sequence-first.server.job.tests.js
+++ b/modules/users/tests/server/jobs/user-welcome-sequence-first.server.job.tests.js
@@ -57,7 +57,6 @@ describe('Job: welcome sequence, first email', function () {
       emailTemporary: 'test@test.com', // unconfirmed users have this set
       emailToken: 'initial email token',
       username: 'user_unconfirmed',
-      displayUsername: 'user_unconfirmed',
       password: 'M3@n.jsI$Aw3$0m3',
       provider: 'local',
       welcomeSequenceStep: 0,
@@ -80,7 +79,6 @@ describe('Job: welcome sequence, first email', function () {
       displayName: 'Full Name',
       email: 'confirmed-test@test.com',
       username: 'user_confirmed',
-      displayUsername: 'user_confirmed',
       password: 'M3@n.jsI$Aw3$0m4',
       provider: 'local',
       welcomeSequenceStep: 0,

--- a/modules/users/tests/server/jobs/user-welcome-sequence-second.server.job.tests.js
+++ b/modules/users/tests/server/jobs/user-welcome-sequence-second.server.job.tests.js
@@ -59,7 +59,6 @@ describe('Job: welcome sequence, second email', function () {
       emailTemporary: 'test@test.com', // unconfirmed users have this set
       emailToken: 'initial email token',
       username: 'user_unconfirmed',
-      displayUsername: 'user_unconfirmed',
       password: 'M3@n.jsI$Aw3$0m3',
       provider: 'local',
       welcomeSequenceStep: 0,
@@ -82,7 +81,6 @@ describe('Job: welcome sequence, second email', function () {
       displayName: 'Full Name',
       email: 'confirmed-test@test.com',
       username: 'user_confirmed',
-      displayUsername: 'user_confirmed',
       password: 'M3@n.jsI$Aw3$0m4',
       provider: 'local',
       welcomeSequenceStep: 1,

--- a/modules/users/tests/server/jobs/user-welcome-sequence-third.server.job.tests.js
+++ b/modules/users/tests/server/jobs/user-welcome-sequence-third.server.job.tests.js
@@ -59,7 +59,6 @@ describe('Job: welcome sequence, third email', function () {
       emailTemporary: 'test@test.com', // unconfirmed users have this set
       emailToken: 'initial email token',
       username: 'user_unconfirmed',
-      displayUsername: 'user_unconfirmed',
       password: 'M3@n.jsI$Aw3$0m3',
       provider: 'local',
       welcomeSequenceStep: 0,
@@ -82,7 +81,6 @@ describe('Job: welcome sequence, third email', function () {
       displayName: 'Full Name',
       email: 'confirmed-test@test.com',
       username: 'user_confirmed',
-      displayUsername: 'user_confirmed',
       password: 'M3@n.jsI$Aw3$0m4',
       provider: 'local',
       welcomeSequenceStep: 2,

--- a/modules/users/tests/server/search-users.server.routes.tests.js
+++ b/modules/users/tests/server/search-users.server.routes.tests.js
@@ -57,7 +57,6 @@ describe('Search users: GET /users?search=string', function () {
         get displayName() { return this.firstName + ' ' + this.lastName; },
         get emailTemporary() { return this.email; },
         emailToken: 'initial email token',
-        get displayUsername() { return this.username; },
         password: user.password || '******password',
         provider: 'local',
         public: _.has(user, 'public') ? user.public : true,

--- a/modules/users/tests/server/user-invite.server.routes.tests.js
+++ b/modules/users/tests/server/user-invite.server.routes.tests.js
@@ -46,7 +46,6 @@ describe('User invites CRUD tests', function () {
       displayName: 'Full Name',
       email: 'test@example.org',
       username: credentials.username.toLowerCase(),
-      displayUsername: credentials.username,
       password: credentials.password,
       provider: 'local',
       public: true

--- a/modules/users/tests/server/user-lastseen.server.tests.js
+++ b/modules/users/tests/server/user-lastseen.server.tests.js
@@ -47,7 +47,6 @@ describe('User last seen CRUD tests', function () {
       displayName: 'Full Name',
       email: 'confirmed-test@test.com',
       username: 'usertest',
-      displayUsername: 'usertest',
       password: 'aPassWoRd_*....',
       provider: 'local'
     };

--- a/modules/users/tests/server/user-password.server.routes.tests.js
+++ b/modules/users/tests/server/user-password.server.routes.tests.js
@@ -47,7 +47,6 @@ describe('User password CRUD tests', function () {
       email: 'test@example.org',
       emailToken: 'initial email token',
       username: credentials.username.toLowerCase(),
-      displayUsername: credentials.username,
       password: credentials.password,
       provider: 'local'
     };

--- a/modules/users/tests/server/user-profile.server.routes.tests.js
+++ b/modules/users/tests/server/user-profile.server.routes.tests.js
@@ -50,7 +50,6 @@ describe('User profile CRUD tests', function () {
       displayName: 'Full Name',
       email: 'test@example.org',
       username: credentials.username.toLowerCase(),
-      displayUsername: credentials.username,
       password: credentials.password,
       provider: 'local'
     };
@@ -77,7 +76,6 @@ describe('User profile CRUD tests', function () {
       emailTemporary: 'unconfirmed-test@example.org', // unconfirmed users have this set
       emailToken: 'initial email token',
       username: unConfirmedCredentials.username.toLowerCase(),
-      displayUsername: unConfirmedCredentials.username,
       password: unConfirmedCredentials.password,
       provider: 'local'
     };
@@ -108,7 +106,6 @@ describe('User profile CRUD tests', function () {
 
             res.body.should.be.instanceof(Object);
             res.body.username.should.equal(unConfirmedUser.username);
-            res.body.displayUsername.should.equal(unConfirmedUser.displayUsername);
             res.body.public.should.equal(false); // Unpublic right after signup
             res.body.avatarSource.should.equal('gravatar'); // Defaults to `gravatar`
             should.exist(res.body.languages);

--- a/modules/users/tests/server/user-removal.server.routes.tests.js
+++ b/modules/users/tests/server/user-removal.server.routes.tests.js
@@ -69,7 +69,6 @@ describe('User removal CRUD tests', function () {
       displayName: 'Full Name A',
       email: 'user_a@example.com',
       username: credentialsA.username.toLowerCase(),
-      displayUsername: credentialsA.username,
       password: credentialsA.password,
       provider: 'local'
     };
@@ -97,7 +96,6 @@ describe('User removal CRUD tests', function () {
       displayName: 'Full Name B',
       email: 'user_b@example.com',
       username: credentialsB.username.toLowerCase(),
-      displayUsername: credentialsB.username,
       password: credentialsB.password,
       provider: 'local'
     };
@@ -752,7 +750,6 @@ describe('User removal CRUD tests', function () {
             displayName: 'Full Name C',
             email: 'user_c@example.com',
             username: 'userc',
-            displayUsername: 'userc',
             password: '**********asdfasdf',
             provider: 'local'
           });

--- a/modules/users/tests/server/user-signup-validate.server.routes.tests.js
+++ b/modules/users/tests/server/user-signup-validate.server.routes.tests.js
@@ -85,7 +85,6 @@ describe('User signup validation CRUD tests', function () {
         email: 'test@example.org',
         emailToken: 'initial email token',
         username: 'taken_username',
-        displayUsername: 'taken_username',
         password: 'TR-I$Aw3$0m4',
         provider: 'local'
       });

--- a/modules/users/tests/server/user-signup.server.routes.tests.js
+++ b/modules/users/tests/server/user-signup.server.routes.tests.js
@@ -53,7 +53,6 @@ describe('User signup and authentication CRUD tests', function () {
       email: 'test@example.org',
       emailToken: 'initial email token',
       username: confirmedCredentials.username.toLowerCase(),
-      displayUsername: confirmedCredentials.username,
       password: confirmedCredentials.password,
       provider: 'local'
     };
@@ -80,7 +79,6 @@ describe('User signup and authentication CRUD tests', function () {
       emailTemporary: 'unconfirmed-test@example.org', // unconfirmed users have this set
       emailToken: 'initial email token',
       username: unConfirmedCredentials.username.toLowerCase(),
-      displayUsername: unConfirmedCredentials.username,
       password: unConfirmedCredentials.password,
       provider: 'local',
       acquisitionStory: 'A fish told me...'
@@ -107,7 +105,6 @@ describe('User signup and authentication CRUD tests', function () {
         }
         signupRes.body.username.should.equal(_unConfirmedUser.username.toLowerCase());
         signupRes.body.username.should.not.equal(_unConfirmedUser.username);
-        signupRes.body.displayUsername.should.equal(_unConfirmedUser.username);
         signupRes.body.email.should.equal(_unConfirmedUser.email);
         signupRes.body.emailTemporary.should.equal(_unConfirmedUser.email);
         signupRes.body.provider.should.equal('local');

--- a/modules/users/tests/server/user-tribe.server.routes.tests.js
+++ b/modules/users/tests/server/user-tribe.server.routes.tests.js
@@ -46,7 +46,6 @@ describe('User tribe memberships CRUD tests', function () {
       email: 'test@example.org',
       emailToken: 'initial email token',
       username: credentials.username.toLowerCase(),
-      displayUsername: credentials.username,
       password: credentials.password,
       provider: 'local'
     };

--- a/scripts/mass-email/loadData.js
+++ b/scripts/mass-email/loadData.js
@@ -40,7 +40,6 @@ async.eachSeries(
     const user = _.extend(
       _.pick(doc, [
         "displayName",
-        "displayUsername",
         "email",
         "firstName",
         "lastName",

--- a/testutils/data.server.testutils.js
+++ b/testutils/data.server.testutils.js
@@ -40,7 +40,6 @@ function generateUsers(count, { username='username', firstName='GivenName', last
     lastName: lastName + i,
     email: i + email,
     username: username + i,
-    displayUsername: username + i,
     locale,
     password: password || crypto.randomBytes(24).toString('base64')
   }));


### PR DESCRIPTION
#### Proposed Changes

* remove displayUsername

it does not do any db migrations, perhaps a reversed version of [add-user-displayUsername.js](https://github.com/Trustroots/trustroots/blob/d887dc3aa3c74014407a692c44c3db1a6d28edd9/migrations/archived/1429124257492-add-user-displayUsername.js) would be necessary?

#### Testing Instructions

Completely untested, asking for review.

Fixes #860 
