### PR TITLE
Browsers compatibility: let WP core maintain the list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1449,6 +1449,12 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@wordpress/browserslist-config": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-2.3.0.tgz",
+      "integrity": "sha512-bNOahe6ntNF3pRvCaeh2tGgnpPxe35U6UBfvRjDcOk3sIRvN1S7XlG0rlGZOOD+vJU93VLDM8AUj4uL6VPqPgQ==",
+      "dev": true
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -14,11 +14,7 @@
     "mongodb": ">=3.6 <=4.0"
   },
   "browserslist": [
-    "last 2 versions",
-    "Safari >= 10",
-    "iOS >= 10",
-    "not ie <= 10",
-    "> 1%"
+    "extends @wordpress/browserslist-config"
   ],
   "scripts": {
     "agenda-maintenance": "node ./bin/db-maintenance/archive-done-agenda-jobs.js",
@@ -187,6 +183,7 @@
     "@babel/plugin-proposal-object-rest-spread": "~7.4.4",
     "@babel/preset-env": "~7.4.4",
     "@babel/preset-react": "~7.0.0",
+    "@wordpress/browserslist-config": "~2.3.0",
     "agendash": "~1.0.0",
     "babel-loader": "~8.0.5",
     "babel-plugin-angularjs-annotate": "~0.10.0",


### PR DESCRIPTION
Let WP core maintain the list; they do a great job at it so that we don't have to.

Babel, autoprefixer and other tooling rely on this list.

This list is a bit stricter than the previous old list, hence resulting little bit smaller bundle size (because of less vendor specific CSS).


https://github.com/WordPress/gutenberg/tree/master/packages/browserslist-config
