### PR TITLE
Really remove meta links

### DIFF
--- a/docs/Support-Getting-Started.md
+++ b/docs/Support-Getting-Started.md
@@ -1,3 +1,3 @@
 # Getting started with support
 
-We have many support requests to handle. Check out the [meta thread](https://meta.trustroots.org/t/wiki-support-team/22) to get involved.
+We have many support requests to handle. Introduce yourself in the support channel of our [volunteer chat](Chat.md) to get involved. <!-- Check out the [meta thread](https://meta.trustroots.org/t/wiki-support-team/22) to get involved. -->

--- a/docs/Volunteering.md
+++ b/docs/Volunteering.md
@@ -31,6 +31,6 @@ Some of the easiest ways to help *right now* are:
 
 If you write a post about Trustroots on your blog, definitely [let us know](https://www.trustroots.org/contact) so that we can share it.
 
-If you're still not sure and just want to chat to some humans, introduce yourself in our [volunteer chat](Chat.md). <!-- on our [volunteer forum](https://meta.trustroots.org/). --> All are welcome and we'll be happy to help you get started.
+If you're still not sure and just want to chat to some humans, introduce yourself in our [volunteer chat](Chat.md). All are welcome and we'll be happy to help you get started.
 
 _Thanks for helping out, we really appreciate it!_ ❤️

--- a/docs/Volunteering.md
+++ b/docs/Volunteering.md
@@ -31,6 +31,6 @@ Some of the easiest ways to help *right now* are:
 
 If you write a post about Trustroots on your blog, definitely [let us know](https://www.trustroots.org/contact) so that we can share it.
 
-If you're still not sure and just want to chat to some humans, introduce yourself on our [volunteer forum](https://meta.trustroots.org/). All are welcome and we'll be happy to help you get started.
+If you're still not sure and just want to chat to some humans, introduce yourself in our [volunteer chat](Chat.md). <!-- on our [volunteer forum](https://meta.trustroots.org/). --> All are welcome and we'll be happy to help you get started.
 
 _Thanks for helping out, we really appreciate it!_ ❤️

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,9 +52,6 @@ title: Trustroots Team Guide
 
 ## More information
 - [Privacy Policy](Privacy-Policy.md)
-<!--
-- Project discussions at [meta.trustroots.org](https://meta.trustroots.org/)
--->
 - Logos and other graphics from [media repository](https://github.com/trustroots/media)
 - [Trustroots in Media](https://www.trustroots.org/media)
 
@@ -74,7 +71,4 @@ Is Trustroots.org down or is it just me? Check
 
 - [Contact us via our support form](https://www.trustroots.org/contact).
 - We are using [chat](Chat.md) for volunteer, day-to-day communications.
-<!--
-- For generic, async project conversations that are open for everyone head over to [meta forums](https://meta.trustroots.org/).
--->
 - It's also great if you join the [hacker tribe](https://www.trustroots.org/tribes/hackers)!

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,7 +52,9 @@ title: Trustroots Team Guide
 
 ## More information
 - [Privacy Policy](Privacy-Policy.md)
+<!--
 - Project discussions at [meta.trustroots.org](https://meta.trustroots.org/)
+-->
 - Logos and other graphics from [media repository](https://github.com/trustroots/media)
 - [Trustroots in Media](https://www.trustroots.org/media)
 
@@ -72,5 +74,7 @@ Is Trustroots.org down or is it just me? Check
 
 - [Contact us via our support form](https://www.trustroots.org/contact).
 - We are using [chat](Chat.md) for volunteer, day-to-day communications.
+<!--
 - For generic, async project conversations that are open for everyone head over to [meta forums](https://meta.trustroots.org/).
+-->
 - It's also great if you join the [hacker tribe](https://www.trustroots.org/tribes/hackers)!

--- a/modules/pages/client/views/team.client.view.html
+++ b/modules/pages/client/views/team.client.view.html
@@ -26,11 +26,7 @@
           <br/> Nobody can do everything, but everyone can do something.
         </em>
       </p>
-
-        <a href="https://meta.trustroots.org/t/wiki-support-team/22">Support team</a>  - <a href="https://github.com/orgs/Trustroots/teams/devs">Developer team</a> - <a href="https://meta.trustroots.org/t/lets-translate-trustroots/59">Translation team</a>
-
-      <a ui-sref="volunteering">Get active!</a>
-
+        <a href="https://team.trustroots.org/Volunteering.html">Get active!</a>
       </p>
     </div>
   </div><!-- /.row -->


### PR DESCRIPTION
Commenting out didn't work with Markdown, so I deleted the links to meta.trustroots.org.
Also replaced links from the "Team" page to several volunteering topics with just one link to our Volunteering page, so we only have to update them at one place. 