### PR TITLE
Centralize React map layer config to a component

### DIFF
--- a/config/env/local.sample.js
+++ b/config/env/local.sample.js
@@ -69,10 +69,17 @@ module.exports = {
   /*
   mapbox: {
     maps: {
+      // Old Trustroots main map layer (2014–05/2019)
+      //streets: {
+      //  map: 'k8mokch5',
+      //  user: 'trustroots',
+      //  legacy: true
+      //},
+      // New Trustroots main map layer (05/2019–)
       streets: {
-        map: 'k8mokch5',
-        user: 'trustroots',
-        legacy: true
+        map: 'streets-v11',
+        user: 'mapbox',
+        legacy: false
       },
       satellite: {
         map: 'satellite-streets-v9',

--- a/config/env/local.sample.js
+++ b/config/env/local.sample.js
@@ -76,6 +76,7 @@ module.exports = {
       //  legacy: true
       //},
       // New Trustroots main map layer (05/2019–)
+      // https://www.mapbox.com/maps/streets/
       streets: {
         map: 'streets-v11',
         user: 'mapbox',

--- a/modules/core/client/components/MapLayers.component.js
+++ b/modules/core/client/components/MapLayers.component.js
@@ -10,9 +10,9 @@ export default function MapLayers() {
   let tileAttribution;
 
   // Is Mapbox configuration available?
-  const mapboxConfig = get(window, ['settings', 'mapbox']);
+  const mapboxConfig = get(window, ['settings', 'mapbox'], {});
 
-  if (mapboxConfig && mapboxConfig.publicKey) {
+  if (mapboxConfig.publicKey) {
     // Other styles than `streets` are `outdoors` and `satellite` but we're not u sing them here yet.
     // Default to `streets-v11` if not configured
     const style = get(mapboxConfig, ['maps', 'streets', 'map'], 'streets-v11');

--- a/modules/core/client/components/MapLayers.component.js
+++ b/modules/core/client/components/MapLayers.component.js
@@ -10,17 +10,17 @@ export default function MapLayers() {
   let tileAttribution;
 
   // Is Mapbox configuration available?
-  const mapboxToken = get(window, ['settings', 'mapbox', 'publicKey']);
+  const mapboxConfig = get(window, ['settings', 'mapbox']);
 
-  if (mapboxToken) {
+  if (mapboxConfig && mapboxConfig.publicKey) {
     // Other styles than `streets` are `outdoors` and `satellite` but we're not u sing them here yet.
     // Default to `streets-v11` if not configured
-    const style = get(window, ['settings', 'mapbox', 'maps', 'streets', 'map'], 'streets-v11');
+    const style = get(mapboxConfig, ['maps', 'streets', 'map'], 'streets-v11');
 
     // Default to `mapbox` if not configured but that works only with Mapbox' global public styles
-    const user = get(window, ['settings', 'mapbox', 'maps', 'streets', 'user'], 'mapbox');
+    const user = get(mapboxConfig, ['maps', 'streets', 'user'], 'mapbox');
 
-    tileUrl = `https://api.mapbox.com/styles/v1/${user}/${style}/tiles/256/{z}/{x}/{y}?access_token=${mapboxToken}`;
+    tileUrl = `https://api.mapbox.com/styles/v1/${user}/${style}/tiles/256/{z}/{x}/{y}?access_token=${mapboxConfig.publicKey}`;
     tileAttribution = '© <a href="https://www.mapbox.com/about/maps/">Mapbox</a>';
   // Fall back to OSM
   } else {

--- a/modules/core/client/components/MapLayers.component.js
+++ b/modules/core/client/components/MapLayers.component.js
@@ -1,0 +1,35 @@
+import { TileLayer } from 'react-leaflet';
+import React from 'react';
+import { get } from 'lodash';
+
+/**
+ * Configures Trustroots map layers
+ */
+export default function MapLayers() {
+  let tileUrl;
+  let tileAttribution;
+
+  // Is Mapbox configuration available?
+  const mapboxToken = get(window, ['settings', 'mapbox', 'publicKey']);
+
+  if (mapboxToken) {
+    // Other styles than `streets` are `outdoors` and `satellite` but we're not u sing them here yet.
+    // Default to `streets-v11` if not configured
+    const style = get(window, ['settings', 'mapbox', 'maps', 'streets', 'map'], 'streets-v11');
+
+    // Default to `mapbox` if not configured but that works only with Mapbox' global public styles
+    const user = get(window, ['settings', 'mapbox', 'maps', 'streets', 'user'], 'mapbox');
+
+    tileUrl = `https://api.mapbox.com/styles/v1/${user}/${style}/tiles/256/{z}/{x}/{y}?access_token=${mapboxToken}`;
+    tileAttribution = '© <a href="https://www.mapbox.com/about/maps/">Mapbox</a>';
+  // Fall back to OSM
+  } else {
+    tileUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+    tileAttribution = '© <a href="http://osm.org/copyright">OpenStreetMap</a> contributors';
+  }
+  return (
+    <TileLayer attribution={tileAttribution} url={tileUrl} />
+  );
+}
+
+MapLayers.propTypes = {};

--- a/modules/core/client/components/MapLayers.component.js
+++ b/modules/core/client/components/MapLayers.component.js
@@ -1,6 +1,6 @@
 import { TileLayer } from 'react-leaflet';
 import React from 'react';
-import { get } from 'lodash';
+import get from 'lodash/get';
 
 /**
  * Configures Trustroots map layers

--- a/modules/offers/client/components/OfferLocationPresentational.js
+++ b/modules/offers/client/components/OfferLocationPresentational.js
@@ -1,8 +1,11 @@
+// External dependencies
 import React from 'react';
 import PropTypes from 'prop-types';
 import L from 'leaflet';
+import { Map, Circle, Marker } from 'react-leaflet';
 
-import { Map, TileLayer, Circle, Marker } from 'react-leaflet';
+// Internal dependencies
+import MapLayers from '../../../core/client/components/MapLayers.component';
 
 export default function OfferLocationPresentational({ zoom, location, onChangeZoom, marker='', windowWidth }) {
 
@@ -15,10 +18,7 @@ export default function OfferLocationPresentational({ zoom, location, onChangeZo
       onZoom={({ target: { _zoom: zoom } }) => onChangeZoom(zoom)}
       scrollWheelZoom={false}
     >
-      <TileLayer
-        attribution='&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
-        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-      />
+      <MapLayers />
       {/* @TODO Circle and Marker will need to be reusable when we migrate the /search to React */}
       {(zoom >= 12) ?
         <Circle
@@ -112,5 +112,3 @@ OfferLocationPresentational.propTypes = {
   marker: PropTypes.string,
   windowWidth: PropTypes.number.isRequired
 };
-
-


### PR DESCRIPTION
#### Proposed Changes

* Change default config layer from our custom Mapbox layer to Mapbox's globally provided one: https://www.mapbox.com/maps/streets/ — already updated to all other maps in production via configuration
* Conditionally load either OSM or Mapbox in a component that provides map layers for React components (and hence for React-Leaflet)

#### Testing Instructions

See hosting  offer map on user profile:

![image](https://user-images.githubusercontent.com/87168/57975942-a7b68200-79dd-11e9-8cb8-a88f11dfff2c.png)

Previously it would show up OSM map, which isn't very pretty nor it's supposed to be used in production sites: 

![image](https://user-images.githubusercontent.com/87168/57975947-bc931580-79dd-11e9-9562-7e93557081e8.png)

Fixes https://github.com/Trustroots/trustroots/issues/1067