### PR TITLE
Admin: show email verification links at admin dash

### DIFF
--- a/modules/admin/client/components/AdminUser.component.js
+++ b/modules/admin/client/components/AdminUser.component.js
@@ -5,8 +5,9 @@ import React, { Component } from 'react';
 // Internal dependencies
 import { getUser, suspendUser } from '../api/users.api';
 import AdminHeader from './AdminHeader.component';
-import UserState from './UserState.component';
 import Json from './Json.component';
+import UserEmailConfirmLink from './UserEmailConfirmLink.component';
+import UserState from './UserState.component';
 
 // Mongo ObjectId is always 24 chars long
 const MONGO_OBJECT_ID_LENGTH = 24;
@@ -158,6 +159,7 @@ export default class AdminUser extends Component {
                       </ul>
                       <p><strong>{ user.contacts.length } contact(s)</strong></p>
                       <p><strong>{ user.offers.length } hosting or meet offer(s)</strong></p>
+                      <UserEmailConfirmLink user={ user.profile } />
                     </div>
                   </div>
 

--- a/modules/admin/client/components/UserEmailConfirmLink.component.js
+++ b/modules/admin/client/components/UserEmailConfirmLink.component.js
@@ -1,0 +1,38 @@
+// External dependencies
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function UserEmailConfirmLink({ user }) {
+  if (!user || !user.emailToken || !user.emailTemporary) {
+    return null;
+  }
+
+  // During signup, these emails are identical
+  const isSignup = user.email === user.emailTemporary;
+
+  return (
+    <>
+      { isSignup ? (
+        <label htmlFor="user-email-reset-link">Link to confirm email {user.emailTemporary} during signup</label>
+      ) : (
+        <label htmlFor="user-email-reset-link">Link to confirm email change {user.email} → {user.emailTemporary}</label>
+      ) }
+      <input
+        className="form-control"
+        id="user-email-reset-link"
+        readOnly="readonly"
+        type="text"
+        value={`https://www.trustroots.org/confirm-email/${user.emailToken}${isSignup ? '?signup=true' : ''}`}
+      />
+      <p className="help-block">
+        <span className="text-danger">
+          Make sure to send this link <em>only</em> to email <b>{user.emailTemporary}</b> and nowhere else!
+        </span>
+      </p>
+    </>
+  );
+}
+
+UserEmailConfirmLink.propTypes = {
+  user: PropTypes.object.isRequired
+};

--- a/modules/admin/server/controllers/admin.users.server.controller.js
+++ b/modules/admin/server/controllers/admin.users.server.controller.js
@@ -22,7 +22,7 @@ const SEARCH_STRING_LIMIT = 3;
  * Overwrite tokens from results as a security measure.
  * We still want to pull this info to know if it's there.
  */
-function obfuscateWriteTokens(user) {
+function obfuscateTokens(user) {
   if (!user) {
     return;
   }
@@ -31,7 +31,7 @@ function obfuscateWriteTokens(user) {
   const _user = user.toObject();
 
   [
-    'emailToken',
+    // 'emailToken', // Needed to generate email reset links visible at dashboard
     'removeProfileToken',
     'resetPasswordToken',
     // Arrays just to speed up lodash operations. That's what lodash does internally anyway
@@ -95,7 +95,7 @@ exports.searchUsers = (req, res) => {
         });
       }
 
-      const result = users ? users.map(obfuscateWriteTokens) : [];
+      const result = users ? users.map(obfuscateTokens) : [];
 
       return res.send(result);
     });
@@ -194,7 +194,7 @@ exports.getUser = async (req, res) => {
       messageFromCount,
       messageToCount,
       offers: offers || [],
-      profile: obfuscateWriteTokens(user),
+      profile: obfuscateTokens(user),
       threadCount,
       threadReferencesSentNo,
       threadReferencesReceivedNo,

--- a/modules/admin/tests/server/admin.users.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.users.server.routes.tests.js
@@ -230,11 +230,11 @@ describe('Admin User CRUD tests', () => {
               const profile = res.body.profile;
 
               profile.username.should.equal('user-regular');
+              profile.emailToken.should.equal('test-token');
               // These should have been removed
               should.not.exist(profile.password);
               should.not.exist(profile.salt);
               // These should have been obfuscated
-              profile.emailToken.should.equal('(Hidden from admins.)');
               profile.removeProfileToken.should.equal('(Hidden from admins.)');
               profile.resetPasswordToken.should.equal('(Hidden from admins.)');
               return done(err);


### PR DESCRIPTION
Adds email confirmation link visible in the admin dash:

![image](https://user-images.githubusercontent.com/87168/63580755-2b17de80-c59e-11e9-9dea-28605da99d78.png)


...so that support volunteers can easier send these to members if needed.