### PR TITLE
Update magic number for splash screen

### DIFF
--- a/modules/pages/client/controllers/home.client.controller.js
+++ b/modules/pages/client/controllers/home.client.controller.js
@@ -37,7 +37,7 @@
     var vm = this;
 
     // Exposed to the view
-    vm.boardHeight = $window.innerWidth <= 480 && $window.innerHeight < 700 ? 400 : $window.innerHeight - headerHeight - 10;
+    vm.boardHeight = $window.innerWidth <= 480 && $window.innerHeight < 700 ? 400 : $window.innerHeight - headerHeight + 14;
 
     // Load front page's landing photos
     if ($stateParams.tribe && ['hitchhikers', 'dumpster-divers', 'punks'].indexOf($stateParams.tribe) > -1) {


### PR DESCRIPTION
The home screen was acting up in Chromium, showing double scrollbars, a white margin at the bottom (not apparent in screenshot because I didn't think to consider that GitHub's background color is white), and not scrolling.

Since this is part of the Angular code and I'm new to the code base, I didn't want to put too much effort into a nice solution, so I just went with updating the magic number so the issue went away :innocent:

Seems to work fine with different screen sizes, but it's probably a good idea if someone else tests the code as well.

#### Testing Instructions

* Open [Trustroots](https://www.trustroots.org) in Chromium (76.0.3809.132)
* Try to scroll

Before:
![www trustroots org_withnotes](https://user-images.githubusercontent.com/3090888/64078968-9d489b80-cce1-11e9-9108-c3d5507394ee.png)
After:
![localhost_3000_](https://user-images.githubusercontent.com/3090888/64078969-a20d4f80-cce1-11e9-9cdc-a5a0c0765e3e.png)