### PR TITLE
Add FB to connectSrc CSP rules

### DIFF
--- a/config/lib/express.js
+++ b/config/lib/express.js
@@ -355,9 +355,10 @@ module.exports.initHelmetHeaders = function (app) {
       // If not allowed the browser emulates a 400 HTTP status code.
       connectSrc: [
         '\'self\'',
-        'maitreapp.co', // Signup waiting list feature
         'api.mapbox.com',
-        'fcm.googleapis.com'
+        'fcm.googleapis.com',
+        'maitreapp.co', // Signup waiting list feature
+        'www.facebook.com'
       ].concat(cspSrcDevelopment),
 
       // Allows control over Flash and other plugins.


### PR DESCRIPTION
Avoids CSP warnings when FB SDK is used.