### PR TITLE
Allow mongodb engine <=4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "engines": {
     "node": ">=10.0.0",
     "npm": ">=6.0.0",
-    "mongodb": ">=3.6 <=4.0"
+    "mongodb": ">=3.6 <=4.2"
   },
   "browserslist": [
     "extends @wordpress/browserslist-config"


### PR DESCRIPTION
#### Proposed Changes

This is a small change.

* allow mongodb <=4.2 (previously <= 4.0)

Motivation: to accommodate my needs after I reinstalled mongodb locally.
