### PR TITLE
Fix failing confirm-contact because of a wrong api request

### DIFF
--- a/modules/contacts/client/config/contacts.client.routes.js
+++ b/modules/contacts/client/config/contacts.client.routes.js
@@ -42,10 +42,10 @@
         controllerAs: 'contactConfirm',
         resolve: {
           // A string value resolves to a service
-          ContactByService: 'ContactByService',
+          Contact: 'Contact',
 
-          contact: function (ContactByService, $stateParams) {
-            return ContactByService.get({ contactId: $stateParams.contactId });
+          contact: function (Contact, $stateParams) {
+            return Contact.get({ contactId: $stateParams.contactId });
           }
 
         },

--- a/modules/contacts/tests/client/contacts.client.routes.tests.js
+++ b/modules/contacts/tests/client/contacts.client.routes.tests.js
@@ -92,8 +92,6 @@
           $templateCache.put('/modules/contacts/views/confirm-contact.client.view.html', '');
           $httpBackend.when('GET', '/api/contact/123').respond(200, '');
           $httpBackend.expectGET('/api/contact/123');
-          $httpBackend.when('GET', '/api/contact-by?contactId=123').respond(200, '');
-          $httpBackend.expectGET('/api/contact-by?contactId=123');
 
           $state.go('contactConfirm', { contactId: '123' });
           $rootScope.$digest();


### PR DESCRIPTION
#### Issue

The path `/contact-confirm/:contactId` shows error (_contact doesn't exist or maybe logged as different user?_) unexpectedly.
The api request to load the contact changed from `/api/contact/:contactId` to `/api/contact-by?contactId=:contactId`, leading to 404 error response. Possibly introduced in #1112.

#### Proposed Changes

This PR fixes the above issue.

#### Testing Instructions

1. Logged as `someuser`, create a contact request for `otheruser`.
2. Log in as `otheruser` and go to "Contacts".
3. Try to click "confirm contact" with `someuser`
4. See that this action fails on master but succeeds on this branch

#### Maybe TODO

Look if similar issue was introduced elsewhere. (not in this PR)