### PR TITLE
Fix eslint `no-prototype-builtins` issues

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -33,7 +33,7 @@ var getGlobbedPaths = function (globPatterns, excludes) {
         files = files.map(function (file) {
           if (_.isArray(excludes)) {
             for (var i in excludes) {
-              if (excludes.hasOwnProperty(i)) {
+              if (Object.prototype.hasOwnProperty.call(excludes, i)) {
                 file = file.replace(excludes[i], '');
               }
             }

--- a/config/config.js
+++ b/config/config.js
@@ -33,7 +33,7 @@ var getGlobbedPaths = function (globPatterns, excludes) {
         files = files.map(function (file) {
           if (_.isArray(excludes)) {
             for (var i in excludes) {
-              if (Object.prototype.hasOwnProperty.call(excludes, i)) {
+              if (_.has(excludes, i)) {
                 file = file.replace(excludes[i], '');
               }
             }

--- a/modules/references/server/controllers/reference.server.controller.js
+++ b/modules/references/server/controllers/reference.server.controller.js
@@ -41,14 +41,14 @@ function validateCreate(req) {
 
   // Values of interactions must be boolean
   ['met', 'hostedMe', 'hostedThem'].forEach(function (interaction) {
-    if (req.body.interactions && req.body.interactions.hasOwnProperty(interaction) && typeof req.body.interactions[interaction] !== 'boolean') {
+    if (_.has(req, ['body', 'interactions', interaction]) && typeof req.body.interactions[interaction] !== 'boolean') {
       valid = false;
       interactionErrors[interaction] = 'boolean expected';
     }
   });
 
   // Value of userTo must exist and be a UserId
-  if (!req.body.hasOwnProperty('userTo')) {
+  if (!_.has(req, ['body', 'userTo'])) {
     valid = false;
     details.userTo = 'missing';
   } else if (!mongoose.Types.ObjectId.isValid(req.body.userTo)) {

--- a/modules/sparkpost/server/controllers/sparkpost-webhooks.server.controller.js
+++ b/modules/sparkpost/server/controllers/sparkpost-webhooks.server.controller.js
@@ -55,7 +55,7 @@ exports.receiveBatch = function (req, res) {
  */
 exports.processAndSendMetrics = function (event, callback) {
   // When adding a webhook, Sparkpost sends us `[{"msys":{}}]`
-  if (!event.hasOwnProperty('msys') || _.isEmpty(event.msys)) {
+  if (!_.has(event, 'msys') || _.isEmpty(event.msys)) {
     return callback();
   }
 

--- a/modules/stats/server/services/stats.server.service.js
+++ b/modules/stats/server/services/stats.server.service.js
@@ -202,10 +202,8 @@ function validateStat(stat) {
   }
 
   // time, if provided, should be of type Date
-  if (stat.hasOwnProperty('time')) {
-    if (!_.isDate(stat.time)) {
-      throw new Error('Time must be a Date object or not provided');
-    }
+  if (_.has(stat, 'time') && !_.isDate(stat.time)) {
+    throw new Error('Time must be a Date object or not provided');
   }
 }
 


### PR DESCRIPTION
This is a smaller iteration step from https://github.com/Trustroots/trustroots/pull/1126 where I'm converting eslint config to extend [`eslint:recommended`](https://eslint.org/docs/user-guide/configuring#extending-configuration-files).

That ruleset includes [`no-prototype-builtins`](https://eslint.org/docs/rules/no-prototype-builtins) rule and there were a few warnings so I set to fix those. Instead of using elaborate `Object.prototype.hasOwnProperty.call(foo, "bar")` I'm just using Lodash's `has` here instead.

I generally like using vanilla JS over Lodash especially in frontend code but this is all server-side and just feels more readable in these cases. We're also already using Lodash in all these files.

#### Proposed Changes

* Use `_.has()` over `hasOwnProperty` checks

#### Testing Instructions

* Does the app start?
* Do the tests pass?
