### PR TITLE
Fix script test:server:watch to watch again

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -182,7 +182,7 @@ gulp.task('watch:server:run-tests', function watchServerRunTests() {
   // Add Server Test file rules
   gulp.watch([
     'modules/*/tests/server/**/*.js',
-    defaultAssets.server.allJS,
+    ...defaultAssets.server.allJS,
     defaultAssets.server.migrations
   ],
   gulp.series('test:server'))


### PR DESCRIPTION
#### Proposed Changes

* `npm run test:server:watch` was failing after the tests ran. Fix.

#### Testing Instructions

* see that before this change, `npm run test:server:watch` doesn't watch, but fails after the first round of tests
* see that after this change, `npm run test:server:watch` runs again

#### To do later
Some tests weirdly fail in the second and further rounds of tests. Won't fix in this PR.
