### PR TITLE
Remove app store buttons in native app

### DIFF
--- a/modules/core/client/controllers/app.client.controller.js
+++ b/modules/core/client/controllers/app.client.controller.js
@@ -42,6 +42,7 @@ function AppController(
   vm.isFooterHidden = false;
   vm.isHeaderHidden = false;
   vm.isAboutPage = false;
+  vm.isNativeMobileApp = $window.isNativeMobileApp;
 
   /**
    * Handle the window blur event

--- a/modules/pages/client/views/home.client.view.html
+++ b/modules/pages/client/views/home.client.view.html
@@ -17,7 +17,7 @@
           <a ui-sref="signup" class="btn btn-action btn-default home-join hidden-xs">
             Join Trustroots now
           </a>
-          <div class="home-apps">
+          <div class="home-apps" ng-if="::!app.isNativeMobileApp">
             <a href="https://play.google.com/store/apps/details?id=org.trustroots.trustrootsApp"
                rel="noopener"
                class="btn btn-lg btn-default">
@@ -186,7 +186,7 @@
     <div class="row text-center">
       <hr class="hr-white hr-xs" />
 
-      <div class="home-apps">
+      <div class="home-apps" ng-if="::!app.isNativeMobileApp">
         <a href="https://play.google.com/store/apps/details?id=org.trustroots.trustrootsApp"
            rel="noopener"
            class="btn btn-lg btn-default">

--- a/modules/pages/client/views/navigation.client.view.html
+++ b/modules/pages/client/views/navigation.client.view.html
@@ -75,7 +75,7 @@
 
 <div class="container font-brand-regular">
 
-  <p>
+  <p class="home-apps" ng-if="::!app.isNativeMobileApp">
     <a href="https://play.google.com/store/apps/details?id=org.trustroots.trustrootsApp"
        class="btn btn-default btn-app center-block">
       <svg viewBox="0 0 2700 800" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
#### Proposed Changes

* Remove app store buttons when inside the native app

#### Testing Instructions

* Use mobile expo and app store buttons shouldn't be there anymore

[Fixes one blocking point to publish iOS](https://github.com/Trustroots/trustroots-expo-mobile/issues/10#issuecomment-528238998)
