### PR TITLE
Move around utils

### DIFF
--- a/modules/core/client/utils/filters.js
+++ b/modules/core/client/utils/filters.js
@@ -1,0 +1,9 @@
+export const limitTo = (text, length) => {
+  return text.substring(0, length);
+};
+
+export const plainTextLength = (text) => {
+  return text && typeof(text) === 'string'
+    ? String(text).replace(/&nbsp;/g, ' ').replace(/<[^>]+>/gm, '').trim().length
+    : 0;
+};

--- a/modules/users/client/components/AboutMe.component.js
+++ b/modules/users/client/components/AboutMe.component.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { withTranslation } from '@/modules/core/client/utils/i18n-angular-load';
 import '@/config/client/i18n';
 import PropTypes from 'prop-types';
-import { limitTo, plainTextLength } from './utils/filters';
+import { limitTo, plainTextLength } from '@/modules/core/client/utils/filters';
 
 export class AboutMe extends Component {
   constructor(props) {

--- a/modules/users/client/components/ProfileViewBasics.js
+++ b/modules/users/client/components/ProfileViewBasics.js
@@ -4,7 +4,7 @@ import { withTranslation } from 'react-i18next';
 import { Trans } from 'react-i18next';
 import PropTypes from 'prop-types';
 import * as languages from '@/config/languages/languages';
-import { hasConnectedAdditionalSocialAccounts, isWarmshowersId, socialAccountLink } from './utils/networks';
+import { hasConnectedAdditionalSocialAccounts, isWarmshowersId, socialAccountLink } from '../utils/networks';
 
 
 export function ProfileViewBasics({ t, profile }) {
@@ -179,7 +179,7 @@ export function ProfileViewBasics({ t, profile }) {
         <li className="social-profile">
           <i className="social-profile-icon icon-fw icon-lg icon-warmshowers"></i>
           <a className="social-profile-handle"
-            href={`https://www.warmshowers.org/${isWarmshowersId(profile) ? 'user' : 'users' }/${profile.extSitesWS}`}>
+            href={`https://www.warmshowers.org/${isWarmshowersId(profile.extSitesWS) ? 'user' : 'users' }/${profile.extSitesWS}`}>
             Warmshowers
           </a>
         </li>}

--- a/modules/users/client/components/utils/filters.js
+++ b/modules/users/client/components/utils/filters.js
@@ -1,7 +1,0 @@
-export const limitTo = (text, length) => {
-  return text.substring(0, length);
-};
-
-export const plainTextLength = (text) => {
-  return text && typeof(text) === 'string' ? String(text).replace(/&nbsp;/g, ' ').replace(/<[^>]+>/gm, '').trim().length : 0; // eslint-disable-line angular/typecheck-string
-};

--- a/modules/users/client/utils/networks.js
+++ b/modules/users/client/utils/networks.js
@@ -2,34 +2,30 @@
  * Determine if given user handle for Warmshowers is an id or username
  * @link https://github.com/Trustroots/trustroots/issues/308
  */
-function isWarmshowersId(profile) {
+export function isWarmshowersId(id) {
   // WarmShowers id should contain only digits
-  return /^[0-9]*$/.test(profile.extSitesWS);
+  return /^[0-9]*$/.test(id);
 }
 
 /**
  * Check if there are additional accounts
  */
-function hasConnectedAdditionalSocialAccounts(profile) {
-  return (profile.additionalProvidersData && Object.keys(profile.additionalProvidersData).length);
+export function hasConnectedAdditionalSocialAccounts(profile) {
+  return profile.additionalProvidersData && Object.keys(profile.additionalProvidersData).length > 0;
 }
 
 /**
  * Return an URL for user's social media profiles
  * Ensure these values are published at users.profile.server.controller.js
  */
-function socialAccountLink(providerName, providerData) {
+export function socialAccountLink(providerName, providerData) {
   if (providerName === 'facebook' && providerData.id) {
-    return 'https://www.facebook.com/app_scoped_user_id/' + providerData.id;
+    return `https://www.facebook.com/app_scoped_user_id/${providerData.id}`;
   } else if (providerName === 'twitter' && providerData.screen_name) {
-    return 'https://twitter.com/' + providerData.screen_name;
+    return `https://twitter.com/${providerData.screen_name}`;
   } else if (providerName === 'github' && providerData.login) {
-    return 'https://github.com/' + providerData.login;
+    return `https://github.com/${providerData.login}`;
   } else {
     return '#';
   }
 }
-
-
-
-module.exports = { hasConnectedAdditionalSocialAccounts, socialAccountLink, isWarmshowersId };


### PR DESCRIPTION
Mainly wanted to pull some unrelated changes out from https://github.com/Trustroots/trustroots/pull/1161

#### Proposed Changes

* Move generic utils to the core module
* Simplify `isWarmshowersId()` input attribute
* Small ES6'ifying

#### Testing Instructions

* Profile works as usual
