### PR TITLE
Add "read more" component

### DIFF
--- a/modules/core/client/components/ReadMorePanel.js
+++ b/modules/core/client/components/ReadMorePanel.js
@@ -20,11 +20,6 @@ export class ReadMorePanel extends Component {
     this.setState({ showMore: true });
   }
 
-  componentDidCatch(error, errorInfo) {
-    // You can also log the error to an error reporting service
-    console.error(error, errorInfo); //eslint-disable-line
-  }
-
   render() {
     const { showMore } = this.state;
     const { content, id } = this.props;

--- a/modules/core/client/components/ReadMorePanel.js
+++ b/modules/core/client/components/ReadMorePanel.js
@@ -2,6 +2,9 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
+// Internal dependencies
+import { plainTextLength } from '../utils/filters';
+
 export class ReadMorePanel extends Component {
   constructor(props) {
     super(props);
@@ -28,7 +31,7 @@ export class ReadMorePanel extends Component {
       return;
     }
 
-    if (showMore || content.length <= limit) {
+    if (showMore || plainTextLength(content) <= limit) {
       return <div dangerouslySetInnerHTML={{ __html: content }} />;
     }
 

--- a/modules/core/client/components/ReadMorePanel.js
+++ b/modules/core/client/components/ReadMorePanel.js
@@ -45,5 +45,4 @@ export default function ReadMorePanel({ content, id }) {
 ReadMorePanel.propTypes = {
   content: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
-  t: PropTypes.func.isRequired,
 };

--- a/modules/core/client/components/ReadMorePanel.js
+++ b/modules/core/client/components/ReadMorePanel.js
@@ -1,7 +1,7 @@
 // External dependencies
 import { withTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 
 // Internal dependencies
 import '@/config/client/i18n';
@@ -9,51 +9,36 @@ import { plainText, plainTextLength } from '../utils/filters';
 
 const LIMIT = 2000;
 
-export class ReadMorePanel extends Component {
-  constructor(props) {
-    super(props);
-    this.toggleMore = this.toggleMore.bind(this);
-    this.state = {
-      showMore: false
-    };
+function ReadMorePanel({ content, id, t }) {
+  const [showMore, setShowMore] = useState(false);
+
+  if (content.length === 0) {
+    return;
   }
 
-  toggleMore() {
-    this.setState({ showMore: true });
+  if (showMore || plainTextLength(content) <= LIMIT) {
+    return <div dangerouslySetInnerHTML={{ __html: content }} />;
   }
 
-  render() {
-    const { showMore } = this.state;
-    const { content, id, t } = this.props;
-
-    if (content.length === 0) {
-      return;
-    }
-
-    if (showMore || plainTextLength(content) <= LIMIT) {
-      return <div dangerouslySetInnerHTML={{ __html: content }} />;
-    }
-
-    return (
-      <div className="panel-more-wrap">
-        <div
-          className="panel-more-wrap"
-          dangerouslySetInnerHTML={{ __html: `${plainText(content).substr(0, LIMIT)} …` }}
-          id={id}
-          onClick={this.toggleMore}
-        />
-        <div
-          aria-controls={id}
-          aria-expanded="false"
-          className="panel-more-fade"
-          onClick={this.toggleMore}
-          type="button"
-        >
-          {t('Read more…')}
-        </div>
+  return (
+    <div className="panel-more-wrap">
+      <div
+        className="panel-more-wrap"
+        dangerouslySetInnerHTML={{ __html: `${plainText(content).substr(0, LIMIT)} …` }}
+        id={id}
+        onClick={() => setShowMore(true)}
+      />
+      <div
+        aria-controls={id}
+        aria-expanded="false"
+        className="panel-more-fade"
+        onClick={() => setShowMore(true)}
+        type="button"
+      >
+        {t('Read more…')}
       </div>
-    );
-  }
+    </div>
+  );
 }
 
 ReadMorePanel.propTypes = {

--- a/modules/core/client/components/ReadMorePanel.js
+++ b/modules/core/client/components/ReadMorePanel.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
 // Internal dependencies
-import { plainTextLength } from '../utils/filters';
+import { plainText, plainTextLength } from '../utils/filters';
 
 export class ReadMorePanel extends Component {
   constructor(props) {
@@ -39,7 +39,7 @@ export class ReadMorePanel extends Component {
       <div className="panel-more-wrap">
         <div
           className="panel-more-wrap"
-          dangerouslySetInnerHTML={{ __html: content.substr(0, limit) }}
+          dangerouslySetInnerHTML={{ __html: plainText(content).substr(0, limit) }}
           id={id}
           onClick={this.toggleMore}
         />

--- a/modules/core/client/components/ReadMorePanel.js
+++ b/modules/core/client/components/ReadMorePanel.js
@@ -5,6 +5,8 @@ import React, { Component } from 'react';
 // Internal dependencies
 import { plainText, plainTextLength } from '../utils/filters';
 
+const LIMIT = 2000;
+
 export class ReadMorePanel extends Component {
   constructor(props) {
     super(props);
@@ -25,13 +27,13 @@ export class ReadMorePanel extends Component {
 
   render() {
     const { showMore } = this.state;
-    const { content, id, limit } = this.props;
+    const { content, id } = this.props;
 
     if (content.length === 0) {
       return;
     }
 
-    if (showMore || plainTextLength(content) <= limit) {
+    if (showMore || plainTextLength(content) <= LIMIT) {
       return <div dangerouslySetInnerHTML={{ __html: content }} />;
     }
 
@@ -39,7 +41,7 @@ export class ReadMorePanel extends Component {
       <div className="panel-more-wrap">
         <div
           className="panel-more-wrap"
-          dangerouslySetInnerHTML={{ __html: plainText(content).substr(0, limit) }}
+          dangerouslySetInnerHTML={{ __html: `${plainText(content).substr(0, LIMIT)} …` }}
           id={id}
           onClick={this.toggleMore}
         />
@@ -58,14 +60,9 @@ export class ReadMorePanel extends Component {
   }
 }
 
-ReadMorePanel.defaultProps = {
-  limit: 2000
-};
-
 ReadMorePanel.propTypes = {
   content: PropTypes.string.isRequired,
-  id: PropTypes.string.isRequired,
-  limit: PropTypes.number
+  id: PropTypes.string.isRequired
 };
 
 export default ReadMorePanel;

--- a/modules/core/client/components/ReadMorePanel.js
+++ b/modules/core/client/components/ReadMorePanel.js
@@ -1,0 +1,68 @@
+// External dependencies
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+
+export class ReadMorePanel extends Component {
+  constructor(props) {
+    super(props);
+    this.toggleMore = this.toggleMore.bind(this);
+    this.state = {
+      showMore: false
+    };
+  }
+
+  toggleMore() {
+    this.setState({ showMore: true });
+  }
+
+  componentDidCatch(error, errorInfo) {
+    // You can also log the error to an error reporting service
+    console.error(error, errorInfo); //eslint-disable-line
+  }
+
+  render() {
+    const { showMore } = this.state;
+    const { content, id, limit } = this.props;
+
+    if (content.length === 0) {
+      return;
+    }
+
+    if (showMore || content.length <= limit) {
+      return <div dangerouslySetInnerHTML={{ __html: content }} />;
+    }
+
+    return (
+      <div className="panel-more-wrap">
+        <div
+          className="panel-more-wrap"
+          dangerouslySetInnerHTML={{ __html: content }}
+          id={id}
+          onClick={this.toggleMore}
+        />
+        <div
+          aria-controls={id}
+          aria-expanded="false"
+          className="panel-more-fade"
+          onClick={this.toggleMore}
+          type="button"
+        >
+          {/* TODO: translate */}
+          Read more…
+        </div>
+      </div>
+    );
+  }
+}
+
+ReadMorePanel.defaultProps = {
+  limit: 2000
+};
+
+ReadMorePanel.propTypes = {
+  content: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired,
+  limit: PropTypes.number
+};
+
+export default ReadMorePanel;

--- a/modules/core/client/components/ReadMorePanel.js
+++ b/modules/core/client/components/ReadMorePanel.js
@@ -39,7 +39,7 @@ export class ReadMorePanel extends Component {
       <div className="panel-more-wrap">
         <div
           className="panel-more-wrap"
-          dangerouslySetInnerHTML={{ __html: content }}
+          dangerouslySetInnerHTML={{ __html: content.substr(0, limit) }}
           id={id}
           onClick={this.toggleMore}
         />

--- a/modules/core/client/components/ReadMorePanel.js
+++ b/modules/core/client/components/ReadMorePanel.js
@@ -44,7 +44,7 @@ function ReadMorePanel({ content, id, t }) {
 ReadMorePanel.propTypes = {
   content: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
-  t: PropTypes.func.isRequired
+  t: PropTypes.func.isRequired,
 };
 
 export default withTranslation('core')(ReadMorePanel);

--- a/modules/core/client/components/ReadMorePanel.js
+++ b/modules/core/client/components/ReadMorePanel.js
@@ -1,8 +1,10 @@
 // External dependencies
+import { withTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
 // Internal dependencies
+import '@/config/client/i18n';
 import { plainText, plainTextLength } from '../utils/filters';
 
 const LIMIT = 2000;
@@ -22,7 +24,7 @@ export class ReadMorePanel extends Component {
 
   render() {
     const { showMore } = this.state;
-    const { content, id } = this.props;
+    const { content, id, t } = this.props;
 
     if (content.length === 0) {
       return;
@@ -47,8 +49,7 @@ export class ReadMorePanel extends Component {
           onClick={this.toggleMore}
           type="button"
         >
-          {/* TODO: translate */}
-          Read more…
+          {t('Read more…')}
         </div>
       </div>
     );
@@ -57,7 +58,8 @@ export class ReadMorePanel extends Component {
 
 ReadMorePanel.propTypes = {
   content: PropTypes.string.isRequired,
-  id: PropTypes.string.isRequired
+  id: PropTypes.string.isRequired,
+  t: PropTypes.func.isRequired
 };
 
-export default ReadMorePanel;
+export default withTranslation('core')(ReadMorePanel);

--- a/modules/core/client/components/ReadMorePanel.js
+++ b/modules/core/client/components/ReadMorePanel.js
@@ -13,7 +13,7 @@ function ReadMorePanel({ content, id, t }) {
   const [showMore, setShowMore] = useState(false);
 
   if (content.length === 0) {
-    return;
+    return null;
   }
 
   if (showMore || plainTextLength(content) <= LIMIT) {

--- a/modules/core/client/components/ReadMorePanel.js
+++ b/modules/core/client/components/ReadMorePanel.js
@@ -1,5 +1,5 @@
 // External dependencies
-import { withTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 
@@ -9,8 +9,9 @@ import { plainText, plainTextLength } from '../utils/filters';
 
 const LIMIT = 2000;
 
-function ReadMorePanel({ content, id, t }) {
+export default function ReadMorePanel({ content, id }) {
   const [showMore, setShowMore] = useState(false);
+  const { t } = useTranslation('core');
 
   if (content.length === 0) {
     return null;
@@ -46,5 +47,3 @@ ReadMorePanel.propTypes = {
   id: PropTypes.string.isRequired,
   t: PropTypes.func.isRequired,
 };
-
-export default withTranslation('core')(ReadMorePanel);

--- a/modules/core/client/utils/filters.js
+++ b/modules/core/client/utils/filters.js
@@ -1,9 +1,12 @@
-export const limitTo = (text, length) => {
-  return text.substring(0, length);
+export const plainText = (html) => {
+  if (!html || typeof(html) !== 'string' || !document) {
+    return '';
+  }
+  const div = document.createElement('div');
+  div.innerHTML = html;
+  return div.textContent || div.innerText || '';
 };
 
-export const plainTextLength = (text) => {
-  return text && typeof(text) === 'string'
-    ? String(text).replace(/&nbsp;/g, ' ').replace(/<[^>]+>/gm, '').trim().length
-    : 0;
+export const plainTextLength = (html) => {
+  return plainText(html).trim().length;
 };

--- a/modules/core/client/utils/filters.js
+++ b/modules/core/client/utils/filters.js
@@ -1,5 +1,5 @@
 export const plainText = (html) => {
-  if (!html || typeof(html) !== 'string' || !document) {
+  if (!html || typeof html !== 'string' || typeof document !== 'undefined') {
     return '';
   }
   const div = document.createElement('div');

--- a/modules/core/client/utils/filters.js
+++ b/modules/core/client/utils/filters.js
@@ -1,5 +1,5 @@
 export const plainText = (html) => {
-  if (!html || typeof html !== 'string' || typeof document !== 'undefined') {
+  if (!html || typeof html !== 'string' || typeof document === 'undefined') {
     return '';
   }
   const div = document.createElement('div');

--- a/modules/users/client/components/AboutMe.component.js
+++ b/modules/users/client/components/AboutMe.component.js
@@ -1,54 +1,42 @@
-import React, { Component } from 'react';
-import { withTranslation } from '@/modules/core/client/utils/i18n-angular-load';
-import '@/config/client/i18n';
+// External dependencies
 import PropTypes from 'prop-types';
-import { limitTo, plainTextLength } from '@/modules/core/client/utils/filters';
+import React from 'react';
 
-export class AboutMe extends Component {
-  constructor(props) {
-    super(props);
-    this.changeProfileDescriptionToggle = this.changeProfileDescriptionToggle.bind(this);
+// Internal dependencies
+import '@/config/client/i18n';
+import { plainTextLength } from './utils/filters';
+import { ReadMorePanel } from '@/modules/core/client/components/ReadMorePanel';
+import { withTranslation } from '@/modules/core/client/utils/i18n-angular-load';
 
-    this.state = {
-      profileDescriptionToggle: false,
-    };
-  }
-  changeProfileDescriptionToggle(){
-    this.setState((prevState) => ({
-      profileDescriptionToggle: !prevState.profileDescriptionToggle,
-    }));
-  }
-
-  render(){
-    const { t, profile, isSelf, appSettings } = this.props;
-    return (<>
+function AboutMe({ t, profile, isSelf, profileMinimumLength }) {
+  return (
+    <>
       <section className="panel panel-default">
         <header className="panel-heading">
           {t('About me')}
         </header>
         <div className="panel-body">
-          {/* Short descriptions */}
-          {(profile.description.length < 2400 || this.state.profileDescriptionToggle) &&
-          <div dangerouslySetInnerHTML={{ __html: profile.description }}></div>}
-
-          {/* Long descriptions */}
-          {profile.description.length >= 2400 && !this.state.profileDescriptionToggle &&
-          <div
-            className="panel-more-wrap">
-            <div className="panel-more-excerpt" dangerouslySetInnerHTML={{ __html: limitTo(profile.description, 2400) }}></div>
-            <div className="panel-more-fade" onClick={this.changeProfileDescriptionToggle}>{t('Show more...')}</div>
-          </div>}
+          {profile.description && (
+            <ReadMorePanel
+              content={profile.description}
+              id="profile-description"
+              limit={400}
+            />
+          )}
 
           {/* If no description, show deep thoughts... */}
-          {(!profile.description || profile.description === '') &&
-          <blockquote className="profile-quote"
-            aria-label={t('Member has not written description about themself.')}>
-          “Everyone is necessarily the hero of their own life story.”
-          </blockquote>}
+          {!profile.description && (
+            <blockquote
+              aria-label={t('Member has not written description about themself.')}
+              className="profile-quote"
+            >
+              {t('“Everyone is necessarily the hero of their own life story.”')}
+            </blockquote>
+          )}
         </div>
 
         {/* User watching their own profile and it's too short */}
-        {(isSelf && (!profile.description || plainTextLength(profile.description) < appSettings.profileMinimumLength)) &&
+        {(isSelf && (!profile.description || plainTextLength(profile.description) < profileMinimumLength)) &&
         <footer className="panel-footer">
           <p className="lead">
             {t('Your profile description should be longer so that you can send messages.')}
@@ -57,14 +45,14 @@ export class AboutMe extends Component {
           </p>
         </footer>}
       </section>
-    </>);
-  }
+    </>
+  );
 }
 
 AboutMe.propTypes = {
   profile: PropTypes.object,
   isSelf: PropTypes.bool,
-  appSettings: PropTypes.object,
+  profileMinimumLength: PropTypes.number.isRequired,
   t: PropTypes.func,
 };
 

--- a/modules/users/client/components/AboutMe.component.js
+++ b/modules/users/client/components/AboutMe.component.js
@@ -20,7 +20,6 @@ function AboutMe({ t, profile, isSelf, profileMinimumLength }) {
             <ReadMorePanel
               content={profile.description}
               id="profile-description"
-              limit={2400}
             />
           )}
 

--- a/modules/users/client/components/AboutMe.component.js
+++ b/modules/users/client/components/AboutMe.component.js
@@ -20,7 +20,7 @@ function AboutMe({ t, profile, isSelf, profileMinimumLength }) {
             <ReadMorePanel
               content={profile.description}
               id="profile-description"
-              limit={400}
+              limit={2400}
             />
           )}
 

--- a/modules/users/client/components/AboutMe.component.js
+++ b/modules/users/client/components/AboutMe.component.js
@@ -4,7 +4,7 @@ import React from 'react';
 
 // Internal dependencies
 import '@/config/client/i18n';
-import { plainTextLength } from './utils/filters';
+import { plainTextLength } from '@/modules/core/client/utils/filters';
 import { ReadMorePanel } from '@/modules/core/client/components/ReadMorePanel';
 import { withTranslation } from '@/modules/core/client/utils/i18n-angular-load';
 

--- a/modules/users/client/components/AboutMe.component.js
+++ b/modules/users/client/components/AboutMe.component.js
@@ -1,14 +1,16 @@
 // External dependencies
+import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 import React from 'react';
 
 // Internal dependencies
 import '@/config/client/i18n';
 import { plainTextLength } from '@/modules/core/client/utils/filters';
-import { withTranslation } from '@/modules/core/client/utils/i18n-angular-load';
 import ReadMorePanel from '@/modules/core/client/components/ReadMorePanel';
 
-function AboutMe({ t, profile, isSelf, profileMinimumLength }) {
+export default function AboutMe({ profile, isSelf, profileMinimumLength }) {
+  const { t } = useTranslation('user-profile');
+
   return (
     <>
       <section className="panel panel-default">
@@ -52,7 +54,4 @@ AboutMe.propTypes = {
   profile: PropTypes.object,
   isSelf: PropTypes.bool,
   profileMinimumLength: PropTypes.number.isRequired,
-  t: PropTypes.func,
 };
-
-export default withTranslation(['user-profile'])(AboutMe);

--- a/modules/users/client/components/AboutMe.component.js
+++ b/modules/users/client/components/AboutMe.component.js
@@ -5,8 +5,8 @@ import React from 'react';
 // Internal dependencies
 import '@/config/client/i18n';
 import { plainTextLength } from '@/modules/core/client/utils/filters';
-import { ReadMorePanel } from '@/modules/core/client/components/ReadMorePanel';
 import { withTranslation } from '@/modules/core/client/utils/i18n-angular-load';
+import ReadMorePanel from '@/modules/core/client/components/ReadMorePanel';
 
 function AboutMe({ t, profile, isSelf, profileMinimumLength }) {
   return (

--- a/modules/users/client/components/utils/filters.js
+++ b/modules/users/client/components/utils/filters.js
@@ -1,0 +1,3 @@
+export const plainTextLength = (text) => {
+  return text && typeof(text) === 'string' ? String(text).replace(/&nbsp;/g, ' ').replace(/<[^>]+>/gm, '').trim().length : 0; // eslint-disable-line angular/typecheck-string
+};

--- a/modules/users/client/components/utils/filters.js
+++ b/modules/users/client/components/utils/filters.js
@@ -1,3 +1,0 @@
-export const plainTextLength = (text) => {
-  return text && typeof(text) === 'string' ? String(text).replace(/&nbsp;/g, ' ').replace(/<[^>]+>/gm, '').trim().length : 0; // eslint-disable-line angular/typecheck-string
-};

--- a/modules/users/client/views/profile/profile-view-about.client.view.html
+++ b/modules/users/client/views/profile/profile-view-about.client.view.html
@@ -1,7 +1,11 @@
 
 <div class="row">
   <div class="col-md-6">
-    <about-me profile="profileCtrl.profile" isSelf="app.user._id === profileCtrl.profile._id" appSettings="app.appSettings"></about-me>
+    <about-me
+      isSelf="app.user._id === profileCtrl.profile._id"
+      profile="profileCtrl.profile"
+      profileMinimumLength="app.appSettings.profileMinimumLength"
+    />
   </div>
 
   <div class="col-md-6">


### PR DESCRIPTION
I PRed some related file-movings and things in https://github.com/Trustroots/trustroots/pull/1160 which can be merged first. (update: done!)

#### Proposed Changes

* Extract "Read more" feature from profile to its own component. Later own this will be useful in some offer components (there's a similar mechanism in https://github.com/Trustroots/trustroots/pull/1045) 
* Simplify `AboutMe` component
* Switch text to say "Read more…" instead of "Show more..."

#### Testing Instructions

* Create over 2400 chars long profile description
* Open profile, and observe this functionality work just fine:
  <img width="435" alt="Screenshot 2020-01-03 at 00 22 17" src="https://user-images.githubusercontent.com/87168/71697565-11469d80-2dc1-11ea-9b12-d8fbf23e079f.png">
  <img width="436" alt="Screenshot 2020-01-03 at 00 22 21" src="https://user-images.githubusercontent.com/87168/71697564-11469d80-2dc1-11ea-8174-4adf8a89e214.png">

* Test also with an empty description or short description.
