### PR TITLE
Tribes: Format the Tribe member count according to current language

### DIFF
--- a/config/client/i18n.js
+++ b/config/client/i18n.js
@@ -44,6 +44,10 @@ function format(value, format, languageCode) {
     return moment(value).format(format);
   }
 
+  if (typeof value === 'number' && format === 'number') {
+    return value.toLocaleString(languageCode);
+  }
+
   return value;
 }
 

--- a/modules/tribes/client/components/TribeItem.component.js
+++ b/modules/tribes/client/components/TribeItem.component.js
@@ -15,7 +15,7 @@ export default function TribeItem({ tribe, user, onMembershipUpdated }) {
 
   const countInfo = (tribe.count === 0)
     ? t('No members yet')
-    : t('{{count}} members', { count: tribe.count });
+    : t('{{count, number}} members', { count: tribe.count });
 
   return <div
     className="panel tribe tribe-image"

--- a/public/locales/en/tribes.json
+++ b/public/locales/en/tribes.json
@@ -1,5 +1,5 @@
 {
   "No members yet": "No members yet",
-  "{{count}} members": "One member",
-  "{{count}} members_plural": "{{count}} members"
+  "{{count, number}} members": "One member",
+  "{{count, number}} members_plural": "{{count, number}} members"
 }


### PR DESCRIPTION
#### Proposed Changes

In #1134 we show the number of tribes in the format `1234567890 members`, but before the migration it was `1,234,567,890` in English.
So we fix this and add also support for different number formats based on current i18n language. Based on [`number.toLocaleString(languageCode)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString).
![image](https://user-images.githubusercontent.com/7449720/71769146-77e0ce00-2f1d-11ea-83e3-d5cd4ab419ad.png)
![image](https://user-images.githubusercontent.com/7449720/71769151-95159c80-2f1d-11ea-91e4-33da6252e9cb.png)

#### Testing Instructions
- git switch or checkout to a branch `tribes-react-fix-translation`
- run the app (e.g. `npm start`)
- go to http://localhost:3000/tribes
- see that the numbers are formatted as announced here
- switch the language and see that the number format changes (e.g. from 50,000 to 50 000).

Now, if the membership of the tribes is too low, you may need to select the `Tribe` react component with _React Developer Tools_ and change the tribe.count (sub)property of that component.

![image](https://user-images.githubusercontent.com/7449720/71769116-1fa9cc00-2f1d-11ea-9a25-203474e8f004.png)

Continuous work on #1148. When it's approved, we'll squash it into #1134 because that's where it belongs.