### PR TITLE
Remove all IIFEs

### DIFF
--- a/modules/admin/client/config/admin.client.routes.js
+++ b/modules/admin/client/config/admin.client.routes.js
@@ -1,87 +1,85 @@
-(function () {
-  angular
-    .module('admin')
-    .config(AdminRoutes);
+angular
+  .module('admin')
+  .config(AdminRoutes);
 
-  /* @ngInject */
-  function AdminRoutes($stateProvider) {
+/* @ngInject */
+function AdminRoutes($stateProvider) {
 
-    $stateProvider.
-      state('admin', {
-        url: '/admin',
-        template: '<admin></admin>', // This should be lowercase
-        requiresRole: 'admin',
-        requiresAuth: true,
-        footerHidden: true,
-        data: {
-          pageTitle: 'Admin',
-        },
-      }).
-      state('admin-audit-log', {
-        url: '/admin/audit-log',
-        // `template` is Angular state so
-        // it should be lowercase, with dashes
-        // This is the bridge towards (and from) React
-        template: '<admin-audit-log></admin-audit-log>',
-        requiresRole: 'admin',
-        requiresAuth: true,
-        footerHidden: true,
-        data: {
-          pageTitle: 'Admin - Audit log',
-        },
-      }).
-      state('admin-acquisition-stories', {
-        url: '/admin/acquisition-stories',
-        // `template` is Angular state so
-        // it should be lowercase, with dashes
-        // This is the bridge towards (and from) React
-        template: '<admin-acquisition-stories></admin-acquisition-stories>',
-        requiresRole: 'admin',
-        requiresAuth: true,
-        footerHidden: true,
-        data: {
-          pageTitle: 'Admin - Acquisition stories',
-        },
-      }).
-      state('admin-messages', {
-        url: '/admin/messages',
-        // `template` is Angular state so
-        // it should be lowercase, with dashes
-        // This is the bridge towards (and from) React
-        template: '<admin-messages></admin-messages>',
-        requiresRole: 'admin',
-        requiresAuth: true,
-        footerHidden: true,
-        data: {
-          pageTitle: 'Admin - Messages',
-        },
-      }).
-      state('admin-search-users', {
-        url: '/admin/search-users',
-        // `template` is Angular state so
-        // it should be lowercase, with dashes
-        // This is the bridge towards (and from) React
-        template: '<admin-search-users></admin-search-users>',
-        requiresRole: 'admin',
-        requiresAuth: true,
-        footerHidden: true,
-        data: {
-          pageTitle: 'Admin - Search users',
-        },
-      }).
-      state('admin-user', {
-        url: '/admin/user',
-        // `template` is Angular state so
-        // it should be lowercase, with dashes
-        // This is the bridge towards (and from) React
-        template: '<admin-user></admin-user>',
-        requiresRole: 'admin',
-        requiresAuth: true,
-        footerHidden: true,
-        data: {
-          pageTitle: 'Admin - User',
-        },
-      });
+  $stateProvider.
+    state('admin', {
+      url: '/admin',
+      template: '<admin></admin>', // This should be lowercase
+      requiresRole: 'admin',
+      requiresAuth: true,
+      footerHidden: true,
+      data: {
+        pageTitle: 'Admin',
+      },
+    }).
+    state('admin-audit-log', {
+      url: '/admin/audit-log',
+      // `template` is Angular state so
+      // it should be lowercase, with dashes
+      // This is the bridge towards (and from) React
+      template: '<admin-audit-log></admin-audit-log>',
+      requiresRole: 'admin',
+      requiresAuth: true,
+      footerHidden: true,
+      data: {
+        pageTitle: 'Admin - Audit log',
+      },
+    }).
+    state('admin-acquisition-stories', {
+      url: '/admin/acquisition-stories',
+      // `template` is Angular state so
+      // it should be lowercase, with dashes
+      // This is the bridge towards (and from) React
+      template: '<admin-acquisition-stories></admin-acquisition-stories>',
+      requiresRole: 'admin',
+      requiresAuth: true,
+      footerHidden: true,
+      data: {
+        pageTitle: 'Admin - Acquisition stories',
+      },
+    }).
+    state('admin-messages', {
+      url: '/admin/messages',
+      // `template` is Angular state so
+      // it should be lowercase, with dashes
+      // This is the bridge towards (and from) React
+      template: '<admin-messages></admin-messages>',
+      requiresRole: 'admin',
+      requiresAuth: true,
+      footerHidden: true,
+      data: {
+        pageTitle: 'Admin - Messages',
+      },
+    }).
+    state('admin-search-users', {
+      url: '/admin/search-users',
+      // `template` is Angular state so
+      // it should be lowercase, with dashes
+      // This is the bridge towards (and from) React
+      template: '<admin-search-users></admin-search-users>',
+      requiresRole: 'admin',
+      requiresAuth: true,
+      footerHidden: true,
+      data: {
+        pageTitle: 'Admin - Search users',
+      },
+    }).
+    state('admin-user', {
+      url: '/admin/user',
+      // `template` is Angular state so
+      // it should be lowercase, with dashes
+      // This is the bridge towards (and from) React
+      template: '<admin-user></admin-user>',
+      requiresRole: 'admin',
+      requiresAuth: true,
+      footerHidden: true,
+      data: {
+        pageTitle: 'Admin - User',
+      },
+    });
 
-  }
-}());
+}

--- a/modules/contacts/client/config/contacts.client.routes.js
+++ b/modules/contacts/client/config/contacts.client.routes.js
@@ -1,59 +1,57 @@
 import contactAddTemplateUrl from '@/modules/contacts/client/views/add-contact.client.view.html';
 import contactConfirmTemplateUrl from '@/modules/contacts/client/views/confirm-contact.client.view.html';
 
-(function () {
-  angular
-    .module('contacts')
-    .config(ContactsRoutes);
+angular
+  .module('contacts')
+  .config(ContactsRoutes);
 
-  /* @ngInject */
-  function ContactsRoutes($stateProvider) {
+/* @ngInject */
+function ContactsRoutes($stateProvider) {
 
-    $stateProvider.
-      state('contactAdd', {
-        url: '/contact-add/:userId',
-        templateUrl: contactAddTemplateUrl,
-        requiresAuth: true,
-        controller: 'ContactAddController',
-        controllerAs: 'contactAdd',
-        resolve: {
-          // A string value resolves to a service
-          ContactByService: 'ContactByService',
-          UsersMini: 'UsersMini',
+  $stateProvider.
+    state('contactAdd', {
+      url: '/contact-add/:userId',
+      templateUrl: contactAddTemplateUrl,
+      requiresAuth: true,
+      controller: 'ContactAddController',
+      controllerAs: 'contactAdd',
+      resolve: {
+        // A string value resolves to a service
+        ContactByService: 'ContactByService',
+        UsersMini: 'UsersMini',
 
-          existingContact: function (ContactByService, $stateParams) {
-            return ContactByService.get({ userId: $stateParams.userId });
-          },
-
-          friend: function (UsersMini, $stateParams) {
-            return UsersMini.get({
-              userId: $stateParams.userId,
-            });
-          },
+        existingContact: function (ContactByService, $stateParams) {
+          return ContactByService.get({ userId: $stateParams.userId });
         },
-        data: {
-          pageTitle: 'Add contact',
-        },
-      }).
-      state('contactConfirm', {
-        url: '/contact-confirm/:contactId',
-        templateUrl: contactConfirmTemplateUrl,
-        requiresAuth: true,
-        controller: 'ContactConfirmController',
-        controllerAs: 'contactConfirm',
-        resolve: {
-          // A string value resolves to a service
-          Contact: 'Contact',
 
-          contact: function (Contact, $stateParams) {
-            return Contact.get({ contactId: $stateParams.contactId });
-          },
-
+        friend: function (UsersMini, $stateParams) {
+          return UsersMini.get({
+            userId: $stateParams.userId,
+          });
         },
-        data: {
-          pageTitle: 'Confirm contact',
-        },
-      });
+      },
+      data: {
+        pageTitle: 'Add contact',
+      },
+    }).
+    state('contactConfirm', {
+      url: '/contact-confirm/:contactId',
+      templateUrl: contactConfirmTemplateUrl,
+      requiresAuth: true,
+      controller: 'ContactConfirmController',
+      controllerAs: 'contactConfirm',
+      resolve: {
+        // A string value resolves to a service
+        Contact: 'Contact',
 
-  }
-}());
+        contact: function (Contact, $stateParams) {
+          return Contact.get({ contactId: $stateParams.contactId });
+        },
+
+      },
+      data: {
+        pageTitle: 'Confirm contact',
+      },
+    });
+
+}

--- a/modules/contacts/client/controllers/add-contact.client.controller.js
+++ b/modules/contacts/client/controllers/add-contact.client.controller.js
@@ -1,85 +1,83 @@
-(function () {
-  angular
-    .module('contacts')
-    .controller('ContactAddController', ContactAddController);
+angular
+  .module('contacts')
+  .controller('ContactAddController', ContactAddController);
 
-  /* @ngInject */
-  function ContactAddController($state, $stateParams, Contact, Authentication, friend, existingContact) {
+/* @ngInject */
+function ContactAddController($state, $stateParams, Contact, Authentication, friend, existingContact) {
 
-    // If no friend ID defined, go to elsewhere
-    if (!$stateParams.userId) {
-      $state.go('profile.about');
+  // If no friend ID defined, go to elsewhere
+  if (!$stateParams.userId) {
+    $state.go('profile.about');
+  }
+
+  // ViewModel
+  const vm = this;
+
+  // Exposed to the view
+  vm.add = add;
+  vm.isConnected = false;
+  vm.isLoading = false;
+  vm.friend = friend;
+
+  vm.contact = new Contact({
+    friendUserId: $stateParams.userId,
+    message: '<p>Hi!</p><p>I would like to add you as a contact.</p><p>- ' + Authentication.user.displayName + '</p>',
+  });
+
+  /**
+   * Initialize controller
+   */
+  init();
+  function init() {
+
+    // Prevent connecting with yourself
+    if ($stateParams.userId === Authentication.user._id) {
+      vm.isConnected = true;
+      vm.error = 'You cannot connect with yourself. That is just silly!';
+      return;
     }
 
-    // ViewModel
-    const vm = this;
+    // If contact doesn't exist, stop here
+    friend.$promise.then(
+      function () {
+        // User exists
+      },
+      function () {
+        vm.isConnected = true;
+        vm.error = 'User does not exist.';
+      },
+    );
 
-    // Exposed to the view
-    vm.add = add;
-    vm.isConnected = false;
-    vm.isLoading = false;
-    vm.friend = friend;
-
-    vm.contact = new Contact({
-      friendUserId: $stateParams.userId,
-      message: '<p>Hi!</p><p>I would like to add you as a contact.</p><p>- ' + Authentication.user.displayName + '</p>',
+    // If contact already exists, stop here
+    existingContact.$promise.then(function (response) {
+      if (response) {
+        vm.isConnected = true;
+        vm.success = response.confirmed ? 'You two are already connected. Great!' : 'Connection already initiated; now it has to be confirmed.';
+      }
+    }, function () {
+      vm.isConnected = false;
     });
 
-    /**
-     * Initialize controller
-     */
-    init();
-    function init() {
+  }
 
-      // Prevent connecting with yourself
-      if ($stateParams.userId === Authentication.user._id) {
-        vm.isConnected = true;
-        vm.error = 'You cannot connect with yourself. That is just silly!';
-        return;
+  // Add contact
+  function add() {
+    vm.isLoading = true;
+
+    vm.contact.$save(function () {
+      vm.isLoading = false;
+      vm.isConnected = true;
+      vm.success = 'Done! We sent an email to your contact and he/she still needs to confirm it.';
+    }, function (error) {
+      vm.isLoading = false;
+      if (error.status === 409) {
+        // 409 means contact already existed
+        vm.success = (error.data.confirmed) ? 'You two are already connected. Great!' : 'Connection already initiated; now it has to be confirmed.';
+      } else {
+        vm.error = error.message || 'Something went wrong. Try again.';
       }
-
-      // If contact doesn't exist, stop here
-      friend.$promise.then(
-        function () {
-          // User exists
-        },
-        function () {
-          vm.isConnected = true;
-          vm.error = 'User does not exist.';
-        },
-      );
-
-      // If contact already exists, stop here
-      existingContact.$promise.then(function (response) {
-        if (response) {
-          vm.isConnected = true;
-          vm.success = response.confirmed ? 'You two are already connected. Great!' : 'Connection already initiated; now it has to be confirmed.';
-        }
-      }, function () {
-        vm.isConnected = false;
-      });
-
-    }
-
-    // Add contact
-    function add() {
-      vm.isLoading = true;
-
-      vm.contact.$save(function () {
-        vm.isLoading = false;
-        vm.isConnected = true;
-        vm.success = 'Done! We sent an email to your contact and he/she still needs to confirm it.';
-      }, function (error) {
-        vm.isLoading = false;
-        if (error.status === 409) {
-          // 409 means contact already existed
-          vm.success = (error.data.confirmed) ? 'You two are already connected. Great!' : 'Connection already initiated; now it has to be confirmed.';
-        } else {
-          vm.error = error.message || 'Something went wrong. Try again.';
-        }
-      });
-
-    }
+    });
 
   }
-}());
+
+}

--- a/modules/contacts/client/controllers/confirm-contact.client.controller.js
+++ b/modules/contacts/client/controllers/confirm-contact.client.controller.js
@@ -1,55 +1,53 @@
-(function () {
-  angular
-    .module('contacts')
-    .controller('ContactConfirmController', ContactConfirmController);
+angular
+  .module('contacts')
+  .controller('ContactConfirmController', ContactConfirmController);
 
-  /* @ngInject */
-  function ContactConfirmController($stateParams, Authentication, contact) {
+/* @ngInject */
+function ContactConfirmController($stateParams, Authentication, contact) {
 
-    // ViewModel
-    const vm = this;
+  // ViewModel
+  const vm = this;
 
-    // If no friend ID defined, go to elsewhere
-    if (!$stateParams.contactId) {
-      vm.error = 'Something went wrong. Try again.';
-    }
-
-    vm.isConnected = false;
-    vm.isLoading = true;
-    vm.contact = contact;
-    vm.confirmContact = confirmContact;
-
-    // First fetch contact object, just to make it sure it exists
-    vm.contact.$promise.then(
-      // Got contact
-      function () {
-        vm.isLoading = false;
-        if (vm.contact.confirmed === true) {
-          vm.isConnected = true;
-          vm.success = 'You two are already connected. Great!';
-        } else if (vm.contact.userTo._id !== Authentication.user._id) {
-          vm.error = 'You must wait until they confirm your connection.';
-        }
-      },
-      // Error getting contact
-      function (errorResponse) {
-        vm.isWrongCode = true;
-        vm.error = errorResponse.status === 404 ? 'Could not find contact request. Check the confirmation link from email or you might be logged in with wrong user?' : 'Something went wrong. Try again.';
-      },
-    );
-
-    function confirmContact() {
-      vm.isLoading = true;
-      vm.contact.confirm = true;
-      vm.contact.$update(function () {
-        vm.isLoading = false;
-        vm.isConnected = true;
-        vm.success = 'You two are now connected!';
-      }, function (errorResponse) {
-        vm.isLoading = false;
-        vm.error = errorResponse.data.message || 'Something went wrong. Try again.';
-      });
-    }
-
+  // If no friend ID defined, go to elsewhere
+  if (!$stateParams.contactId) {
+    vm.error = 'Something went wrong. Try again.';
   }
-}());
+
+  vm.isConnected = false;
+  vm.isLoading = true;
+  vm.contact = contact;
+  vm.confirmContact = confirmContact;
+
+  // First fetch contact object, just to make it sure it exists
+  vm.contact.$promise.then(
+    // Got contact
+    function () {
+      vm.isLoading = false;
+      if (vm.contact.confirmed === true) {
+        vm.isConnected = true;
+        vm.success = 'You two are already connected. Great!';
+      } else if (vm.contact.userTo._id !== Authentication.user._id) {
+        vm.error = 'You must wait until they confirm your connection.';
+      }
+    },
+    // Error getting contact
+    function (errorResponse) {
+      vm.isWrongCode = true;
+      vm.error = errorResponse.status === 404 ? 'Could not find contact request. Check the confirmation link from email or you might be logged in with wrong user?' : 'Something went wrong. Try again.';
+    },
+  );
+
+  function confirmContact() {
+    vm.isLoading = true;
+    vm.contact.confirm = true;
+    vm.contact.$update(function () {
+      vm.isLoading = false;
+      vm.isConnected = true;
+      vm.success = 'You two are now connected!';
+    }, function (errorResponse) {
+      vm.isLoading = false;
+      vm.error = errorResponse.data.message || 'Something went wrong. Try again.';
+    });
+  }
+
+}

--- a/modules/contacts/client/controllers/list-contacts.client.controller.js
+++ b/modules/contacts/client/controllers/list-contacts.client.controller.js
@@ -1,33 +1,31 @@
-(function () {
-  angular
-    .module('contacts')
-    .controller('ContactsListController', ContactsListController);
+angular
+  .module('contacts')
+  .controller('ContactsListController', ContactsListController);
 
-  /* @ngInject */
-  function ContactsListController($scope, $rootScope) {
+/* @ngInject */
+function ContactsListController($scope, $rootScope) {
 
-    // ViewModel
-    const vm = this;
+  // ViewModel
+  const vm = this;
 
-    /**
-     * Fetch contact list for the profile currently open in parent view
-     * `profileCtrl` is a reference to a parent controller
-     */
-    vm.contacts = $scope.profileCtrl.contacts;
+  /**
+   * Fetch contact list for the profile currently open in parent view
+   * `profileCtrl` is a reference to a parent controller
+   */
+  vm.contacts = $scope.profileCtrl.contacts;
 
-    /**
-     * provide broadcast function for react removeContact component
-     */
-    vm.broadcastRemoveContact = function (contact) {
-      $rootScope.$broadcast('contactRemoved', contact);
-    };
+  /**
+   * provide broadcast function for react removeContact component
+   */
+  vm.broadcastRemoveContact = function (contact) {
+    $rootScope.$broadcast('contactRemoved', contact);
+  };
 
-    /**
-     * When contact removal modal signals that the contact was removed, remove it from this list as well
-     */
-    $scope.$on('contactRemoved', function (event, removedContact) {
-      vm.contacts.splice(vm.contacts.indexOf(removedContact), 1);
-    });
+  /**
+   * When contact removal modal signals that the contact was removed, remove it from this list as well
+   */
+  $scope.$on('contactRemoved', function (event, removedContact) {
+    vm.contacts.splice(vm.contacts.indexOf(removedContact), 1);
+  });
 
-  }
-}());
+}

--- a/modules/contacts/client/controllers/remove-contact.client.controller.js
+++ b/modules/contacts/client/controllers/remove-contact.client.controller.js
@@ -1,68 +1,66 @@
-(function () {
-  angular
-    .module('contacts')
-    .controller('ContactRemoveController', ContactRemoveController);
+angular
+  .module('contacts')
+  .controller('ContactRemoveController', ContactRemoveController);
 
-  /* @ngInject */
-  function ContactRemoveController($scope, $rootScope, $uibModalInstance, messageCenterService, Contact, Authentication) {
+/* @ngInject */
+function ContactRemoveController($scope, $rootScope, $uibModalInstance, messageCenterService, Contact, Authentication) {
 
-    const contactToRemove = $scope.contactToRemove;
+  const contactToRemove = $scope.contactToRemove;
 
-    // ViewModel
-    const vm = this;
+  // ViewModel
+  const vm = this;
 
-    // Exposed to the view
-    vm.isLoading = false;
-    vm.user = Authentication.user;
-    vm.contact = contactToRemove;
-    vm.removeContact = removeContact;
-    vm.cancelContactRemoval = cancelContactRemoval;
+  // Exposed to the view
+  vm.isLoading = false;
+  vm.user = Authentication.user;
+  vm.contact = contactToRemove;
+  vm.removeContact = removeContact;
+  vm.cancelContactRemoval = cancelContactRemoval;
 
-    // Different confirm button label and modal title depending on situation
+  // Different confirm button label and modal title depending on situation
 
-    if (angular.isDefined(contactToRemove.confirmed) && contactToRemove.confirmed === false && Authentication.user._id === contactToRemove.userFrom) {
-      // User is cancelling a request they sent
-      vm.labelConfirm = 'Yes, revoke request';
-      vm.labelTitle = 'Revoke contact request?';
-      vm.labelTime = 'Requested';
-    } else if (angular.isDefined(contactToRemove.confirmed) && contactToRemove.confirmed === false && Authentication.user._id === contactToRemove.userTo) {
-      // Decline received request
-      vm.labelConfirm = 'Yes, decline request';
-      vm.labelTitle = 'Decline contact request?';
-      vm.labelTime = 'Requested';
-    } else {
-      // Removing confirmed contact
-      vm.labelConfirm = 'Yes, remove contact';
-      vm.labelTitle = 'Remove contact?';
-      vm.labelTime = 'Connected since';
-    }
-
-    function removeContact() {
-      vm.isLoading = true;
-
-      // contact comes from the parent link()
-      Contact.delete({ contactId: contactToRemove._id },
-        // Success
-        function () {
-
-          // Let other controllers know that this was removed, so that they can react
-          $rootScope.$broadcast('contactRemoved', contactToRemove);
-
-          $uibModalInstance.dismiss('cancel');
-        },
-        // Error
-        function () {
-          vm.isLoading = false;
-          $uibModalInstance.dismiss('cancel');
-          messageCenterService.add('danger', 'Oops! Something went wrong. Try again later.', { timeout: 7000 });
-        },
-      );
-    }
-
-    // Close modal
-    function cancelContactRemoval() {
-      $uibModalInstance.dismiss('cancel');
-    }
-
+  if (angular.isDefined(contactToRemove.confirmed) && contactToRemove.confirmed === false && Authentication.user._id === contactToRemove.userFrom) {
+    // User is cancelling a request they sent
+    vm.labelConfirm = 'Yes, revoke request';
+    vm.labelTitle = 'Revoke contact request?';
+    vm.labelTime = 'Requested';
+  } else if (angular.isDefined(contactToRemove.confirmed) && contactToRemove.confirmed === false && Authentication.user._id === contactToRemove.userTo) {
+    // Decline received request
+    vm.labelConfirm = 'Yes, decline request';
+    vm.labelTitle = 'Decline contact request?';
+    vm.labelTime = 'Requested';
+  } else {
+    // Removing confirmed contact
+    vm.labelConfirm = 'Yes, remove contact';
+    vm.labelTitle = 'Remove contact?';
+    vm.labelTime = 'Connected since';
   }
-}());
+
+  function removeContact() {
+    vm.isLoading = true;
+
+    // contact comes from the parent link()
+    Contact.delete({ contactId: contactToRemove._id },
+      // Success
+      function () {
+
+        // Let other controllers know that this was removed, so that they can react
+        $rootScope.$broadcast('contactRemoved', contactToRemove);
+
+        $uibModalInstance.dismiss('cancel');
+      },
+      // Error
+      function () {
+        vm.isLoading = false;
+        $uibModalInstance.dismiss('cancel');
+        messageCenterService.add('danger', 'Oops! Something went wrong. Try again later.', { timeout: 7000 });
+      },
+    );
+  }
+
+  // Close modal
+  function cancelContactRemoval() {
+    $uibModalInstance.dismiss('cancel');
+  }
+
+}

--- a/modules/contacts/client/directives/tr-contact-remove.client.directive.js
+++ b/modules/contacts/client/directives/tr-contact-remove.client.directive.js
@@ -1,35 +1,33 @@
 import templateUrl from '@/modules/contacts/client/views/remove-contact.client.modal.html';
 
-(function () {
-  /**
-   * Remove contact directive to open up a modal to disconnect contacts
-   */
-  angular
-    .module('contacts')
-    .directive('trContactRemove', trContactRemoveDirective);
+/**
+ * Remove contact directive to open up a modal to disconnect contacts
+ */
+angular
+  .module('contacts')
+  .directive('trContactRemove', trContactRemoveDirective);
 
-  /* @ngInject */
-  function trContactRemoveDirective($uibModal) {
-    return {
-      restrict: 'A',
-      scope: {
-        contactToRemove: '=trContactRemove',
-      },
-      link: function (scope, element) {
+/* @ngInject */
+function trContactRemoveDirective($uibModal) {
+  return {
+    restrict: 'A',
+    scope: {
+      contactToRemove: '=trContactRemove',
+    },
+    link: function (scope, element) {
 
-        function openModal() {
-          $uibModal.open({
-            templateUrl,
-            controllerAs: 'removeContactModal',
-            controller: 'ContactRemoveController',
-            scope: scope,
-          });
-        }
+      function openModal() {
+        $uibModal.open({
+          templateUrl,
+          controllerAs: 'removeContactModal',
+          controller: 'ContactRemoveController',
+          scope: scope,
+        });
+      }
 
-        // Bind opening modal to the click
-        element.bind('click', openModal);
+      // Bind opening modal to the click
+      element.bind('click', openModal);
 
-      },
-    };
-  }
-}());
+    },
+  };
+}

--- a/modules/contacts/client/directives/tr-contact.client.directive.js
+++ b/modules/contacts/client/directives/tr-contact.client.directive.js
@@ -1,51 +1,49 @@
 import templateUrl from '@/modules/contacts/client/views/directives/tr-contact.client.view.html';
 
-(function () {
-  /**
-   * Produce a contact card
-   *
-   * Usage:
-   * ```
-   * <div tr-contact="contactObject" tr-contact-profile-id="currentProfileId"></div>
-   * ```
-   *
-   * You can also define avatar size by passing `tr-contact-avatar-size="128"`
-   */
-  angular
-    .module('contacts')
-    .directive('trContact', trContactDirective);
+/**
+ * Produce a contact card
+ *
+ * Usage:
+ * ```
+ * <div tr-contact="contactObject" tr-contact-profile-id="currentProfileId"></div>
+ * ```
+ *
+ * You can also define avatar size by passing `tr-contact-avatar-size="128"`
+ */
+angular
+  .module('contacts')
+  .directive('trContact', trContactDirective);
+
+/* @ngInject */
+function trContactDirective(Authentication) {
+  return {
+    templateUrl,
+    restrict: 'A',
+    replace: true,
+    scope: {
+      contact: '=trContact',
+      profileId: '=trContactProfileId',
+      avatarSize: '@trContactAvatarSize',
+      hideMeta: '=trContactHideMeta',
+    },
+    controller: trContactController,
+    controllerAs: 'contactCtrl',
+  };
 
   /* @ngInject */
-  function trContactDirective(Authentication) {
-    return {
-      templateUrl,
-      restrict: 'A',
-      replace: true,
-      scope: {
-        contact: '=trContact',
-        profileId: '=trContactProfileId',
-        avatarSize: '@trContactAvatarSize',
-        hideMeta: '=trContactHideMeta',
-      },
-      controller: trContactController,
-      controllerAs: 'contactCtrl',
-    };
+  function trContactController($scope) {
 
-    /* @ngInject */
-    function trContactController($scope) {
+    // ViewModel
+    const vm = this;
 
-      // ViewModel
-      const vm = this;
+    // Exposed to the view
+    vm.contact = $scope.contact;
+    vm.profileId = $scope.profileId;
+    vm.avatarSize = $scope.avatarSize || 128;
+    vm.user = Authentication.user;
 
-      // Exposed to the view
-      vm.contact = $scope.contact;
-      vm.profileId = $scope.profileId;
-      vm.avatarSize = $scope.avatarSize || 128;
-      vm.user = Authentication.user;
+    // Hides meta info such as "connected since"
+    vm.hideMeta = $scope.hideMeta || false;
 
-      // Hides meta info such as "connected since"
-      vm.hideMeta = $scope.hideMeta || false;
-
-    }
   }
-}());
+}

--- a/modules/contacts/client/services/contact-by.client.service.js
+++ b/modules/contacts/client/services/contact-by.client.service.js
@@ -1,18 +1,16 @@
-(function () {
-  // ContactBy factory used for communicating with the contacts REST endpoints
-  // Read contact by userId
-  angular
-    .module('contacts')
-    .factory('ContactByService', ContactByService);
+// ContactBy factory used for communicating with the contacts REST endpoints
+// Read contact by userId
+angular
+  .module('contacts')
+  .factory('ContactByService', ContactByService);
 
-  /* @ngInject */
-  function ContactByService($resource) {
-    return $resource('/api/contact-by/:userId', {
-      userId: '@id',
-    }, {
-      get: {
-        method: 'GET',
-      },
-    });
-  }
-}());
+/* @ngInject */
+function ContactByService($resource) {
+  return $resource('/api/contact-by/:userId', {
+    userId: '@id',
+  }, {
+    get: {
+      method: 'GET',
+    },
+  });
+}

--- a/modules/contacts/client/services/contact.client.service.js
+++ b/modules/contacts/client/services/contact.client.service.js
@@ -1,24 +1,22 @@
-(function () {
-  // Contact factory used for communicating with the contacts REST endpoints
-  // Read contact by contactId
-  angular
-    .module('contacts')
-    .factory('Contact', ContactService);
+// Contact factory used for communicating with the contacts REST endpoints
+// Read contact by contactId
+angular
+  .module('contacts')
+  .factory('Contact', ContactService);
 
-  /* @ngInject */
-  function ContactService($resource) {
-    return $resource('/api/contact/:contactId', {
-      contactId: '@_id',
-    }, {
-      get: {
-        method: 'GET',
-      },
-      update: {
-        method: 'PUT',
-      },
-      delete: {
-        method: 'DELETE',
-      },
-    });
-  }
-}());
+/* @ngInject */
+function ContactService($resource) {
+  return $resource('/api/contact/:contactId', {
+    contactId: '@_id',
+  }, {
+    get: {
+      method: 'GET',
+    },
+    update: {
+      method: 'PUT',
+    },
+    delete: {
+      method: 'DELETE',
+    },
+  });
+}

--- a/modules/contacts/client/services/contacts-list.client.service.js
+++ b/modules/contacts/client/services/contacts-list.client.service.js
@@ -1,14 +1,12 @@
-(function () {
-  // ContactsList factory used for communicating with the contacts REST endpoints
-  // Read contact list by userId
-  angular
-    .module('contacts')
-    .factory('ContactsListService', ContactsListService);
+// ContactsList factory used for communicating with the contacts REST endpoints
+// Read contact list by userId
+angular
+  .module('contacts')
+  .factory('ContactsListService', ContactsListService);
 
-  /* @ngInject */
-  function ContactsListService($resource) {
-    return $resource('/api/contacts/:listUserId', {
-      listUserId: '@id',
-    });
-  }
-}());
+/* @ngInject */
+function ContactsListService($resource) {
+  return $resource('/api/contacts/:listUserId', {
+    listUserId: '@id',
+  });
+}

--- a/modules/contacts/tests/client/add-contact.client.controller.tests.js
+++ b/modules/contacts/tests/client/add-contact.client.controller.tests.js
@@ -1,164 +1,161 @@
 import '@/modules/contacts/client/contacts.client.module';
 import AppConfig from '@/modules/core/client/app/config';
 
-(function () {
-  describe('ContactAddController', function () {
-    // Initialize global variables
-    let $httpBackend;
-    let Authentication;
-    let UsersMini;
-    let ContactByService;
-    let ContactAddController;
+describe('ContactAddController', function () {
+  // Initialize global variables
+  let $httpBackend;
+  let Authentication;
+  let UsersMini;
+  let ContactByService;
+  let ContactAddController;
 
-    const user1 = {
-      _id: 'user1',
-      displayName: 'User One',
-    };
+  const user1 = {
+    _id: 'user1',
+    displayName: 'User One',
+  };
 
-    const user2 = {
-      _id: 'user2',
-      displayName: 'User Two',
-    };
+  const user2 = {
+    _id: 'user2',
+    displayName: 'User Two',
+  };
 
-    const contactRequest = {
-      friendUserId: user2._id,
-      message: '<p>Hi!</p><p>I would like to add you as a contact.</p><p>- ' + user1.displayName + '</p>',
-    };
+  const contactRequest = {
+    friendUserId: user2._id,
+    message: '<p>Hi!</p><p>I would like to add you as a contact.</p><p>- ' + user1.displayName + '</p>',
+  };
 
-    // Load the main application module
-    beforeEach(function (done) {
-      angular.mock.module(AppConfig.appModuleName);
+  // Load the main application module
+  beforeEach(function (done) {
+    angular.mock.module(AppConfig.appModuleName);
+    done();
+  });
+
+  beforeEach(function (done) {
+    inject(function (_$httpBackend_, _Authentication_, _UsersMini_, _ContactByService_) {
+      $httpBackend = _$httpBackend_;
+      Authentication = _Authentication_;
+      UsersMini = _UsersMini_;
+      ContactByService = _ContactByService_;
       done();
     });
+  });
+
+  afterEach(function () {
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+  });
+
+  describe('logged in', function () {
 
     beforeEach(function (done) {
-      inject(function (_$httpBackend_, _Authentication_, _UsersMini_, _ContactByService_) {
-        $httpBackend = _$httpBackend_;
-        Authentication = _Authentication_;
-        UsersMini = _UsersMini_;
-        ContactByService = _ContactByService_;
-        done();
-      });
-    });
+      inject(function ($controller) {
 
-    afterEach(function () {
-      $httpBackend.verifyNoOutstandingExpectation();
-      $httpBackend.verifyNoOutstandingRequest();
-    });
+        Authentication.user = user1;
 
-    describe('logged in', function () {
-
-      beforeEach(function (done) {
-        inject(function ($controller) {
-
-          Authentication.user = user1;
-
-          ContactAddController = $controller('ContactAddController', {
-            friend: UsersMini.get({ userId: user2._id }),
-            existingContact: ContactByService.get({ userId: user2._id }),
-            $stateParams: { userId: user2._id },
-          });
-
-          done();
-
+        ContactAddController = $controller('ContactAddController', {
+          friend: UsersMini.get({ userId: user2._id }),
+          existingContact: ContactByService.get({ userId: user2._id }),
+          $stateParams: { userId: user2._id },
         });
+
+        done();
+
+      });
+    });
+
+    describe('when user does not exist', function () {
+
+      beforeEach(function () {
+        $httpBackend.expect('GET', '/api/users/mini/user2').respond(404);
+        $httpBackend.expect('GET', '/api/contact-by/user2').respond(404);
       });
 
-      describe('when user does not exist', function () {
+      it('displays an error message', function () {
+        $httpBackend.flush();
+        expect(ContactAddController.error).toBe('User does not exist.');
+      });
+
+    });
+
+    describe('when user exists', function () {
+
+      beforeEach(function () {
+        $httpBackend.expect('GET', '/api/users/mini/user2').respond(200, user2);
+      });
+
+      describe('when unconfirmed contact exists', function () {
 
         beforeEach(function () {
-          $httpBackend.expect('GET', '/api/users/mini/user2').respond(404);
+          $httpBackend.expect('GET', '/api/contact-by/user2').respond(200, { confirmed: false });
+        });
+
+        it('displays a success message', function () {
+          $httpBackend.flush();
+          expect(ContactAddController.success).toBe('Connection already initiated; now it has to be confirmed.');
+        });
+
+      });
+
+      describe('when confirmed contact exists', function () {
+
+        beforeEach(function () {
+          $httpBackend.expect('GET', '/api/contact-by/user2').respond(200, { confirmed: true });
+        });
+
+        it('Shows a nice message when the contact is confirmed', function () {
+          $httpBackend.flush();
+          expect(ContactAddController.success).toBe('You two are already connected. Great!');
+        });
+
+      });
+
+      describe('when no contact exists', function () {
+
+        beforeEach(function () {
           $httpBackend.expect('GET', '/api/contact-by/user2').respond(404);
         });
 
-        it('displays an error message', function () {
+        it('will make contact request', function () {
+          $httpBackend.expect('POST', '/api/contact', contactRequest).respond(200);
+          ContactAddController.add();
           $httpBackend.flush();
-          expect(ContactAddController.error).toBe('User does not exist.');
+          expect(ContactAddController.success).toBe('Done! We sent an email to your contact and he/she still needs to confirm it.');
         });
 
-      });
-
-      describe('when user exists', function () {
-
-        beforeEach(function () {
-          $httpBackend.expect('GET', '/api/users/mini/user2').respond(200, user2);
+        it('will make contact request with custom message', function () {
+          const customMessage = 'my custom message';
+          ContactAddController.contact.message = customMessage;
+          $httpBackend.expect('POST', '/api/contact', { friendUserId: user2._id, message: customMessage }).respond(200);
+          ContactAddController.add();
+          $httpBackend.flush();
+          expect(ContactAddController.success).toBe('Done! We sent an email to your contact and he/she still needs to confirm it.');
         });
 
-        describe('when unconfirmed contact exists', function () {
+
+        describe('when unconfirmed contact conflict', function () {
 
           beforeEach(function () {
-            $httpBackend.expect('GET', '/api/contact-by/user2').respond(200, { confirmed: false });
+            $httpBackend.expect('POST', '/api/contact', contactRequest).respond(409, { confirmed: false });
           });
 
-          it('displays a success message', function () {
+          it('displays a confirmation waiting success message', function () {
+            ContactAddController.add();
             $httpBackend.flush();
             expect(ContactAddController.success).toBe('Connection already initiated; now it has to be confirmed.');
           });
 
         });
 
-        describe('when confirmed contact exists', function () {
+        describe('with confirmed contact conflict', function () {
 
           beforeEach(function () {
-            $httpBackend.expect('GET', '/api/contact-by/user2').respond(200, { confirmed: true });
+            $httpBackend.expect('POST', '/api/contact', contactRequest).respond(409, { confirmed: true });
           });
 
-          it('Shows a nice message when the contact is confirmed', function () {
+          it('displays an already connected success message', function () {
+            ContactAddController.add();
             $httpBackend.flush();
             expect(ContactAddController.success).toBe('You two are already connected. Great!');
-          });
-
-        });
-
-        describe('when no contact exists', function () {
-
-          beforeEach(function () {
-            $httpBackend.expect('GET', '/api/contact-by/user2').respond(404);
-          });
-
-          it('will make contact request', function () {
-            $httpBackend.expect('POST', '/api/contact', contactRequest).respond(200);
-            ContactAddController.add();
-            $httpBackend.flush();
-            expect(ContactAddController.success).toBe('Done! We sent an email to your contact and he/she still needs to confirm it.');
-          });
-
-          it('will make contact request with custom message', function () {
-            const customMessage = 'my custom message';
-            ContactAddController.contact.message = customMessage;
-            $httpBackend.expect('POST', '/api/contact', { friendUserId: user2._id, message: customMessage }).respond(200);
-            ContactAddController.add();
-            $httpBackend.flush();
-            expect(ContactAddController.success).toBe('Done! We sent an email to your contact and he/she still needs to confirm it.');
-          });
-
-
-          describe('when unconfirmed contact conflict', function () {
-
-            beforeEach(function () {
-              $httpBackend.expect('POST', '/api/contact', contactRequest).respond(409, { confirmed: false });
-            });
-
-            it('displays a confirmation waiting success message', function () {
-              ContactAddController.add();
-              $httpBackend.flush();
-              expect(ContactAddController.success).toBe('Connection already initiated; now it has to be confirmed.');
-            });
-
-          });
-
-          describe('with confirmed contact conflict', function () {
-
-            beforeEach(function () {
-              $httpBackend.expect('POST', '/api/contact', contactRequest).respond(409, { confirmed: true });
-            });
-
-            it('displays an already connected success message', function () {
-              ContactAddController.add();
-              $httpBackend.flush();
-              expect(ContactAddController.success).toBe('You two are already connected. Great!');
-            });
-
           });
 
         });
@@ -168,4 +165,5 @@ import AppConfig from '@/modules/core/client/app/config';
     });
 
   });
-}());
+
+});

--- a/modules/contacts/tests/client/contacts.client.routes.tests.js
+++ b/modules/contacts/tests/client/contacts.client.routes.tests.js
@@ -1,107 +1,105 @@
 import '@/modules/contacts/client/contacts.client.module';
 import AppConfig from '@/modules/core/client/app/config';
 
-(function () {
-  describe('Contact Route Tests', function () {
-    // Initialize global variables
-    let $httpBackend;
+describe('Contact Route Tests', function () {
+  // Initialize global variables
+  let $httpBackend;
 
-    // We can start by loading the main application module
-    beforeEach(angular.mock.module(AppConfig.appModuleName));
+  // We can start by loading the main application module
+  beforeEach(angular.mock.module(AppConfig.appModuleName));
 
-    // The injector ignores leading and trailing underscores here (i.e. _$httpBackend_).
-    // This allows us to inject a service but then attach it to a variable
-    // with the same name as the service.
-    beforeEach(inject(function ($rootScope, _$httpBackend_) {
-      $httpBackend = _$httpBackend_;
-    }));
+  // The injector ignores leading and trailing underscores here (i.e. _$httpBackend_).
+  // This allows us to inject a service but then attach it to a variable
+  // with the same name as the service.
+  beforeEach(inject(function ($rootScope, _$httpBackend_) {
+    $httpBackend = _$httpBackend_;
+  }));
 
-    describe('Route Config for add contact', function () {
-      describe('Add contact Route', function () {
-        let mainstate;
-        beforeEach(inject(function ($state) {
-          // Test expected GET request
-          $httpBackend.when('GET', '/api/contact-by/123').respond(200, '');
-          $httpBackend.expectGET('/api/contact-by/123');
+  describe('Route Config for add contact', function () {
+    describe('Add contact Route', function () {
+      let mainstate;
+      beforeEach(inject(function ($state) {
+        // Test expected GET request
+        $httpBackend.when('GET', '/api/contact-by/123').respond(200, '');
+        $httpBackend.expectGET('/api/contact-by/123');
 
-          mainstate = $state.get('contactAdd');
-        }));
+        mainstate = $state.get('contactAdd');
+      }));
 
-        it('Should have the correct URL', function () {
-          expect(mainstate.url).toEqual('/contact-add/:userId');
-        });
-
-        it('Should not be abstract', function () {
-          expect(mainstate.abstract).toBe(undefined);
-        });
-
-        it('Should have templateUrl', function () {
-          expect(mainstate.templateUrl).toBe('/modules/contacts/views/add-contact.client.view.html');
-        });
+      it('Should have the correct URL', function () {
+        expect(mainstate.url).toEqual('/contact-add/:userId');
       });
 
-      describe('Handle Trailing Slash', function () {
-        beforeEach(inject(function ($state, $rootScope) {
-          // Test expected GET request
-          $httpBackend.when('GET', '/api/contact-by/123').respond(200, '');
-          $httpBackend.expectGET('/api/contact-by/123');
-          $httpBackend.when('GET', '/api/users/mini/123').respond(200, '');
-          $httpBackend.expectGET('/api/users/mini/123');
-
-          $state.go('contactAdd', { userId: '123' });
-          $rootScope.$digest();
-        }));
-
-        it('Should remove trailing slash', inject(function ($state, $location, $rootScope) {
-          $location.path('/contact-add/123/');
-          $rootScope.$digest();
-
-          expect($location.path()).toBe('/contact-add/123');
-        }));
+      it('Should not be abstract', function () {
+        expect(mainstate.abstract).toBe(undefined);
       });
 
+      it('Should have templateUrl', function () {
+        expect(mainstate.templateUrl).toBe('/modules/contacts/views/add-contact.client.view.html');
+      });
     });
 
-    describe('Route Config for confirm contact', function () {
-      describe('Confirm contact Route', function () {
-        let mainstate;
-        beforeEach(inject(function ($state) {
-          mainstate = $state.get('contactConfirm');
-        }));
+    describe('Handle Trailing Slash', function () {
+      beforeEach(inject(function ($state, $rootScope) {
+        // Test expected GET request
+        $httpBackend.when('GET', '/api/contact-by/123').respond(200, '');
+        $httpBackend.expectGET('/api/contact-by/123');
+        $httpBackend.when('GET', '/api/users/mini/123').respond(200, '');
+        $httpBackend.expectGET('/api/users/mini/123');
 
-        it('Should have the correct URL', function () {
-          expect(mainstate.url).toEqual('/contact-confirm/:contactId');
-        });
+        $state.go('contactAdd', { userId: '123' });
+        $rootScope.$digest();
+      }));
 
-        it('Should not be abstract', function () {
-          expect(mainstate.abstract).toBe(undefined);
-        });
+      it('Should remove trailing slash', inject(function ($state, $location, $rootScope) {
+        $location.path('/contact-add/123/');
+        $rootScope.$digest();
 
-        it('Should have templateUrl', function () {
-          expect(mainstate.templateUrl).toBe('/modules/contacts/views/confirm-contact.client.view.html');
-        });
-      });
-
-      describe('Handle Trailing Slash', function () {
-        beforeEach(inject(function ($state, $rootScope) {
-          // Test expected GET request
-          $httpBackend.when('GET', '/api/contact/123').respond(200, '');
-          $httpBackend.expectGET('/api/contact/123');
-
-          $state.go('contactConfirm', { contactId: '123' });
-          $rootScope.$digest();
-        }));
-
-        it('Should remove trailing slash', inject(function ($state, $location, $rootScope) {
-          $location.path('/contact-confirm/123/');
-          $rootScope.$digest();
-
-          expect($location.path()).toBe('/contact-confirm/123');
-        }));
-      });
-
+        expect($location.path()).toBe('/contact-add/123');
+      }));
     });
-
 
   });
-}());
+
+  describe('Route Config for confirm contact', function () {
+    describe('Confirm contact Route', function () {
+      let mainstate;
+      beforeEach(inject(function ($state) {
+        mainstate = $state.get('contactConfirm');
+      }));
+
+      it('Should have the correct URL', function () {
+        expect(mainstate.url).toEqual('/contact-confirm/:contactId');
+      });
+
+      it('Should not be abstract', function () {
+        expect(mainstate.abstract).toBe(undefined);
+      });
+
+      it('Should have templateUrl', function () {
+        expect(mainstate.templateUrl).toBe('/modules/contacts/views/confirm-contact.client.view.html');
+      });
+    });
+
+    describe('Handle Trailing Slash', function () {
+      beforeEach(inject(function ($state, $rootScope) {
+        // Test expected GET request
+        $httpBackend.when('GET', '/api/contact/123').respond(200, '');
+        $httpBackend.expectGET('/api/contact/123');
+
+        $state.go('contactConfirm', { contactId: '123' });
+        $rootScope.$digest();
+      }));
+
+      it('Should remove trailing slash', inject(function ($state, $location, $rootScope) {
+        $location.path('/contact-confirm/123/');
+        $rootScope.$digest();
+
+        expect($location.path()).toBe('/contact-confirm/123');
+      }));
+    });
+
+  });
+
+
+});

--- a/modules/contacts/tests/client/remove-contact.client.controller.tests.js
+++ b/modules/contacts/tests/client/remove-contact.client.controller.tests.js
@@ -2,96 +2,94 @@ import '@/modules/contacts/client/contacts.client.module';
 
 import AppConfig from '@/modules/core/client/app/config';
 
-(function () {
-  describe('ContactRemoveController', function () {
-    // Initialize global variables
-    let $httpBackend;
-    let Authentication;
-    let $rootScope;
-    let $scope;
-    let $uibModalInstance;
-    let messageCenterService;
-    let ContactRemoveController;
+describe('ContactRemoveController', function () {
+  // Initialize global variables
+  let $httpBackend;
+  let Authentication;
+  let $rootScope;
+  let $scope;
+  let $uibModalInstance;
+  let messageCenterService;
+  let ContactRemoveController;
 
-    const user1 = {
-      _id: 'user1',
-      displayName: 'User One',
+  const user1 = {
+    _id: 'user1',
+    displayName: 'User One',
+  };
+
+  const contactToRemove = {
+    _id: 'contact1',
+  };
+
+  // Load the main application module
+  beforeEach(angular.mock.module(AppConfig.appModuleName));
+
+  beforeEach(inject(function (_$httpBackend_, _Authentication_, _$rootScope_, _messageCenterService_) {
+    $httpBackend = _$httpBackend_;
+    Authentication = _Authentication_;
+
+    $rootScope = _$rootScope_;
+    spyOn($rootScope, '$broadcast').and.callThrough();
+
+    messageCenterService = _messageCenterService_;
+    spyOn(messageCenterService, 'add').and.callThrough();
+
+    $uibModalInstance = {
+      close: jest.fn(),
+      dismiss: jest.fn(),
     };
 
-    const contactToRemove = {
-      _id: 'contact1',
-    };
+    $scope = $rootScope.$new();
+    $scope.contactToRemove = contactToRemove;
+  }));
 
-    // Load the main application module
-    beforeEach(angular.mock.module(AppConfig.appModuleName));
+  afterEach(function () {
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+  });
 
-    beforeEach(inject(function (_$httpBackend_, _Authentication_, _$rootScope_, _messageCenterService_) {
-      $httpBackend = _$httpBackend_;
-      Authentication = _Authentication_;
+  describe('logged in', function () {
 
-      $rootScope = _$rootScope_;
-      spyOn($rootScope, '$broadcast').and.callThrough();
-
-      messageCenterService = _messageCenterService_;
-      spyOn(messageCenterService, 'add').and.callThrough();
-
-      $uibModalInstance = {
-        close: jest.fn(),
-        dismiss: jest.fn(),
-      };
-
-      $scope = $rootScope.$new();
-      $scope.contactToRemove = contactToRemove;
-    }));
-
-    afterEach(function () {
-      $httpBackend.verifyNoOutstandingExpectation();
-      $httpBackend.verifyNoOutstandingRequest();
+    beforeEach(function (done) {
+      inject(function ($controller) {
+        Authentication.user = user1;
+        ContactRemoveController = $controller('ContactRemoveController', {
+          $scope: $scope,
+          $uibModalInstance: $uibModalInstance,
+          messageCenterService: messageCenterService,
+        });
+        done();
+      });
     });
 
-    describe('logged in', function () {
+    it('sets the contact', function () {
+      expect(ContactRemoveController.contact).toBe(contactToRemove);
+    });
 
-      beforeEach(function (done) {
-        inject(function ($controller) {
-          Authentication.user = user1;
-          ContactRemoveController = $controller('ContactRemoveController', {
-            $scope: $scope,
-            $uibModalInstance: $uibModalInstance,
-            messageCenterService: messageCenterService,
-          });
-          done();
-        });
-      });
+    it('can remove the contact', function () {
+      $httpBackend.expect('DELETE', '/api/contact/' + contactToRemove._id).respond(200);
+      expect(ContactRemoveController.removeContact).toBeDefined();
+      ContactRemoveController.removeContact();
+      $httpBackend.flush();
+      expect($uibModalInstance.dismiss).toHaveBeenCalledWith('cancel');
+      expect($rootScope.$broadcast).toHaveBeenCalledWith('contactRemoved', contactToRemove);
+    });
 
-      it('sets the contact', function () {
-        expect(ContactRemoveController.contact).toBe(contactToRemove);
-      });
+    it('can be cancelled', function () {
+      expect(ContactRemoveController.cancelContactRemoval).toBeDefined();
+      ContactRemoveController.cancelContactRemoval();
+      expect($uibModalInstance.dismiss).toHaveBeenCalledWith('cancel');
+      expect($rootScope.$broadcast).not.toHaveBeenCalled();
+    });
 
-      it('can remove the contact', function () {
-        $httpBackend.expect('DELETE', '/api/contact/' + contactToRemove._id).respond(200);
-        expect(ContactRemoveController.removeContact).toBeDefined();
-        ContactRemoveController.removeContact();
-        $httpBackend.flush();
-        expect($uibModalInstance.dismiss).toHaveBeenCalledWith('cancel');
-        expect($rootScope.$broadcast).toHaveBeenCalledWith('contactRemoved', contactToRemove);
-      });
-
-      it('can be cancelled', function () {
-        expect(ContactRemoveController.cancelContactRemoval).toBeDefined();
-        ContactRemoveController.cancelContactRemoval();
-        expect($uibModalInstance.dismiss).toHaveBeenCalledWith('cancel');
-        expect($rootScope.$broadcast).not.toHaveBeenCalled();
-      });
-
-      it('handles backend errors gracefully', function () {
-        $httpBackend.expect('DELETE', '/api/contact/' + contactToRemove._id).respond(400);
-        ContactRemoveController.removeContact();
-        $httpBackend.flush();
-        expect($uibModalInstance.dismiss).toHaveBeenCalledWith('cancel');
-        expect(messageCenterService.add).toHaveBeenCalledWith('danger', 'Oops! Something went wrong. Try again later.', { timeout: 7000 });
-      });
-
+    it('handles backend errors gracefully', function () {
+      $httpBackend.expect('DELETE', '/api/contact/' + contactToRemove._id).respond(400);
+      ContactRemoveController.removeContact();
+      $httpBackend.flush();
+      expect($uibModalInstance.dismiss).toHaveBeenCalledWith('cancel');
+      expect(messageCenterService.add).toHaveBeenCalledWith('danger', 'Oops! Something went wrong. Try again later.', { timeout: 7000 });
     });
 
   });
-}());
+
+});

--- a/modules/core/client/config/core.client.config.js
+++ b/modules/core/client/config/core.client.config.js
@@ -1,24 +1,22 @@
-(function () {
-  angular
-    .module('core')
-    .config(CoreConfig);
+angular
+  .module('core')
+  .config(CoreConfig);
 
-  /* @ngInject */
-  function CoreConfig($httpProvider) {
-    // Config HTTP Error Handling
-    // Set the httpProvider "not authorized" interceptor
-    $httpProvider.interceptors.push(CoreServiceUnavailable);
-  }
+/* @ngInject */
+function CoreConfig($httpProvider) {
+  // Config HTTP Error Handling
+  // Set the httpProvider "not authorized" interceptor
+  $httpProvider.interceptors.push(CoreServiceUnavailable);
+}
 
-  /* @ngInject */
-  function CoreServiceUnavailable($q, $rootScope) {
-    return {
-      responseError: function (rejection) {
-        if (rejection.status === 503) {
-          $rootScope.$broadcast('serviceUnavailable');
-        }
-        return $q.reject(rejection);
-      },
-    };
-  }
-}());
+/* @ngInject */
+function CoreServiceUnavailable($q, $rootScope) {
+  return {
+    responseError: function (rejection) {
+      if (rejection.status === 503) {
+        $rootScope.$broadcast('serviceUnavailable');
+      }
+      return $q.reject(rejection);
+    },
+  };
+}

--- a/modules/core/client/config/core.client.routes.js
+++ b/modules/core/client/config/core.client.routes.js
@@ -1,38 +1,36 @@
 import templateUrl from '@/modules/core/client/views/404.client.view.html';
 
-(function () {
-  angular
-    .module('core')
-    .config(CoreRoutes);
+angular
+  .module('core')
+  .config(CoreRoutes);
 
-  /* @ngInject */
-  function CoreRoutes($stateProvider, $urlRouterProvider) {
+/* @ngInject */
+function CoreRoutes($stateProvider, $urlRouterProvider) {
 
-    // Remove trailing slash from routes
-    $urlRouterProvider.rule(function ($injector, $location) {
-      const path = $location.path();
-      const hasTrailingSlash = path.length > 1 && path[path.length - 1] === '/';
+  // Remove trailing slash from routes
+  $urlRouterProvider.rule(function ($injector, $location) {
+    const path = $location.path();
+    const hasTrailingSlash = path.length > 1 && path[path.length - 1] === '/';
 
-      if (hasTrailingSlash) {
+    if (hasTrailingSlash) {
 
-        // If last character is a slash, return the same url without the slash
-        const newPath = path.substr(0, path.length - 1);
-        $location.replace().path(newPath);
-      }
+      // If last character is a slash, return the same url without the slash
+      const newPath = path.substr(0, path.length - 1);
+      $location.replace().path(newPath);
+    }
+  });
+
+  // Redirect to 404 when route not found
+  $urlRouterProvider.otherwise('not-found');
+
+  $stateProvider.
+    state('not-found', {
+      url: '/not-found',
+      templateUrl,
+      footerHidden: true,
+      headerHidden: true,
+      data: {
+        pageTitle: 'Not found',
+      },
     });
-
-    // Redirect to 404 when route not found
-    $urlRouterProvider.otherwise('not-found');
-
-    $stateProvider.
-      state('not-found', {
-        url: '/not-found',
-        templateUrl,
-        footerHidden: true,
-        headerHidden: true,
-        data: {
-          pageTitle: 'Not found',
-        },
-      });
-  }
-}());
+}

--- a/modules/core/client/config/core.client.run.js
+++ b/modules/core/client/config/core.client.run.js
@@ -1,19 +1,17 @@
-(function () {
-  angular
-    .module('core')
-    .run(coreRun);
+angular
+  .module('core')
+  .run(coreRun);
 
-  /* @ngInject */
-  function coreRun(Facebook, push) {
+/* @ngInject */
+function coreRun(Facebook, push) {
 
-    // Attempt to initialize Facebook SDK on first page load
-    // If this fails, we'll try this again on successfull login
-    Facebook.init();
+  // Attempt to initialize Facebook SDK on first page load
+  // If this fails, we'll try this again on successfull login
+  Facebook.init();
 
-    // Initialize the push service if available
-    // It will check if user intended to enable push for this browser
-    // and setup the service-worker and backend registration accordingly
-    push.init();
+  // Initialize the push service if available
+  // It will check if user intended to enable push for this browser
+  // and setup the service-worker and backend registration accordingly
+  push.init();
 
-  }
-}());
+}

--- a/modules/core/client/controllers/app.client.controller.js
+++ b/modules/core/client/controllers/app.client.controller.js
@@ -1,282 +1,280 @@
 import '@/modules/users/client/users.client.module';
 import '@/modules/messages/client/messages.client.module';
 
-(function () {
+/**
+ * Application wide view controller
+ */
+angular
+  .module('core')
+  .controller('AppController', AppController);
+
+/* @ngInject */
+function AppController(
+  $location,
+  $scope,
+  $rootScope,
+  $uibModal,
+  $window,
+  $state,
+  $analytics,
+  Authentication,
+  SettingsFactory,
+  Languages,
+  locker,
+  PollMessagesCount,
+  push,
+  trNativeAppBridge) {
+
+  // ViewModel
+  const vm = this;
+
+  // Exposed to the view
+  vm.user = Authentication.user;
+  vm.appSettings = SettingsFactory.get();
+  vm.languageNames = Languages.get('object');
+  vm.pageTitle = $window.title;
+  vm.goHome = goHome;
+  vm.signout = signout;
+  vm.onWindowBlur = onWindowBlur;
+  vm.onWindowFocus = onWindowFocus;
+  vm.photoCredits = {};
+  vm.photoCreditsCount = 0;
+  vm.isFooterHidden = false;
+  vm.isHeaderHidden = false;
+  vm.isAboutPage = false;
+
   /**
-   * Application wide view controller
+   * Handle the window blur event
    */
-  angular
-    .module('core')
-    .controller('AppController', AppController);
+  function onWindowBlur() {
+    PollMessagesCount.setFrequency('low');
+  }
 
-  /* @ngInject */
-  function AppController(
-    $location,
-    $scope,
-    $rootScope,
-    $uibModal,
-    $window,
-    $state,
-    $analytics,
-    Authentication,
-    SettingsFactory,
-    Languages,
-    locker,
-    PollMessagesCount,
-    push,
-    trNativeAppBridge) {
+  /**
+   * handle window focus event
+   */
+  function onWindowFocus() {
+    PollMessagesCount.setFrequency('high');
+  }
 
-    // ViewModel
-    const vm = this;
+  // Default options for Medium-Editor directive used site wide
+  // @link https://github.com/yabwe/medium-editor/blob/master/OPTIONS.md
+  vm.editorOptions = {
+    disableReturn: false,
+    disableDoubleReturn: false,
+    disableExtraSpaces: false,
+    // Automatically turns URLs entered into
+    // the text field into HTML anchor tags
+    autoLink: false,
+    paste: {
+      // Forces pasting as plain text
+      forcePlainText: false,
+      // Cleans pasted content from different sources, like google docs etc
+      cleanPastedHTML: true,
+      // List of element attributes to remove during
+      // paste when `cleanPastedHTML` is `true`
+      cleanAttrs: [
+        'class', 'style', 'dir', 'id', 'title', 'target', 'tabindex',
+        'onclick', 'oncontextmenu', 'ondblclick', 'onmousedown', 'onmouseenter',
+        'onmouseleave', 'onmousemove', 'onmouseover', 'onmouseout', 'onmouseup',
+        'onwheel', 'onmousewheel', 'onmessage', 'ontouchstart', 'ontouchmove',
+        'ontouchend', 'ontouchcancel', 'onload', 'onscroll',
+      ],
+      // list of element tag names to remove during
+      // paste when `cleanPastedHTML` is `true`
+      cleanTags: [
+        'link', 'iframe', 'frameset', 'noframes', 'object', 'video', 'audio',
+        'track', 'source', 'base', 'basefont', 'applet', 'param', 'embed',
+        'script', 'meta', 'head', 'title', 'svg', 'script', 'style',
+        'input', 'textarea', 'form', 'hr', 'select', 'optgroup', 'label',
+        'img', 'canvas', 'area', 'map', 'figure', 'picture', 'figcaption',
+        'noscript',
+      ],
+      //  list of element tag names to unwrap (remove the element tag but retain
+      // its child elements) during paste when `cleanPastedHTML` is `true`
+      unwrapTags: [
+        '!DOCTYPE', 'html', 'body', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+        'table', 'th', 'tr', 'td', 'tbody', 'thead', 'tfoot', 'article',
+        'header', 'footer', 'section', 'aside', 'font', 'center', 'big',
+        'code', 'pre', 'small', 'button', 'label', 'fieldset', 'legend',
+        'datalist', 'keygen', 'output', 'nav', 'main', 'div', 'span',
+      ],
+    },
+    // Toolbar buttons which appear when highlighting text
+    toolbar: {
+      buttons: [{
+        name: 'bold',
+        contentDefault: '<span class="icon-bold"></span>',
+      }, {
+        name: 'italic',
+        contentDefault: '<span class="icon-italic"></span>',
+      }, {
+        name: 'underline',
+        contentDefault: '<span class="icon-underline"></span>',
+      }, {
+        name: 'anchor',
+        contentDefault: '<span class="icon-link"></span>',
+      }, {
+        name: 'quote',
+        contentDefault: '<span class="icon-quote"></span>',
+      }, {
+        name: 'unorderedlist',
+        contentDefault: '<span class="icon-list"></span>',
+      }],
+    },
+  };
 
-    // Exposed to the view
-    vm.user = Authentication.user;
-    vm.appSettings = SettingsFactory.get();
-    vm.languageNames = Languages.get('object');
-    vm.pageTitle = $window.title;
-    vm.goHome = goHome;
-    vm.signout = signout;
-    vm.onWindowBlur = onWindowBlur;
-    vm.onWindowFocus = onWindowFocus;
-    vm.photoCredits = {};
-    vm.photoCreditsCount = 0;
-    vm.isFooterHidden = false;
-    vm.isHeaderHidden = false;
-    vm.isAboutPage = false;
+  activate();
 
-    /**
-     * Handle the window blur event
-     */
-    function onWindowBlur() {
-      PollMessagesCount.setFrequency('low');
-    }
-
-    /**
-     * handle window focus event
-     */
-    function onWindowFocus() {
-      PollMessagesCount.setFrequency('high');
-    }
-
-    // Default options for Medium-Editor directive used site wide
-    // @link https://github.com/yabwe/medium-editor/blob/master/OPTIONS.md
-    vm.editorOptions = {
-      disableReturn: false,
-      disableDoubleReturn: false,
-      disableExtraSpaces: false,
-      // Automatically turns URLs entered into
-      // the text field into HTML anchor tags
-      autoLink: false,
-      paste: {
-        // Forces pasting as plain text
-        forcePlainText: false,
-        // Cleans pasted content from different sources, like google docs etc
-        cleanPastedHTML: true,
-        // List of element attributes to remove during
-        // paste when `cleanPastedHTML` is `true`
-        cleanAttrs: [
-          'class', 'style', 'dir', 'id', 'title', 'target', 'tabindex',
-          'onclick', 'oncontextmenu', 'ondblclick', 'onmousedown', 'onmouseenter',
-          'onmouseleave', 'onmousemove', 'onmouseover', 'onmouseout', 'onmouseup',
-          'onwheel', 'onmousewheel', 'onmessage', 'ontouchstart', 'ontouchmove',
-          'ontouchend', 'ontouchcancel', 'onload', 'onscroll',
-        ],
-        // list of element tag names to remove during
-        // paste when `cleanPastedHTML` is `true`
-        cleanTags: [
-          'link', 'iframe', 'frameset', 'noframes', 'object', 'video', 'audio',
-          'track', 'source', 'base', 'basefont', 'applet', 'param', 'embed',
-          'script', 'meta', 'head', 'title', 'svg', 'script', 'style',
-          'input', 'textarea', 'form', 'hr', 'select', 'optgroup', 'label',
-          'img', 'canvas', 'area', 'map', 'figure', 'picture', 'figcaption',
-          'noscript',
-        ],
-        //  list of element tag names to unwrap (remove the element tag but retain
-        // its child elements) during paste when `cleanPastedHTML` is `true`
-        unwrapTags: [
-          '!DOCTYPE', 'html', 'body', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
-          'table', 'th', 'tr', 'td', 'tbody', 'thead', 'tfoot', 'article',
-          'header', 'footer', 'section', 'aside', 'font', 'center', 'big',
-          'code', 'pre', 'small', 'button', 'label', 'fieldset', 'legend',
-          'datalist', 'keygen', 'output', 'nav', 'main', 'div', 'span',
-        ],
-      },
-      // Toolbar buttons which appear when highlighting text
-      toolbar: {
-        buttons: [{
-          name: 'bold',
-          contentDefault: '<span class="icon-bold"></span>',
-        }, {
-          name: 'italic',
-          contentDefault: '<span class="icon-italic"></span>',
-        }, {
-          name: 'underline',
-          contentDefault: '<span class="icon-underline"></span>',
-        }, {
-          name: 'anchor',
-          contentDefault: '<span class="icon-link"></span>',
-        }, {
-          name: 'quote',
-          contentDefault: '<span class="icon-quote"></span>',
-        }, {
-          name: 'unorderedlist',
-          contentDefault: '<span class="icon-list"></span>',
-        }],
-      },
-    };
-
-    activate();
+  /**
+   * Initialize controller
+   */
+  function activate() {
 
     /**
-     * Initialize controller
+     * Show "service unavailable" badge if http interceptor sends us this signal
      */
-    function activate() {
-
-      /**
-       * Show "service unavailable" badge if http interceptor sends us this signal
-       */
-      $rootScope.$on('serviceUnavailable', function () {
-        $uibModal.open({
-          ariaLabelledBy: 'Service unavailable',
-          template:
-            '<div class="modal-body lead text-center">' +
-            '  <p class="lead">Unfortunately Trustroots is down for a bit of maintenance right now.</p>' +
-            '  <p>We expect to be back in a couple minutes. Thanks for your patience.</p>' +
-            '  <p>In the meantime, check our ' +
-            '    <a href="https://twitter.com/trustroots" target="_blank">Twitter account</a> or ' +
-            '    <a href="http://status.trustroots.org/" target="_blank">status page</a> for news.</p>' +
-            '</div>' +
-            '<div class="modal-footer">' +
-            '  <button class="btn btn-primary" type="button" ng-click="$dismiss()">OK</button>' +
-            '</div>',
-        });
+    $rootScope.$on('serviceUnavailable', function () {
+      $uibModal.open({
+        ariaLabelledBy: 'Service unavailable',
+        template:
+          '<div class="modal-body lead text-center">' +
+          '  <p class="lead">Unfortunately Trustroots is down for a bit of maintenance right now.</p>' +
+          '  <p>We expect to be back in a couple minutes. Thanks for your patience.</p>' +
+          '  <p>In the meantime, check our ' +
+          '    <a href="https://twitter.com/trustroots" target="_blank">Twitter account</a> or ' +
+          '    <a href="http://status.trustroots.org/" target="_blank">status page</a> for news.</p>' +
+          '</div>' +
+          '<div class="modal-footer">' +
+          '  <button class="btn btn-primary" type="button" ng-click="$dismiss()">OK</button>' +
+          '</div>',
       });
+    });
 
-      /**
-       * Snif and apply user changes
-       */
-      $scope.$on('userUpdated', function () {
-        vm.user = Authentication.user;
-      });
+    /**
+     * Snif and apply user changes
+     */
+    $scope.$on('userUpdated', function () {
+      vm.user = Authentication.user;
+    });
 
-      /**
-       * Before page change
-       */
-      $scope.$on('$stateChangeStart', function (event, toState, toParams) {
+    /**
+     * Before page change
+     */
+    $scope.$on('$stateChangeStart', function (event, toState, toParams) {
 
-        if (toState.requiresRole) {
-          if (!Authentication.user) {
-            toState.requiresAuth = true;
-          }
-          // Check if user has the required role
-          else if (Authentication.user && !Authentication.user.roles.includes(toState.requiresRole)) {
-            event.preventDefault();
-            $window.alert('This page would require you to be a Trustroots volunteer. Wanna help us build Trustroots?');
-            $state.go('volunteering');
-          }
+      if (toState.requiresRole) {
+        if (!Authentication.user) {
+          toState.requiresAuth = true;
         }
-
-        // Redirect to login page if no user
-        if (toState.requiresAuth && !Authentication.user) {
-          // Cancel stateChange
+        // Check if user has the required role
+        else if (Authentication.user && !Authentication.user.roles.includes(toState.requiresRole)) {
           event.preventDefault();
-
-          // Save previous state
-          // See modules/users/client/controllers/authentication.client.controller.js for how they're used
-          $rootScope.signinState = toState.name;
-          $rootScope.signinStateParams = toParams;
-
-          // Show a special signup ad for certain pages if user isn't authenticated
-          // (Normally we just splash a signup page at this point)
-          if (toState.name === 'profile') {
-            $state.go('profile-signup');
-          } else if (toState.name === 'search' || toState.name === 'search.map') {
-            $state.go('search-signin', toParams || {});
-          } else {
-            // Or just continue to the signup page...
-            $state.go('signin', { 'continue': true });
-          }
+          $window.alert('This page would require you to be a Trustroots volunteer. Wanna help us build Trustroots?');
+          $state.go('volunteering');
         }
+      }
 
-      });
+      // Redirect to login page if no user
+      if (toState.requiresAuth && !Authentication.user) {
+        // Cancel stateChange
+        event.preventDefault();
 
-      /**
-       * After page change
-       */
-      $scope.$on('$stateChangeSuccess', function (event, toState) {
+        // Save previous state
+        // See modules/users/client/controllers/authentication.client.controller.js for how they're used
+        $rootScope.signinState = toState.name;
+        $rootScope.signinStateParams = toParams;
 
-        // Footer is hidden on these pages
-        vm.isFooterHidden = (angular.isDefined(toState.footerHidden) && toState.footerHidden === true);
+        // Show a special signup ad for certain pages if user isn't authenticated
+        // (Normally we just splash a signup page at this point)
+        if (toState.name === 'profile') {
+          $state.go('profile-signup');
+        } else if (toState.name === 'search' || toState.name === 'search.map') {
+          $state.go('search-signin', toParams || {});
+        } else {
+          // Or just continue to the signup page...
+          $state.go('signin', { 'continue': true });
+        }
+      }
 
-        // Header is hidden on these pages
-        vm.isHeaderHidden = (angular.isDefined(toState.headerHidden) && toState.headerHidden === true);
-
-        // Indicate we are browsing primary landing page
-        vm.isHomePage = toState.name === 'home';
-
-        // Reset photo copyrights on each page change
-        // trBoards directive hits in after this and we'll fill this with potential photo credits
-        vm.photoCredits = {};
-        vm.photoCreditsCount = 0;
-
-        // Reset page scroll on page change
-        $window.scrollTo(0, 0);
-      });
-
-      /**
-       * Sniff and apply photo credit changes
-       */
-      $scope.$on('photoCreditsUpdated', function (scope, photo) {
-        angular.extend(vm.photoCredits, photo);
-        vm.photoCreditsCount++;
-      });
-
-    }
+    });
 
     /**
-     * Determine where to direct user from "home" links
+     * After page change
      */
-    function goHome() {
-      if (Authentication.user) {
-        $state.go('search.map');
-      } else {
-        $state.go('home');
-      }
-    }
+    $scope.$on('$stateChangeSuccess', function (event, toState) {
+
+      // Footer is hidden on these pages
+      vm.isFooterHidden = (angular.isDefined(toState.footerHidden) && toState.footerHidden === true);
+
+      // Header is hidden on these pages
+      vm.isHeaderHidden = (angular.isDefined(toState.headerHidden) && toState.headerHidden === true);
+
+      // Indicate we are browsing primary landing page
+      vm.isHomePage = toState.name === 'home';
+
+      // Reset photo copyrights on each page change
+      // trBoards directive hits in after this and we'll fill this with potential photo credits
+      vm.photoCredits = {};
+      vm.photoCreditsCount = 0;
+
+      // Reset page scroll on page change
+      $window.scrollTo(0, 0);
+    });
 
     /**
-     * Sign out authenticated user
+     * Sniff and apply photo credit changes
      */
-    function signout($event) {
-      if ($event) {
-        $event.preventDefault();
-      }
-
-      $analytics.eventTrack('signout', {
-        category: 'authentication',
-        label: 'Sign out',
-      });
-
-      // Clear out session/localstorage
-      // @link https://github.com/tymondesigns/angular-locker#removing-items-from-locker
-      if (locker.supported()) {
-        locker.clean();
-      }
-
-      push.disable().finally(function () {
-        // Do the signout and refresh the page
-        $window.top.location.href = '/api/auth/signout';
-      });
-
-      // This will tell Mobile apps wrapping the site to disable push notifications at the device
-      if (angular.isFunction($window.postMessage)) {
-        $window.postMessage('unAuthenticated', $location.protocol() + '://' + $location.host());
-      }
-
-      // Signal native mobile app we've unauthenticated
-      trNativeAppBridge.signalUnAuthenticated();
-    }
-
+    $scope.$on('photoCreditsUpdated', function (scope, photo) {
+      angular.extend(vm.photoCredits, photo);
+      vm.photoCreditsCount++;
+    });
 
   }
-}());
+
+  /**
+   * Determine where to direct user from "home" links
+   */
+  function goHome() {
+    if (Authentication.user) {
+      $state.go('search.map');
+    } else {
+      $state.go('home');
+    }
+  }
+
+  /**
+   * Sign out authenticated user
+   */
+  function signout($event) {
+    if ($event) {
+      $event.preventDefault();
+    }
+
+    $analytics.eventTrack('signout', {
+      category: 'authentication',
+      label: 'Sign out',
+    });
+
+    // Clear out session/localstorage
+    // @link https://github.com/tymondesigns/angular-locker#removing-items-from-locker
+    if (locker.supported()) {
+      locker.clean();
+    }
+
+    push.disable().finally(function () {
+      // Do the signout and refresh the page
+      $window.top.location.href = '/api/auth/signout';
+    });
+
+    // This will tell Mobile apps wrapping the site to disable push notifications at the device
+    if (angular.isFunction($window.postMessage)) {
+      $window.postMessage('unAuthenticated', $location.protocol() + '://' + $location.host());
+    }
+
+    // Signal native mobile app we've unauthenticated
+    trNativeAppBridge.signalUnAuthenticated();
+  }
+
+
+}

--- a/modules/core/client/directives/message-center.client.directive.js
+++ b/modules/core/client/directives/message-center.client.directive.js
@@ -10,50 +10,48 @@
  * See usage instructions from https://github.com/e0ipso/message-center
  */
 
-(function () {
-  /**
-   * Directive for error/success/info etc notifications
-   */
-  angular
-    .module('core')
-    .directive('mcMessages', mcMessages);
+/**
+ * Directive for error/success/info etc notifications
+ */
+angular
+  .module('core')
+  .directive('mcMessages', mcMessages);
 
-  /* @ngInject */
-  function mcMessages($rootScope, messageCenterService) {
-    const templateString = '\
-    <div id="mc-messages-wrapper">\
-      <div class="alert alert-{{ message.type }} {{ animation }}" ng-repeat="message in mcMessages">\
-        <a class="close" ng-click="message.close();" data-dismiss="alert" aria-hidden="true">&times;</a>\
-        <span ng-switch on="message.html">\
-          <span ng-switch-when="true">\
-            <span ng-bind-html="message.message"></span>\
-          </span>\
-          <span ng-switch-default>\
-            {{ message.message }}\
-          </span>\
+/* @ngInject */
+function mcMessages($rootScope, messageCenterService) {
+  const templateString = '\
+  <div id="mc-messages-wrapper">\
+    <div class="alert alert-{{ message.type }} {{ animation }}" ng-repeat="message in mcMessages">\
+      <a class="close" ng-click="message.close();" data-dismiss="alert" aria-hidden="true">&times;</a>\
+      <span ng-switch on="message.html">\
+        <span ng-switch-when="true">\
+          <span ng-bind-html="message.message"></span>\
         </span>\
-      </div>\
+        <span ng-switch-default>\
+          {{ message.message }}\
+        </span>\
+      </span>\
     </div>\
-    ';
-    return {
-      restrict: 'EA',
-      template: templateString,
-      link: function (scope, element, attrs) {
-        // Bind the messages from the service to the root scope.
+  </div>\
+  ';
+  return {
+    restrict: 'EA',
+    template: templateString,
+    link: function (scope, element, attrs) {
+      // Bind the messages from the service to the root scope.
+      messageCenterService.flush();
+      const changeReaction = function () { // event, to, from
+        // Update 'unseen' messages to be marked as 'shown'.
+        messageCenterService.markShown();
+        // Remove the messages that have been shown.
+        messageCenterService.removeShown();
+        $rootScope.mcMessages = messageCenterService.mcMessages;
         messageCenterService.flush();
-        const changeReaction = function () { // event, to, from
-          // Update 'unseen' messages to be marked as 'shown'.
-          messageCenterService.markShown();
-          // Remove the messages that have been shown.
-          messageCenterService.removeShown();
-          $rootScope.mcMessages = messageCenterService.mcMessages;
-          messageCenterService.flush();
-        };
-        if (angular.isUndefined(messageCenterService.offlistener)) {
-          messageCenterService.offlistener = $rootScope.$on('$locationChangeSuccess', changeReaction);
-        }
-        scope.animation = attrs.animation || 'fade in';
-      },
-    };
-  }
-}());
+      };
+      if (angular.isUndefined(messageCenterService.offlistener)) {
+        messageCenterService.offlistener = $rootScope.$on('$locationChangeSuccess', changeReaction);
+      }
+      scope.animation = attrs.animation || 'fade in';
+    },
+  };
+}

--- a/modules/core/client/directives/tr-board-credits.client.directive.js
+++ b/modules/core/client/directives/tr-board-credits.client.directive.js
@@ -1,25 +1,23 @@
-(function () {
-  /**
-   * Print out credits for photos used at the page by tr-boards directive
-   */
-  angular
-    .module('core')
-    .directive('trBoardCredits', trBoardCreditsDirective);
+/**
+ * Print out credits for photos used at the page by tr-boards directive
+ */
+angular
+  .module('core')
+  .directive('trBoardCredits', trBoardCreditsDirective);
 
-  /* @ngInject */
-  function trBoardCreditsDirective() {
-    return {
-      template:
-        '<span class="boards-credits" ng-if="app.photoCreditsCount">' +
-        '  <span ng-if="app.photoCreditsCount === 1">Photo by</span>' +
-        '  <span ng-if="app.photoCreditsCount > 1">Photos by</span>' +
-        '   <span ng-repeat="(key, credit) in app.photoCredits track by key">' +
-        '    <a ng-href="{{ credit.url }}" ng-bind="credit.name" rel="noopener"></a>' +
-        '    <span ng-if="credit.license"> (<a ng-href="{{ credit.license_url }}" ng-bind-html="credit.license" title="License" rel="license noopener" aria-label="License"></a>)</span>' +
-        '    <span ng-if="($first && app.photoCreditsCount > 1) || $middle">, </span>' +
-        '  </span>' +
-        '</span>',
-      restrict: 'A',
-    };
-  }
-}());
+/* @ngInject */
+function trBoardCreditsDirective() {
+  return {
+    template:
+      '<span class="boards-credits" ng-if="app.photoCreditsCount">' +
+      '  <span ng-if="app.photoCreditsCount === 1">Photo by</span>' +
+      '  <span ng-if="app.photoCreditsCount > 1">Photos by</span>' +
+      '   <span ng-repeat="(key, credit) in app.photoCredits track by key">' +
+      '    <a ng-href="{{ credit.url }}" ng-bind="credit.name" rel="noopener"></a>' +
+      '    <span ng-if="credit.license"> (<a ng-href="{{ credit.license_url }}" ng-bind-html="credit.license" title="License" rel="license noopener" aria-label="License"></a>)</span>' +
+      '    <span ng-if="($first && app.photoCreditsCount > 1) || $middle">, </span>' +
+      '  </span>' +
+      '</span>',
+    restrict: 'A',
+  };
+}

--- a/modules/core/client/directives/tr-boards.client.directive.js
+++ b/modules/core/client/directives/tr-boards.client.directive.js
@@ -1,65 +1,63 @@
 import photos from '@/modules/core/client/services/photos.service';
 
-(function () {
-  /**
-   * Directive that simply picks a background image given element and emits copyright info down the scope.
-   *
-   * Usage:
-   * <div tr-boards="imageid">
-   *
-   * Or from many:
-   * <div tr-boards="['imageid1', 'imageid2']">
-   *
-   * To stop cover image being set for small screens (<= 480px width),
-   * use `tr-boards-ignore-small` attribute.
-   *
-   */
-  angular
-    .module('core')
-    .directive('trBoards', trBoardsDirective);
+/**
+ * Directive that simply picks a background image given element and emits copyright info down the scope.
+ *
+ * Usage:
+ * <div tr-boards="imageid">
+ *
+ * Or from many:
+ * <div tr-boards="['imageid1', 'imageid2']">
+ *
+ * To stop cover image being set for small screens (<= 480px width),
+ * use `tr-boards-ignore-small` attribute.
+ *
+ */
+angular
+  .module('core')
+  .directive('trBoards', trBoardsDirective);
 
-  /* @ngInject */
-  function trBoardsDirective($window) {
-    return {
-      restrict: 'A',
-      replace: false,
-      scope: {
-        trBoards: '=',
-      },
-      link: function (scope, elem, attrs) {
+/* @ngInject */
+function trBoardsDirective($window) {
+  return {
+    restrict: 'A',
+    replace: false,
+    scope: {
+      trBoards: '=',
+    },
+    link: function (scope, elem, attrs) {
 
-        // Don't set background images for mobile screens if defined so via attribute
-        if (angular.isDefined(attrs.trBoardsIgnoreSmall) && $window.innerWidth <= 480) {
-          return;
-        }
+      // Don't set background images for mobile screens if defined so via attribute
+      if (angular.isDefined(attrs.trBoardsIgnoreSmall) && $window.innerWidth <= 480) {
+        return;
+      }
 
-        // If requested photo is missing or request is invalid, rely on this photo
-        const defaultPhoto = 'bokeh';
+      // If requested photo is missing or request is invalid, rely on this photo
+      const defaultPhoto = 'bokeh';
 
-        // scope.trBoards might be an array (therefore just pick one key from it) or a string (thus just use it as is)
-        const key = angular.isArray(scope.trBoards) ? scope.trBoards[Math.floor(Math.random() * (scope.trBoards.length))] : scope.trBoards;
+      // scope.trBoards might be an array (therefore just pick one key from it) or a string (thus just use it as is)
+      const key = angular.isArray(scope.trBoards) ? scope.trBoards[Math.floor(Math.random() * (scope.trBoards.length))] : scope.trBoards;
 
-        // Pick the photo
-        const photo = photos[key] || photos[defaultPhoto];
+      // Pick the photo
+      const photo = photos[key] || photos[defaultPhoto];
 
-        // Add photo as a background to the element
-        elem.addClass('board-' + key);
+      // Add photo as a background to the element
+      elem.addClass('board-' + key);
 
-        // For small screens, if mobile image exists, use it
-        const file = ($window.innerWidth <= 480 && photo.file_mobile) ? photo.file_mobile : photo.file;
+      // For small screens, if mobile image exists, use it
+      const file = ($window.innerWidth <= 480 && photo.file_mobile) ? photo.file_mobile : photo.file;
 
-        elem.css({
-          'background-image': 'url(/img/board/' + file + ')',
-        });
+      elem.css({
+        'background-image': 'url(/img/board/' + file + ')',
+      });
 
-        // To prevent key being literally `key`: `{key: ...}`, we want it to be actual keyname such as `hitchroad`.
-        const photoObject = {};
-        photoObject[key] = photo;
+      // To prevent key being literally `key`: `{key: ...}`, we want it to be actual keyname such as `hitchroad`.
+      const photoObject = {};
+      photoObject[key] = photo;
 
-        // Send copyright info down the scope... something will pick it up! (pst, core/app-controller)
-        scope.$emit('photoCreditsUpdated', photoObject);
+      // Send copyright info down the scope... something will pick it up! (pst, core/app-controller)
+      scope.$emit('photoCreditsUpdated', photoObject);
 
-      },
-    };
-  }
-}());
+    },
+  };
+}

--- a/modules/core/client/directives/tr-date-select.client.directive.js
+++ b/modules/core/client/directives/tr-date-select.client.directive.js
@@ -1,147 +1,145 @@
-(function () {
-  /**
-   * @ngdoc directive
-   *
-   * @name trustroots:trDateSelect
-   *
-   * Fork of https://github.com/sambs/angular-sb-date-select with additional features:
-   * - allows choosing empty values
-   * - allows passing our own templates
-   *
-   * Relies on MomentJS
-   * @link http://momentjs.com/
-   *
-   */
-  angular.module('core')
+/**
+ * @ngdoc directive
+ *
+ * @name trustroots:trDateSelect
+ *
+ * Fork of https://github.com/sambs/angular-sb-date-select with additional features:
+ * - allows choosing empty values
+ * - allows passing our own templates
+ *
+ * Relies on MomentJS
+ * @link http://momentjs.com/
+ *
+ */
+angular.module('core')
 
-    .run(['$templateCache', function ($templateCache) {
+  .run(['$templateCache', function ($templateCache) {
 
-      const template = [
-        '<div class="sb-date-select">',
-        '  <select class="sb-date-select-day sb-date-select-select" ng-class="selectClass" ng-model="val.date" ng-options="d for d in dates track by d">',
-        '    <option value disabled selected>Day</option>',
-        '  </select>',
-        '  <select class="sb-date-select-month sb-date-select-select" ng-class="selectClass" ng-model="val.month" ng-options="m.value as m.name for m in months">',
-        '  <option value disabled>Month</option>',
-        '  </select>',
-        '  <select class="sb-date-select-year sb-date-select-select" ng-class="selectClass" ng-model="val.year" ng-options="y for y in years">',
-        '    <option value disabled selected>Year</option>',
-        '  </select>',
-        '</div>',
-      ];
+    const template = [
+      '<div class="sb-date-select">',
+      '  <select class="sb-date-select-day sb-date-select-select" ng-class="selectClass" ng-model="val.date" ng-options="d for d in dates track by d">',
+      '    <option value disabled selected>Day</option>',
+      '  </select>',
+      '  <select class="sb-date-select-month sb-date-select-select" ng-class="selectClass" ng-model="val.month" ng-options="m.value as m.name for m in months">',
+      '  <option value disabled>Month</option>',
+      '  </select>',
+      '  <select class="sb-date-select-year sb-date-select-select" ng-class="selectClass" ng-model="val.year" ng-options="y for y in years">',
+      '    <option value disabled selected>Year</option>',
+      '  </select>',
+      '</div>',
+    ];
 
-      $templateCache.put('tr-date-select.html', template.join(''));
+    $templateCache.put('tr-date-select.html', template.join(''));
 
-    }])
+  }])
 
-    .directive('trDateSelect', [function () {
+  .directive('trDateSelect', [function () {
 
-      return {
-        restrict: 'A',
-        replace: true,
-        templateUrl: function ($element, $attrs) {
-          return $attrs.templateUrl || 'tr-date-select.html';
-        },
-        require: 'ngModel',
-        scope: {
-          disabled: '=ngDisabled',
-          selectClass: '@trSelectClass',
-        },
+    return {
+      restrict: 'A',
+      replace: true,
+      templateUrl: function ($element, $attrs) {
+        return $attrs.templateUrl || 'tr-date-select.html';
+      },
+      require: 'ngModel',
+      scope: {
+        disabled: '=ngDisabled',
+        selectClass: '@trSelectClass',
+      },
 
-        link: function (scope, elem, attrs, ngModel) {
-          scope.val = {};
+      link: function (scope, elem, attrs, ngModel) {
+        scope.val = {};
 
-          const min = scope.min = moment(attrs.min || '1900-01-01');
-          const max = scope.max = moment(attrs.max); // Defaults to now
+        const min = scope.min = moment(attrs.min || '1900-01-01');
+        const max = scope.max = moment(attrs.max); // Defaults to now
 
-          scope.years = [];
+        scope.years = [];
 
-          for (let i = max.year(); i >= min.year(); i--) {
-            scope.years.push(i);
+        for (let i = max.year(); i >= min.year(); i--) {
+          scope.years.push(i);
+        }
+
+        scope.$watch('val.year', function () {
+          updateMonthOptions();
+        });
+
+        scope.$watchCollection('[val.month, val.year]', function () {
+          updateDateOptions();
+        });
+
+        scope.$watchCollection('[val.date, val.month, val.year]', function (newDate, oldDate) {
+          if (scope.val.year && scope.val.month && scope.val.date) {
+            if (!angular.equals(newDate, oldDate)) {
+              const m = moment([scope.val.year, scope.val.month - 1, scope.val.date]);
+              ngModel.$setViewValue(m.format('YYYY-MM-DD'));
+            }
+          } else {
+            ngModel.$setViewValue(null);
+          }
+        });
+
+        function updateMonthOptions() {
+          // Values begin at 1 to permit easier boolean testing
+          scope.months = [];
+
+          const minMonth = scope.val.year && min.isSame([scope.val.year], 'year') ? min.month() : 0;
+          const maxMonth = scope.val.year && max.isSame([scope.val.year], 'year') ? max.month() : 11;
+
+          const monthNames = moment.months();
+
+          for (let j = minMonth; j <= maxMonth; j++) {
+            scope.months.push({
+              name: monthNames[j],
+              value: j + 1,
+            });
           }
 
-          scope.$watch('val.year', function () {
-            updateMonthOptions();
-          });
+          if (scope.val.month - 1 > maxMonth || scope.val.month - 1 < minMonth) {
+            delete scope.val.month;
+          }
+        }
 
-          scope.$watchCollection('[val.month, val.year]', function () {
-            updateDateOptions();
-          });
+        function updateDateOptions() {
+          let minDate;
+          let maxDate;
 
-          scope.$watchCollection('[val.date, val.month, val.year]', function (newDate, oldDate) {
-            if (scope.val.year && scope.val.month && scope.val.date) {
-              if (!angular.equals(newDate, oldDate)) {
-                const m = moment([scope.val.year, scope.val.month - 1, scope.val.date]);
-                ngModel.$setViewValue(m.format('YYYY-MM-DD'));
-              }
-            } else {
-              ngModel.$setViewValue(null);
-            }
-          });
-
-          function updateMonthOptions() {
-            // Values begin at 1 to permit easier boolean testing
-            scope.months = [];
-
-            const minMonth = scope.val.year && min.isSame([scope.val.year], 'year') ? min.month() : 0;
-            const maxMonth = scope.val.year && max.isSame([scope.val.year], 'year') ? max.month() : 11;
-
-            const monthNames = moment.months();
-
-            for (let j = minMonth; j <= maxMonth; j++) {
-              scope.months.push({
-                name: monthNames[j],
-                value: j + 1,
-              });
-            }
-
-            if (scope.val.month - 1 > maxMonth || scope.val.month - 1 < minMonth) {
-              delete scope.val.month;
-            }
+          if (scope.val.year && scope.val.month && min.isSame([scope.val.year, scope.val.month - 1], 'month')) {
+            minDate = min.date();
+          } else {
+            minDate = 1;
           }
 
-          function updateDateOptions() {
-            let minDate;
-            let maxDate;
-
-            if (scope.val.year && scope.val.month && min.isSame([scope.val.year, scope.val.month - 1], 'month')) {
-              minDate = min.date();
-            } else {
-              minDate = 1;
-            }
-
-            if (scope.val.year && scope.val.month && max.isSame([scope.val.year, scope.val.month - 1], 'month')) {
-              maxDate = max.date();
-            } else if (scope.val.year && scope.val.month) {
-              maxDate = moment([scope.val.year, scope.val.month - 1]).daysInMonth();
-            } else {
-              maxDate = 31;
-            }
-
-            scope.dates = [];
-
-            for (let i = minDate; i <= maxDate; i++) {
-              scope.dates.push(i);
-            }
-            if (scope.val.date < minDate || scope.val.date > maxDate) {
-              delete scope.val.date;
-            }
+          if (scope.val.year && scope.val.month && max.isSame([scope.val.year, scope.val.month - 1], 'month')) {
+            maxDate = max.date();
+          } else if (scope.val.year && scope.val.month) {
+            maxDate = moment([scope.val.year, scope.val.month - 1]).daysInMonth();
+          } else {
+            maxDate = 31;
           }
 
-          // ngModel -> view
-          ngModel.$render = function () {
-            if (!ngModel.$viewValue) return;
+          scope.dates = [];
 
-            const m = moment(new Date(ngModel.$viewValue));
+          for (let i = minDate; i <= maxDate; i++) {
+            scope.dates.push(i);
+          }
+          if (scope.val.date < minDate || scope.val.date > maxDate) {
+            delete scope.val.date;
+          }
+        }
 
-            // Always use a dot in ng-model attrs...
-            scope.val = {
-              year: m.year(),
-              month: m.month() + 1,
-              date: m.date(),
-            };
+        // ngModel -> view
+        ngModel.$render = function () {
+          if (!ngModel.$viewValue) return;
+
+          const m = moment(new Date(ngModel.$viewValue));
+
+          // Always use a dot in ng-model attrs...
+          scope.val = {
+            year: m.year(),
+            month: m.month() + 1,
+            date: m.date(),
           };
-        },
-      };
-    }]);
-}());
+        };
+      },
+    };
+  }]);

--- a/modules/core/client/directives/tr-editor.client.directive.js
+++ b/modules/core/client/directives/tr-editor.client.directive.js
@@ -1,123 +1,121 @@
 import MediumEditor from 'medium-editor/dist/js/medium-editor';
 
-(function () {
-  /**
-   * Directive to embed Medium Editor instances
-   *
-   * Medium editor: https://github.com/yabwe/medium-editor
-   *
-   * Fork of https://github.com/thijsw/angular-medium-editor
-   * Original By Thijs Wijnmaalen (The MIT License)
-   *
-   *
-   * Use as an attribute:
-   * ```html
-   * <p tr-editor></p>
-   * ```
-   *
-   * Pass options with `tr-editor-options` attribute:
-   * ```html
-   * <p tr-editor tr-editor-options="options"></p>
-   * ```
-   *
-   * See MediumEditor's options documentation for details:
-   * @link https://github.com/yabwe/medium-editor#mediumeditor-options
-   *
-   * ## Examples
-   *
-   * #### Single line, no toolbar
-   * Header example limited to one line and no toolbar
-   * ```html
-   * <h1 ng-model="title"
-   *     tr-editor
-   *     tr-editor-options="{disableReturn: true, disableExtraSpaces: true, toolbar: false}"
-   *     data-placeholder="Enter a title"></h1>
-   * ```
-   *
-   * #### Multiline with custom toolbar
-   * Paragraph with support for multiple lines and customized toolbar buttons
-   * ```html
-   * <p ng-model="description"
-   *    tr-editor
-   *    tr-editor-options="{'toolbar': {'buttons': ['bold', 'italic', 'underline']}}"
-   *    data-placeholder="Enter a description"></p>
-   * ```
-   *
-   * #### Apply function on control+enter
-   * ```html
-   * <p tr-editor
-   *    tr-editor-on-ctrl-enter="functionname()">
-   * </p>
-   * ```
-   *
-   */
-  angular
-    .module('core')
-    .directive('trEditor', trEditorDirective);
+/**
+ * Directive to embed Medium Editor instances
+ *
+ * Medium editor: https://github.com/yabwe/medium-editor
+ *
+ * Fork of https://github.com/thijsw/angular-medium-editor
+ * Original By Thijs Wijnmaalen (The MIT License)
+ *
+ *
+ * Use as an attribute:
+ * ```html
+ * <p tr-editor></p>
+ * ```
+ *
+ * Pass options with `tr-editor-options` attribute:
+ * ```html
+ * <p tr-editor tr-editor-options="options"></p>
+ * ```
+ *
+ * See MediumEditor's options documentation for details:
+ * @link https://github.com/yabwe/medium-editor#mediumeditor-options
+ *
+ * ## Examples
+ *
+ * #### Single line, no toolbar
+ * Header example limited to one line and no toolbar
+ * ```html
+ * <h1 ng-model="title"
+ *     tr-editor
+ *     tr-editor-options="{disableReturn: true, disableExtraSpaces: true, toolbar: false}"
+ *     data-placeholder="Enter a title"></h1>
+ * ```
+ *
+ * #### Multiline with custom toolbar
+ * Paragraph with support for multiple lines and customized toolbar buttons
+ * ```html
+ * <p ng-model="description"
+ *    tr-editor
+ *    tr-editor-options="{'toolbar': {'buttons': ['bold', 'italic', 'underline']}}"
+ *    data-placeholder="Enter a description"></p>
+ * ```
+ *
+ * #### Apply function on control+enter
+ * ```html
+ * <p tr-editor
+ *    tr-editor-on-ctrl-enter="functionname()">
+ * </p>
+ * ```
+ *
+ */
+angular
+  .module('core')
+  .directive('trEditor', trEditorDirective);
 
-  /* @ngInject */
-  function trEditorDirective($parse) {
+/* @ngInject */
+function trEditorDirective($parse) {
 
-    function toInnerText(value) {
-      // eslint-disable-next-line angular/document-service
-      const tempEl = document.createElement('div');
-      tempEl.innerHTML = value;
-      const text = tempEl.textContent || '';
-      return text.trim();
-    }
-
-    return {
-      require: 'ngModel',
-      restrict: 'AE',
-      scope: {
-        trEditorOptions: '=',
-      },
-      link: function (scope, iElement, iAttrs, ngModel) {
-
-        const angularIElement = angular.element(iElement);
-
-        angularIElement.addClass('tr-editor');
-
-        ngModel.editor = new MediumEditor(iElement, scope.trEditorOptions);
-
-        ngModel.$render = function () {
-          iElement.html(ngModel.$viewValue || '');
-
-          const placeholder = ngModel.editor.getExtensionByName('placeholder');
-          if (placeholder) {
-            placeholder.updatePlaceholder(iElement[0]);
-          }
-        };
-
-        ngModel.$isEmpty = function (value) {
-          if (/[<>]/.test(value)) {
-            return toInnerText(value).length === 0;
-          } else if (value) {
-            return value.length === 0;
-          } else {
-            return true;
-          }
-        };
-
-        ngModel.editor.subscribe('editableInput', function (event, editable) {
-          ngModel.$setViewValue(editable.innerHTML.trim());
-        });
-
-        // On ctrl+enter
-        if (iAttrs.trEditorOnCtrlEnter) {
-          ngModel.editor.subscribe('editableKeydownEnter', function (event) {
-            if (event.ctrlKey) {
-              event.preventDefault();
-              // Apply linked function
-              $parse(iAttrs.trEditorOnCtrlEnter)(scope.$parent);
-            }
-          });
-        }
-
-        scope.$watch('trEditorOptions', function (trEditorOptions) {
-          ngModel.editor.init(iElement, trEditorOptions);
-        });
-      },
-    };
+  function toInnerText(value) {
+    // eslint-disable-next-line angular/document-service
+    const tempEl = document.createElement('div');
+    tempEl.innerHTML = value;
+    const text = tempEl.textContent || '';
+    return text.trim();
   }
-}());
+
+  return {
+    require: 'ngModel',
+    restrict: 'AE',
+    scope: {
+      trEditorOptions: '=',
+    },
+    link: function (scope, iElement, iAttrs, ngModel) {
+
+      const angularIElement = angular.element(iElement);
+
+      angularIElement.addClass('tr-editor');
+
+      ngModel.editor = new MediumEditor(iElement, scope.trEditorOptions);
+
+      ngModel.$render = function () {
+        iElement.html(ngModel.$viewValue || '');
+
+        const placeholder = ngModel.editor.getExtensionByName('placeholder');
+        if (placeholder) {
+          placeholder.updatePlaceholder(iElement[0]);
+        }
+      };
+
+      ngModel.$isEmpty = function (value) {
+        if (/[<>]/.test(value)) {
+          return toInnerText(value).length === 0;
+        } else if (value) {
+          return value.length === 0;
+        } else {
+          return true;
+        }
+      };
+
+      ngModel.editor.subscribe('editableInput', function (event, editable) {
+        ngModel.$setViewValue(editable.innerHTML.trim());
+      });
+
+      // On ctrl+enter
+      if (iAttrs.trEditorOnCtrlEnter) {
+        ngModel.editor.subscribe('editableKeydownEnter', function (event) {
+          if (event.ctrlKey) {
+            event.preventDefault();
+            // Apply linked function
+            $parse(iAttrs.trEditorOnCtrlEnter)(scope.$parent);
+          }
+        });
+      }
+
+      scope.$watch('trEditorOptions', function (trEditorOptions) {
+        ngModel.editor.init(iElement, trEditorOptions);
+      });
+    },
+  };
+}

--- a/modules/core/client/directives/tr-flashcards.client.directive.js
+++ b/modules/core/client/directives/tr-flashcards.client.directive.js
@@ -1,53 +1,51 @@
-(function () {
-  /**
-   * Directive to embed Trustroots host guide flashcards
-   *
-   * See also `guide` page under `pages` module.
-   *
-   * Use as an attribute:
-   * ```html
-   * <p tr-flashcards></p>
-   * ```
-   *
-   */
-  angular
-    .module('core')
-    .directive('trFlashcards', trFlashcardsDirective);
+/**
+ * Directive to embed Trustroots host guide flashcards
+ *
+ * See also `guide` page under `pages` module.
+ *
+ * Use as an attribute:
+ * ```html
+ * <p tr-flashcards></p>
+ * ```
+ *
+ */
+angular
+  .module('core')
+  .directive('trFlashcards', trFlashcardsDirective);
 
-  /* @ngInject */
-  function trFlashcardsDirective() {
-    return {
-      restrict: 'A',
-      template: '<a ui-sref="guide" class="tr-flashcards text-center font-brand-regular">' +
-                '  <small class="tr-flashcards-tip text-uppercase">Tip</small>' +
-                '  <p class="tr-flashcards-title" ng-bind="::flashTitle"></p>' +
-                '  <p class="tr-flashcards-content" ng-bind="::flashContent"></p>' +
-                '</a>',
-      link: function (scope) {
+/* @ngInject */
+function trFlashcardsDirective() {
+  return {
+    restrict: 'A',
+    template: '<a ui-sref="guide" class="tr-flashcards text-center font-brand-regular">' +
+              '  <small class="tr-flashcards-tip text-uppercase">Tip</small>' +
+              '  <p class="tr-flashcards-title" ng-bind="::flashTitle"></p>' +
+              '  <p class="tr-flashcards-content" ng-bind="::flashContent"></p>' +
+              '</a>',
+    link: function (scope) {
 
-        const flashcards = [{
-          title: 'Make sure your profile is complete',
-          content: 'You\'re much more likely to get a positive response if you have written a bit about yourself.',
-        }, {
-          title: 'Tell a little bit about yourself',
-          content: 'You\'re much more likely to get a positive response if you have written a bit about yourself.',
-        }, {
-          title: 'Explain to them why you are choosing them',
-          content: '...explaining that you are interested in meeting them, not just looking for free accommodation.',
-        }, {
-          title: 'Tell your host why you\'re on a trip',
-          content: 'What are your expectations in regards with going through their town?',
-        }, {
-          title: 'Trustroots is very much about spontaneous travel',
-          content: 'Don\'t write to people 2 months ahead.',
-        }];
+      const flashcards = [{
+        title: 'Make sure your profile is complete',
+        content: 'You\'re much more likely to get a positive response if you have written a bit about yourself.',
+      }, {
+        title: 'Tell a little bit about yourself',
+        content: 'You\'re much more likely to get a positive response if you have written a bit about yourself.',
+      }, {
+        title: 'Explain to them why you are choosing them',
+        content: '...explaining that you are interested in meeting them, not just looking for free accommodation.',
+      }, {
+        title: 'Tell your host why you\'re on a trip',
+        content: 'What are your expectations in regards with going through their town?',
+      }, {
+        title: 'Trustroots is very much about spontaneous travel',
+        content: 'Don\'t write to people 2 months ahead.',
+      }];
 
-        const randomFlashcard = flashcards[Math.floor(Math.random() * flashcards.length)];
+      const randomFlashcard = flashcards[Math.floor(Math.random() * flashcards.length)];
 
-        scope.flashTitle = randomFlashcard.title;
-        scope.flashContent = randomFlashcard.content;
+      scope.flashTitle = randomFlashcard.title;
+      scope.flashContent = randomFlashcard.content;
 
-      },
-    };
-  }
-}());
+    },
+  };
+}

--- a/modules/core/client/directives/tr-focustip.client.directive.js
+++ b/modules/core/client/directives/tr-focustip.client.directive.js
@@ -1,43 +1,41 @@
-(function () {
-  /**
-   * Directive that simply Adds a helper text under the input and shows/hides it on focus/blur
-   *
-   * Usage:
-   * <input tr-focustip="'Text to appear under input'" type="text">
-   *
-   * Note that currently this directive uses isolated scope, so you can't combine it with other isolate scope directives.
-   */
-  angular
-    .module('core')
-    .directive('trFocustip', trFocustipDirective);
+/**
+ * Directive that simply Adds a helper text under the input and shows/hides it on focus/blur
+ *
+ * Usage:
+ * <input tr-focustip="'Text to appear under input'" type="text">
+ *
+ * Note that currently this directive uses isolated scope, so you can't combine it with other isolate scope directives.
+ */
+angular
+  .module('core')
+  .directive('trFocustip', trFocustipDirective);
 
-  /* @ngInject */
-  function trFocustipDirective($compile) {
-    return {
-      restrict: 'A',
-      replace: false,
-      scope: {
-        trFocustip: '=',
-      },
-      link: function (scope, element) {
+/* @ngInject */
+function trFocustipDirective($compile) {
+  return {
+    restrict: 'A',
+    replace: false,
+    scope: {
+      trFocustip: '=',
+    },
+    link: function (scope, element) {
 
-        // Compiled template
-        // after() requires jQuery
-        const template = $compile('<div class="help-block" ng-show="enabled">' + scope.trFocustip + '</div>')(scope);
-        element.after(template);
+      // Compiled template
+      // after() requires jQuery
+      const template = $compile('<div class="help-block" ng-show="enabled">' + scope.trFocustip + '</div>')(scope);
+      element.after(template);
 
-        element
-          .bind('focus', function () {
-            // Enable only if there's some text to show
-            scope.enabled = (angular.isString(scope.trFocustip) && scope.trFocustip !== '');
-            scope.$apply();
-          })
-          .bind('blur', function () {
-            scope.enabled = false;
-            scope.$apply();
-          });
+      element
+        .bind('focus', function () {
+          // Enable only if there's some text to show
+          scope.enabled = (angular.isString(scope.trFocustip) && scope.trFocustip !== '');
+          scope.$apply();
+        })
+        .bind('blur', function () {
+          scope.enabled = false;
+          scope.$apply();
+        });
 
-      },
-    };
-  }
-}());
+    },
+  };
+}

--- a/modules/core/client/directives/tr-highlight-on-focus.client.directive.js
+++ b/modules/core/client/directives/tr-highlight-on-focus.client.directive.js
@@ -1,29 +1,27 @@
-(function () {
-  /**
-   * Directive that selects/highlights all text on input when clicking it.
-   *
-   * Usage:
-   * <input tr-select-on-click type="text">
-   *
-   * Thanks to Martin:
-   * @link http://stackoverflow.com/a/14996261/1984644
-   */
-  angular
-    .module('core')
-    .directive('trSelectOnClick', trSelectOnClickDirective);
+/**
+ * Directive that selects/highlights all text on input when clicking it.
+ *
+ * Usage:
+ * <input tr-select-on-click type="text">
+ *
+ * Thanks to Martin:
+ * @link http://stackoverflow.com/a/14996261/1984644
+ */
+angular
+  .module('core')
+  .directive('trSelectOnClick', trSelectOnClickDirective);
 
-  /* @ngInject */
-  function trSelectOnClickDirective($window) {
-    return {
-      restrict: 'A',
-      link: function (scope, element) {
-        element.on('click', function () {
-          if (!$window.getSelection().toString()) {
-            // Required for mobile Safari
-            this.setSelectionRange(0, this.value.length);
-          }
-        });
-      },
-    };
-  }
-}());
+/* @ngInject */
+function trSelectOnClickDirective($window) {
+  return {
+    restrict: 'A',
+    link: function (scope, element) {
+      element.on('click', function () {
+        if (!$window.getSelection().toString()) {
+          // Required for mobile Safari
+          this.setSelectionRange(0, this.value.length);
+        }
+      });
+    },
+  };
+}

--- a/modules/core/client/directives/tr-languages.client.directive.js
+++ b/modules/core/client/directives/tr-languages.client.directive.js
@@ -1,118 +1,116 @@
-(function () {
-  /**
-   * Directive to select languages
-   *
-   * Accepts and ouputs a list of language keys:
-   * `['fi_FI', 'fr_FR', ...]`
-   *
-   * Usage:
-   * ```
-   * <div tr-languages="scopeVariable"></div>
-   * ```
-   *
-   * Since directive is transcluded, you can do so:
-   * ```
-   * <div tr-languages="scopeVariable"
-          ng-change="changed()"
-          aria-label="Demo languages"></div>
-   * ```
-   */
-  angular
-    .module('core')
-    .directive('trLanguages', trLanguagesDirective);
+/**
+ * Directive to select languages
+ *
+ * Accepts and ouputs a list of language keys:
+ * `['fi_FI', 'fr_FR', ...]`
+ *
+ * Usage:
+ * ```
+ * <div tr-languages="scopeVariable"></div>
+ * ```
+ *
+ * Since directive is transcluded, you can do so:
+ * ```
+ * <div tr-languages="scopeVariable"
+        ng-change="changed()"
+        aria-label="Demo languages"></div>
+ * ```
+ */
+angular
+  .module('core')
+  .directive('trLanguages', trLanguagesDirective);
+
+/* @ngInject */
+function trLanguagesDirective() {
+  const directive = {
+    restrict: 'A',
+    replace: true,
+    transclude: true,
+    template: '<select multiple chosen' +
+              '  class="form-control"' +
+              '  placeholder-text-multiple="\'Type to search...\'"' +
+              '  no-results-text="\'Not found: \'"' +
+              '  search-contains="true"' +
+              '  ng-model="trLanguages.selectedLanguages"' +
+              '  ng-options="language.name for language in ::trLanguages.languages track by language.key">' +
+              '</select>',
+    scope: {
+      output: '=trLanguages',
+      onChange: '@trLanguagesOnChange',
+    },
+    controller: trLanguagesDirectiveController,
+    controllerAs: 'trLanguages',
+  };
+
+  return directive;
 
   /* @ngInject */
-  function trLanguagesDirective() {
-    const directive = {
-      restrict: 'A',
-      replace: true,
-      transclude: true,
-      template: '<select multiple chosen' +
-                '  class="form-control"' +
-                '  placeholder-text-multiple="\'Type to search...\'"' +
-                '  no-results-text="\'Not found: \'"' +
-                '  search-contains="true"' +
-                '  ng-model="trLanguages.selectedLanguages"' +
-                '  ng-options="language.name for language in ::trLanguages.languages track by language.key">' +
-                '</select>',
-      scope: {
-        output: '=trLanguages',
-        onChange: '@trLanguagesOnChange',
-      },
-      controller: trLanguagesDirectiveController,
-      controllerAs: 'trLanguages',
-    };
+  function trLanguagesDirectiveController($scope, Languages) {
 
-    return directive;
+    // View model
+    const vm = this;
 
-    /* @ngInject */
-    function trLanguagesDirectiveController($scope, Languages) {
+    // Exposed to the view
+    vm.languages = Languages.get('array');
+    vm.selectedLanguages = [];
 
-      // View model
-      const vm = this;
+    activate();
 
-      // Exposed to the view
-      vm.languages = Languages.get('array');
-      vm.selectedLanguages = [];
+    /**
+     * Initialize controller
+     */
+    function activate() {
 
-      activate();
+      // Ensure output is always an array, even on initialization
+      if (!$scope.output || !angular.isArray($scope.output)) {
+        $scope.output = [];
+      }
 
-      /**
-       * Initialize controller
-       */
-      function activate() {
+      // Pick previously populated languages
+      decodeSelectedLanguages();
 
-        // Ensure output is always an array, even on initialization
-        if (!$scope.output || !angular.isArray($scope.output)) {
-          $scope.output = [];
+      // Watch for changes in select and encode to array on changes
+      $scope.$watch('trLanguages.selectedLanguages', function (newValue, oldValue) {
+        if (newValue.length !== oldValue.length) {
+          encodeSelectedLanguages();
         }
+      });
+    }
 
-        // Pick previously populated languages
-        decodeSelectedLanguages();
-
-        // Watch for changes in select and encode to array on changes
-        $scope.$watch('trLanguages.selectedLanguages', function (newValue, oldValue) {
-          if (newValue.length !== oldValue.length) {
-            encodeSelectedLanguages();
+    /**
+     * Formats array for Chosen selector:
+     * `[{'fi_FI': 'Finnish'}, {'fr_FR': 'French'}, ... }]`
+     *
+     * This array is used only internally for this directive.
+     */
+    function decodeSelectedLanguages() {
+      const selections = [];
+      if ($scope.output.length > 0) {
+        $scope.output.forEach(function (key) {
+          if (angular.isString(key)) {
+            this.push({
+              'key': key,
+              'name': vm.languages[key],
+            });
           }
-        });
-      }
-
-      /**
-       * Formats array for Chosen selector:
-       * `[{'fi_FI': 'Finnish'}, {'fr_FR': 'French'}, ... }]`
-       *
-       * This array is used only internally for this directive.
-       */
-      function decodeSelectedLanguages() {
-        const selections = [];
-        if ($scope.output.length > 0) {
-          $scope.output.forEach(function (key) {
-            if (angular.isString(key)) {
-              this.push({
-                'key': key,
-                'name': vm.languages[key],
-              });
-            }
-          }, selections);
-          vm.selectedLanguages = selections;
-        }
-      }
-
-      /**
-       * Formats array of language keys from Chosen array:
-       * `['fi_FI', 'fr_FR', ...]`
-       *
-       * This is the output format for this directive.
-       */
-      function encodeSelectedLanguages() {
-        const keys = [];
-        angular.forEach(vm.selectedLanguages, function (language) {
-          this.push(String(language.key));
-        }, keys);
-        $scope.output = keys;
+        }, selections);
+        vm.selectedLanguages = selections;
       }
     }
 
+    /**
+     * Formats array of language keys from Chosen array:
+     * `['fi_FI', 'fr_FR', ...]`
+     *
+     * This is the output format for this directive.
+     */
+    function encodeSelectedLanguages() {
+      const keys = [];
+      angular.forEach(vm.selectedLanguages, function (language) {
+        this.push(String(language.key));
+      }, keys);
+      $scope.output = keys;
+    }
   }
-}());
+
+}

--- a/modules/core/client/directives/tr-location.client.directive.js
+++ b/modules/core/client/directives/tr-location.client.directive.js
@@ -1,151 +1,149 @@
-(function () {
-  /**
-   * Directive to extend <input> to have location auto suggestions
-   *
-   * Based on Typeahead (ui.bootstrap.typeahead)
-   * @link http://angular-ui.github.io/bootstrap/#!#typeahead
-   *
-   * Usage:
-   * `<input type="text" tr-location>`
-   *
-   * Usage with Angular-UI-Leaflet:
-   * `<input type="text" tr-location tr-location-center="leafletMapCenter" tr-location-bounds="leafletMapBounds">`
-   *
-   * You can also pass custom minimum length and delay options for Typeahead:
-   * `<input type="text" tr-location typeahead-min-length="2" typeahead-wait-ms="100">`
-   *
-   * Defaults for these are
-   * - typeahead-min-length: 3
-   * - typeahead-wait-ms: 300
-   *
-   * Note that this directive will re-render input element using $compile.
-   */
-  angular
-    .module('core')
-    .directive('trLocation', trLocationDirective);
+/**
+ * Directive to extend <input> to have location auto suggestions
+ *
+ * Based on Typeahead (ui.bootstrap.typeahead)
+ * @link http://angular-ui.github.io/bootstrap/#!#typeahead
+ *
+ * Usage:
+ * `<input type="text" tr-location>`
+ *
+ * Usage with Angular-UI-Leaflet:
+ * `<input type="text" tr-location tr-location-center="leafletMapCenter" tr-location-bounds="leafletMapBounds">`
+ *
+ * You can also pass custom minimum length and delay options for Typeahead:
+ * `<input type="text" tr-location typeahead-min-length="2" typeahead-wait-ms="100">`
+ *
+ * Defaults for these are
+ * - typeahead-min-length: 3
+ * - typeahead-wait-ms: 300
+ *
+ * Note that this directive will re-render input element using $compile.
+ */
+angular
+  .module('core')
+  .directive('trLocation', trLocationDirective);
 
-  /* @ngInject */
-  function trLocationDirective($compile, $timeout, LocationService) {
-    return {
-      restrict: 'A',
-      require: 'ngModel',
-      scope: {
-        value: '=ngModel',
-        // `?` makes these optional
-        limitLocationTypes: '=?',
-        trLocationChange: '=?',
-        trLocationNotfound: '=?',
-        trLocationCenter: '=?',
-        trLocationBounds: '=?',
-      },
-      replace: false,
-      link: function (scope, element, attr, ngModel) {
+/* @ngInject */
+function trLocationDirective($compile, $timeout, LocationService) {
+  return {
+    restrict: 'A',
+    require: 'ngModel',
+    scope: {
+      value: '=ngModel',
+      // `?` makes these optional
+      limitLocationTypes: '=?',
+      trLocationChange: '=?',
+      trLocationNotfound: '=?',
+      trLocationCenter: '=?',
+      trLocationBounds: '=?',
+    },
+    replace: false,
+    link: function (scope, element, attr, ngModel) {
 
-        // Event handler to stop submitting the surrounding form
-        element.bind('keydown keypress focus', function ($event) {
-          scope.trLocationNotfound = false;
+      // Event handler to stop submitting the surrounding form
+      element.bind('keydown keypress focus', function ($event) {
+        scope.trLocationNotfound = false;
 
-          // On enter
-          if ($event.which === 13) {
-            // Signal to controller that enter was pressed
-            scope.skipSuggestions = true;
-            $event.preventDefault();
-          } else {
-            scope.skipSuggestions = false;
-          }
-        });
-
-        // Attach Angular UI Bootstrap TypeAhead
-        // @link http://angular-ui.github.io/bootstrap/#!#typeahead
-        element.attr('typeahead-min-length', attr.typeaheadMinLength ? parseInt(attr.typeaheadMinLength, 10) : 3);
-        element.attr('typeahead-wait-ms', attr.typeaheadWaitMs ? parseInt(attr.typeaheadWaitMs, 10) : 300);
-        element.attr('typeahead-on-select', 'trLocation.onSelect($item, $model, $label, $event)');
-        element.attr('uib-typeahead', 'trTitle as address.trTitle for address in trLocation.searchSuggestions('
-          + getQueryParameters(scope.limitLocationTypes) + ')');
-
-        function getQueryParameters(limitLocationTypes) {
-          return limitLocationTypes ? '$viewValue, "country,region,place,locality,neighborhood"' : '$viewValue';
+        // On enter
+        if ($event.which === 13) {
+          // Signal to controller that enter was pressed
+          scope.skipSuggestions = true;
+          $event.preventDefault();
+        } else {
+          scope.skipSuggestions = false;
         }
+      });
 
-        // Stop infinite rendering on $compile
-        element.removeAttr('tr-location');
+      // Attach Angular UI Bootstrap TypeAhead
+      // @link http://angular-ui.github.io/bootstrap/#!#typeahead
+      element.attr('typeahead-min-length', attr.typeaheadMinLength ? parseInt(attr.typeaheadMinLength, 10) : 3);
+      element.attr('typeahead-wait-ms', attr.typeaheadWaitMs ? parseInt(attr.typeaheadWaitMs, 10) : 300);
+      element.attr('typeahead-on-select', 'trLocation.onSelect($item, $model, $label, $event)');
+      element.attr('uib-typeahead', 'trTitle as address.trTitle for address in trLocation.searchSuggestions('
+        + getQueryParameters(scope.limitLocationTypes) + ')');
 
-        $compile(element)(scope);
+      function getQueryParameters(limitLocationTypes) {
+        return limitLocationTypes ? '$viewValue, "country,region,place,locality,neighborhood"' : '$viewValue';
+      }
 
-        // Without this input value would be left empty due $compile
-        // @todo: any better way of handling this?
-        $timeout(function () {
-          ngModel.$setViewValue(scope.value);
-          ngModel.$render();
-        });
+      // Stop infinite rendering on $compile
+      element.removeAttr('tr-location');
 
-      },
-      controllerAs: 'trLocation',
-      controller: function ($scope, $timeout) {
+      $compile(element)(scope);
 
-        // View Model
-        const vm = this;
+      // Without this input value would be left empty due $compile
+      // @todo: any better way of handling this?
+      $timeout(function () {
+        ngModel.$setViewValue(scope.value);
+        ngModel.$render();
+      });
 
-        vm.searchSuggestions = searchSuggestions;
-        vm.onSelect = onSelect;
+    },
+    controllerAs: 'trLocation',
+    controller: function ($scope, $timeout) {
 
-        /**
-         * Get geolocation suggestions
-         */
-        function searchSuggestions(query, types) {
-          $scope.trLocationNotfound = false;
-          return LocationService.suggestions(query, types).then(function (suggestions) {
-            // Enter was pressed before we got these results, thus just pick first
-            if ($scope.skipSuggestions) {
-              $scope.skipSuggestions = false;
-              if (suggestions.length) {
-                locate(suggestions[0]);
-                $scope.value = suggestions[0].trTitle;
-              } else {
-                // Don't return suggestions list
-                $scope.trLocationNotfound = query;
-              }
-              // Don't return suggestions list
-              return [];
+      // View Model
+      const vm = this;
+
+      vm.searchSuggestions = searchSuggestions;
+      vm.onSelect = onSelect;
+
+      /**
+       * Get geolocation suggestions
+       */
+      function searchSuggestions(query, types) {
+        $scope.trLocationNotfound = false;
+        return LocationService.suggestions(query, types).then(function (suggestions) {
+          // Enter was pressed before we got these results, thus just pick first
+          if ($scope.skipSuggestions) {
+            $scope.skipSuggestions = false;
+            if (suggestions.length) {
+              locate(suggestions[0]);
+              $scope.value = suggestions[0].trTitle;
             } else {
-              // Return suggestions list
-              return suggestions;
+              // Don't return suggestions list
+              $scope.trLocationNotfound = query;
             }
-          });
-        }
-
-        /**
-         * When selecting autosuggested location
-         */
-        function onSelect($item, $model, $label) {
-          $timeout(function () {
-            $scope.value = $label;
-          });
-          locate($item);
-        }
-
-        /**
-         * Modify `trLocationCenter` or `trLocationBounds` objects
-         */
-        function locate(location) {
-
-          // Set center bounds and center coordinates for (Angular-UI-Leaflet) model
-          const bounds = LocationService.getBounds(location);
-          const center = LocationService.getCenter(location);
-
-          if (angular.isObject($scope.trLocationBounds) && bounds) {
-            $scope.trLocationBounds = bounds;
-          } else if (angular.isObject($scope.trLocationCenter) && center) {
-            angular.extend($scope.trLocationCenter, center);
-          } else if (angular.isFunction($scope.trLocationChange) && bounds) {
-            $scope.trLocationChange(bounds, 'bounds');
-          } else if (angular.isFunction($scope.trLocationChange) && center) {
-            $scope.trLocationChange(center, 'center');
+            // Don't return suggestions list
+            return [];
+          } else {
+            // Return suggestions list
+            return suggestions;
           }
+        });
+      }
 
+      /**
+       * When selecting autosuggested location
+       */
+      function onSelect($item, $model, $label) {
+        $timeout(function () {
+          $scope.value = $label;
+        });
+        locate($item);
+      }
+
+      /**
+       * Modify `trLocationCenter` or `trLocationBounds` objects
+       */
+      function locate(location) {
+
+        // Set center bounds and center coordinates for (Angular-UI-Leaflet) model
+        const bounds = LocationService.getBounds(location);
+        const center = LocationService.getCenter(location);
+
+        if (angular.isObject($scope.trLocationBounds) && bounds) {
+          $scope.trLocationBounds = bounds;
+        } else if (angular.isObject($scope.trLocationCenter) && center) {
+          angular.extend($scope.trLocationCenter, center);
+        } else if (angular.isFunction($scope.trLocationChange) && bounds) {
+          $scope.trLocationChange(bounds, 'bounds');
+        } else if (angular.isFunction($scope.trLocationChange) && center) {
+          $scope.trLocationChange(center, 'center');
         }
 
-      },
-    };
-  }
-}());
+      }
+
+    },
+  };
+}

--- a/modules/core/client/directives/tr-page-title.client.directive.js
+++ b/modules/core/client/directives/tr-page-title.client.directive.js
@@ -1,27 +1,25 @@
-(function () {
-  angular.module('core')
-    .directive('trPageTitle', trPageTitle);
+angular.module('core')
+  .directive('trPageTitle', trPageTitle);
 
-  /* @ngInject */
-  function trPageTitle($rootScope, $interpolate, $state, $window) {
-    const directive = {
-      restrict: 'A',
-      link: link,
-    };
+/* @ngInject */
+function trPageTitle($rootScope, $interpolate, $state, $window) {
+  const directive = {
+    restrict: 'A',
+    link: link,
+  };
 
-    return directive;
+  return directive;
 
-    function link(scope, element) {
-      $rootScope.$on('$stateChangeSuccess', listener);
+  function link(scope, element) {
+    $rootScope.$on('$stateChangeSuccess', listener);
 
-      function listener(event, toState) {
-        if (toState.data && toState.data.pageTitle) {
-          const stateTitle = $interpolate(toState.data.pageTitle)($state.$current.locals.globals);
-          element.html(stateTitle + ' - Trustroots');
-        } else {
-          element.html($window.title);
-        }
+    function listener(event, toState) {
+      if (toState.data && toState.data.pageTitle) {
+        const stateTitle = $interpolate(toState.data.pageTitle)($state.$current.locals.globals);
+        element.html(stateTitle + ' - Trustroots');
+      } else {
+        element.html($window.title);
       }
     }
   }
-}());
+}

--- a/modules/core/client/directives/tr-placeholder.client.directive.js
+++ b/modules/core/client/directives/tr-placeholder.client.directive.js
@@ -1,19 +1,17 @@
-(function () {
-  angular
-    .module('core')
-    .directive('trPlaceholder', trPlaceholderDirective);
+angular
+  .module('core')
+  .directive('trPlaceholder', trPlaceholderDirective);
 
-  function trPlaceholderDirective() {
-    return {
-      restrict: 'A',
-      replace: true,
-      scope: false,
-      template:
-        '<div class="tr-placeholder">' +
-          '<span>Lorem ipsum</span><br>' +
-          '<span>Lorem ipsum Lorem ipsum Lorem</span><br>' +
-          '<span>Lorem ipsum Lorem ipsum.</span>' +
-        '</div>',
-    };
-  }
-}());
+function trPlaceholderDirective() {
+  return {
+    restrict: 'A',
+    replace: true,
+    scope: false,
+    template:
+      '<div class="tr-placeholder">' +
+        '<span>Lorem ipsum</span><br>' +
+        '<span>Lorem ipsum Lorem ipsum Lorem</span><br>' +
+        '<span>Lorem ipsum Lorem ipsum.</span>' +
+      '</div>',
+  };
+}

--- a/modules/core/client/directives/tr-share-fb.client.directive.js
+++ b/modules/core/client/directives/tr-share-fb.client.directive.js
@@ -1,71 +1,69 @@
 /* global FB */
-(function () {
-  /**
-   * FB share button for current URL
-   *
-   * Usage:
-   * ```
-   * <div tr-share-facebook></div>
-   * ```
-   */
-  angular
-    .module('core')
-    .directive('trShareFb', trShareFbDirective);
+/**
+ * FB share button for current URL
+ *
+ * Usage:
+ * ```
+ * <div tr-share-facebook></div>
+ * ```
+ */
+angular
+  .module('core')
+  .directive('trShareFb', trShareFbDirective);
 
-  /* @ngInject */
-  function trShareFbDirective($rootScope, $window, Authentication) {
+/* @ngInject */
+function trShareFbDirective($rootScope, $window, Authentication) {
 
-    return {
-      restrict: 'A',
-      replace: true,
-      scope: false,
-      link: trShareFbDirectiveLink,
-    };
+  return {
+    restrict: 'A',
+    replace: true,
+    scope: false,
+    link: trShareFbDirectiveLink,
+  };
 
-    function trShareFbDirectiveLink(scope, element) {
+  function trShareFbDirectiveLink(scope, element) {
 
-      // Don't show share button if user isn't connected to FB
-      if (!Authentication.user || !Authentication.user.additionalProvidersData || !Authentication.user.additionalProvidersData.facebook) {
-        return;
-      }
-
-      // FB API ready, activate
-      if (angular.isDefined($window.FB)) {
-        activate();
-      } else {
-        // FB API was not ready, wait for the ready event
-        const watch = $rootScope.$on('facebookReady', function () {
-          activate();
-          // Removes watch:
-          watch();
-        });
-      }
-
-      /**
-       * Activate directive
-       * https://developers.facebook.com/docs/plugins/share-button
-       */
-      function activate() {
-
-        const button = '<div ' +
-          'class="fb-share-button" ' +
-          'data-href="' + location.href + '" ' +
-          'data-layout="button_count" ' +
-          'data-size="small" ' +
-          'data-mobile-iframe="true"> ' +
-          '  <a class="fb-xfbml-parse-ignore" ' +
-          '    target="_blank" ' +
-          '    href="https://www.facebook.com/sharer/sharer.php?u=' + encodeURIComponent(location.href) + '">' +
-          '      Share' +
-          '  </a> ' +
-          '</div>';
-
-        element.html(button);
-
-        // Parse XFBML code
-        FB.XFBML.parse(element[0]);
-      }
-
+    // Don't show share button if user isn't connected to FB
+    if (!Authentication.user || !Authentication.user.additionalProvidersData || !Authentication.user.additionalProvidersData.facebook) {
+      return;
     }
+
+    // FB API ready, activate
+    if (angular.isDefined($window.FB)) {
+      activate();
+    } else {
+      // FB API was not ready, wait for the ready event
+      const watch = $rootScope.$on('facebookReady', function () {
+        activate();
+        // Removes watch:
+        watch();
+      });
+    }
+
+    /**
+     * Activate directive
+     * https://developers.facebook.com/docs/plugins/share-button
+     */
+    function activate() {
+
+      const button = '<div ' +
+        'class="fb-share-button" ' +
+        'data-href="' + location.href + '" ' +
+        'data-layout="button_count" ' +
+        'data-size="small" ' +
+        'data-mobile-iframe="true"> ' +
+        '  <a class="fb-xfbml-parse-ignore" ' +
+        '    target="_blank" ' +
+        '    href="https://www.facebook.com/sharer/sharer.php?u=' + encodeURIComponent(location.href) + '">' +
+        '      Share' +
+        '  </a> ' +
+        '</div>';
+
+      element.html(button);
+
+      // Parse XFBML code
+      FB.XFBML.parse(element[0]);
+    }
+
   }
-}());
+}

--- a/modules/core/client/directives/tr-share-twitter.client.directive.js
+++ b/modules/core/client/directives/tr-share-twitter.client.directive.js
@@ -1,98 +1,96 @@
 /* global twttr */
-(function () {
-  /**
-   * Twitter share button for current URL
-   *
-   * Usage:
-   * ```
-   * <div tr-share-twitter></div>
-   * ```
-   *
-   * With predefined tweet text:
-   * ```
-   * <div tr-share-twitter data-text="Tweet text here"></div>
-   * ```
-   */
-  angular
-    .module('core')
-    .directive('trShareTwitter', trShareTwitterDirective);
+/**
+ * Twitter share button for current URL
+ *
+ * Usage:
+ * ```
+ * <div tr-share-twitter></div>
+ * ```
+ *
+ * With predefined tweet text:
+ * ```
+ * <div tr-share-twitter data-text="Tweet text here"></div>
+ * ```
+ */
+angular
+  .module('core')
+  .directive('trShareTwitter', trShareTwitterDirective);
 
-  /* @ngInject */
-  function trShareTwitterDirective($window, $document) {
+/* @ngInject */
+function trShareTwitterDirective($window, $document) {
 
-    return {
-      restrict: 'A',
-      replace: true,
-      scope: false,
-      link: trShareTwitterDirectiveLink,
-    };
+  return {
+    restrict: 'A',
+    replace: true,
+    scope: false,
+    link: trShareTwitterDirectiveLink,
+  };
 
-    function trShareTwitterDirectiveLink(scope, element, attrs) {
+  function trShareTwitterDirectiveLink(scope, element, attrs) {
 
-      activate();
+    activate();
 
-      /**
-       * Activate directive
-       * @link https://dev.twitter.com/web/tweet-button
-       */
-      function activate() {
+    /**
+     * Activate directive
+     * @link https://dev.twitter.com/web/tweet-button
+     */
+    function activate() {
 
-        let button = '<a href="https://twitter.com/share" class="twitter-share-button" data-via="trustroots"';
+      let button = '<a href="https://twitter.com/share" class="twitter-share-button" data-via="trustroots"';
 
-        // Predefined Tweet text
-        if (attrs.text) {
-          button += ' data-text="' + attrs.text + '"';
-        }
-
-        button += '>Tweet</a>';
-
-        // Place html to DOM
-        element.html(button);
-
-        if (angular.isDefined($window.twttr)) {
-          // Render tweet button
-          twttr.widgets.load();
-        } else {
-          // No Twitter Widget JS present, initialize it and it'll do the rendering
-          initTwitterJS();
-        }
+      // Predefined Tweet text
+      if (attrs.text) {
+        button += ' data-text="' + attrs.text + '"';
       }
 
-      /**
-       * Initialize Twitter Widgets JS if it's not loaded yet
-       * @link https://dev.twitter.com/web/javascript/loading
-       *
-       * 1. Assign a HTML element ID of twitter-wjs to easily identify
-       *    if the  JavaScript file already exists on the page.
-       *    Exit early if the ID already exists.
-       *
-       * 2. Asynchronously load Twitter’s widget JavaScript.
-       *
-       * 3. Initialize an asynchronous function queue to hold functions
-       *    dependent on Twitter’s widgets JavaScript until the script
-       *    is available.
-       */
-      function initTwitterJS() {
+      button += '>Tweet</a>';
 
-        $window.twttr = (function (d, s, id) {
-          const fjs = d.getElementsByTagName(s)[0];
-          const t = $window.twttr || {};
-          if (d.getElementById(id)) return t;
-          const js = d.createElement(s);
-          js.id = id;
-          js.src = 'https://platform.twitter.com/widgets.js';
-          fjs.parentNode.insertBefore(js, fjs);
+      // Place html to DOM
+      element.html(button);
 
-          t._e = [];
-          t.ready = function (f) {
-            t._e.push(f);
-          };
-
-          return t;
-        }($document[0], 'script', 'twitter-wjs'));
-
+      if (angular.isDefined($window.twttr)) {
+        // Render tweet button
+        twttr.widgets.load();
+      } else {
+        // No Twitter Widget JS present, initialize it and it'll do the rendering
+        initTwitterJS();
       }
+    }
+
+    /**
+     * Initialize Twitter Widgets JS if it's not loaded yet
+     * @link https://dev.twitter.com/web/javascript/loading
+     *
+     * 1. Assign a HTML element ID of twitter-wjs to easily identify
+     *    if the  JavaScript file already exists on the page.
+     *    Exit early if the ID already exists.
+     *
+     * 2. Asynchronously load Twitter’s widget JavaScript.
+     *
+     * 3. Initialize an asynchronous function queue to hold functions
+     *    dependent on Twitter’s widgets JavaScript until the script
+     *    is available.
+     */
+    function initTwitterJS() {
+
+      $window.twttr = (function (d, s, id) {
+        const fjs = d.getElementsByTagName(s)[0];
+        const t = $window.twttr || {};
+        if (d.getElementById(id)) return t;
+        const js = d.createElement(s);
+        js.id = id;
+        js.src = 'https://platform.twitter.com/widgets.js';
+        fjs.parentNode.insertBefore(js, fjs);
+
+        t._e = [];
+        t.ready = function (f) {
+          t._e.push(f);
+        };
+
+        return t;
+      }($document[0], 'script', 'twitter-wjs'));
 
     }
+
   }
-}());
+}

--- a/modules/core/client/directives/tr-spinner.client.directive.js
+++ b/modules/core/client/directives/tr-spinner.client.directive.js
@@ -1,62 +1,60 @@
-(function () {
-  angular
-    .module('core')
-    .directive('trSpinner', trSpinnerDirective);
+angular
+  .module('core')
+  .directive('trSpinner', trSpinnerDirective);
 
-  function trSpinnerDirective() {
-    return {
-      restrict: 'E',
-      link: function (scope, element, attrs) {
+function trSpinnerDirective() {
+  return {
+    restrict: 'E',
+    link: function (scope, element, attrs) {
 
-        // @link https://haltersweb.github.io/Accessibility/svg.html
-        function generateSVGMarkup(size, square, stroke) {
-          return '<svg class="spinner spinner-' + size + '"' +
-                 '  width="' + square + 'px"' +
-                 '  height="' + square + 'px"' +
-                 '  viewBox="0 0 ' + (square + 1) + ' ' + (square + 1) + '"' +
-                 '  role="alertdialog"' +
-                 '  aria-busy="true"' +
-                 '  aria-live="assertive"' +
-                 '  aria-label="Loading, please wait."' +
-                 '  xmlns="http://www.w3.org/2000/svg">' +
-                 '  <circle class="spinner-path"' +
-                 '          fill="none"' +
-                 '          stroke-width="' + stroke + '"' +
-                 '          stroke-linecap="round"' +
-                 '          cx="' + ((square + 1) / 2) + '"' +
-                 '          cy="' + ((square + 1) / 2) + '"' +
-                 '          r="' + (((square + 1) / 2) - stroke) + '"></circle>' +
-                 '</svg>';
+      // @link https://haltersweb.github.io/Accessibility/svg.html
+      function generateSVGMarkup(size, square, stroke) {
+        return '<svg class="spinner spinner-' + size + '"' +
+               '  width="' + square + 'px"' +
+               '  height="' + square + 'px"' +
+               '  viewBox="0 0 ' + (square + 1) + ' ' + (square + 1) + '"' +
+               '  role="alertdialog"' +
+               '  aria-busy="true"' +
+               '  aria-live="assertive"' +
+               '  aria-label="Loading, please wait."' +
+               '  xmlns="http://www.w3.org/2000/svg">' +
+               '  <circle class="spinner-path"' +
+               '          fill="none"' +
+               '          stroke-width="' + stroke + '"' +
+               '          stroke-linecap="round"' +
+               '          cx="' + ((square + 1) / 2) + '"' +
+               '          cy="' + ((square + 1) / 2) + '"' +
+               '          r="' + (((square + 1) / 2) - stroke) + '"></circle>' +
+               '</svg>';
+      }
+
+      function renderSVG() {
+        const size = attrs.size || 'md';
+        let square;
+        let stroke;
+
+        if (size === 'lg') {
+          square = 85;
+          stroke = 4;
+        } else if (size === 'md') {
+          square = 65;
+          stroke = 3;
+        } else if (size === 'sm') {
+          square = 35;
+          stroke = 2;
+        } else if (size === 'xs') {
+          square = 25;
+          stroke = 1;
         }
 
-        function renderSVG() {
-          const size = attrs.size || 'md';
-          let square;
-          let stroke;
+        const svg = generateSVGMarkup(size, square, stroke);
 
-          if (size === 'lg') {
-            square = 85;
-            stroke = 4;
-          } else if (size === 'md') {
-            square = 65;
-            stroke = 3;
-          } else if (size === 'sm') {
-            square = 35;
-            stroke = 2;
-          } else if (size === 'xs') {
-            square = 25;
-            stroke = 1;
-          }
+        element.html(svg);
+      }
 
-          const svg = generateSVGMarkup(size, square, stroke);
+      // Initialize svg
+      renderSVG();
 
-          element.html(svg);
-        }
-
-        // Initialize svg
-        renderSVG();
-
-      },
-    };
-  }
-}());
+    },
+  };
+}

--- a/modules/core/client/directives/tr-switch.client.directive.js
+++ b/modules/core/client/directives/tr-switch.client.directive.js
@@ -1,43 +1,41 @@
-(function () {
-  /**
-   * Directive to create a pretty toggle switches out from `input[type=checkbox]`
-   *
-   * Use as an attribute of the surrounding label:
-   * ```html
-   * <label tr-switch>
-   *   <input type="checkbox">
-   * </label>
-   * ```
-   *
-   */
-  angular
-    .module('core')
-    .directive('trSwitch', trSwitchDirective);
+/**
+ * Directive to create a pretty toggle switches out from `input[type=checkbox]`
+ *
+ * Use as an attribute of the surrounding label:
+ * ```html
+ * <label tr-switch>
+ *   <input type="checkbox">
+ * </label>
+ * ```
+ *
+ */
+angular
+  .module('core')
+  .directive('trSwitch', trSwitchDirective);
 
-  /* @ngInject */
-  function trSwitchDirective() {
-    return {
-      restrict: 'A',
-      link: function (scope, elem, attrs) {
+/* @ngInject */
+function trSwitchDirective() {
+  return {
+    restrict: 'A',
+    link: function (scope, elem, attrs) {
 
-        elem.addClass('tr-switch');
+      elem.addClass('tr-switch');
 
-        // Small size
-        // @todo: add other sizes (`xs`, `md`, `lg`) if needed
-        // Default size is `md`
-        if (attrs.trSwitchSize && attrs.trSwitchSize === 'sm') {
-          elem.addClass('tr-switch-sm');
-        }
+      // Small size
+      // @todo: add other sizes (`xs`, `md`, `lg`) if needed
+      // Default size is `md`
+      if (attrs.trSwitchSize && attrs.trSwitchSize === 'sm') {
+        elem.addClass('tr-switch-sm');
+      }
 
-        if (attrs.trSwitchSide && attrs.trSwitchSide === 'right') {
-          elem.addClass('tr-switch-right');
-        }
+      if (attrs.trSwitchSide && attrs.trSwitchSide === 'right') {
+        elem.addClass('tr-switch-right');
+      }
 
-        // Add toggle
-        const toggle = angular.element('<div class="toggle"></div>');
-        elem.find('input').after(toggle);
+      // Add toggle
+      const toggle = angular.element('<div class="toggle"></div>');
+      elem.find('input').after(toggle);
 
-      },
-    };
-  }
-}());
+    },
+  };
+}

--- a/modules/core/client/directives/tr-time.client.directive.js
+++ b/modules/core/client/directives/tr-time.client.directive.js
@@ -1,95 +1,93 @@
-(function () {
-  /**
-   * Directive that shows time taking into account user's time related settings.
-   *
-   * Clicking on time will change the way it's shown (betwen "ago"-time or absolute time).
-   * When toggled, mode will be stored to localStorage
-   *
-   * Toggle click event won't propagate further in DOM so placing this inside clickable
-   * elements will cause time to toggle, but underlaying button won't be clicked.
-   *
-   * Relies on MomentJS and Angular-Moment
-   * @link http://momentjs.com/docs/
-   * @link https://github.com/urish/angular-moment
-   *
-   * Basic usage:
-   * <time tr-time="Date object or String"></time>
-   *
-   * Adjust tooltip:
-   * <time tr-time="Date object or String" tr-time-tooltip-placement="bottom"></time>
-   *
-   * Tooltip attribute is passed on to UI-Bootstrap directive
-   *
-   * Pass time format:
-   * <time tr-time="Date object or String" tr-time-format="'mediumDate'"></time>
-   *
-   * See formats: https://docs.angularjs.org/api/ng/filter/date
-   */
-  angular
-    .module('core')
-    .directive('trTime', trTimeDirective);
+/**
+ * Directive that shows time taking into account user's time related settings.
+ *
+ * Clicking on time will change the way it's shown (betwen "ago"-time or absolute time).
+ * When toggled, mode will be stored to localStorage
+ *
+ * Toggle click event won't propagate further in DOM so placing this inside clickable
+ * elements will cause time to toggle, but underlaying button won't be clicked.
+ *
+ * Relies on MomentJS and Angular-Moment
+ * @link http://momentjs.com/docs/
+ * @link https://github.com/urish/angular-moment
+ *
+ * Basic usage:
+ * <time tr-time="Date object or String"></time>
+ *
+ * Adjust tooltip:
+ * <time tr-time="Date object or String" tr-time-tooltip-placement="bottom"></time>
+ *
+ * Tooltip attribute is passed on to UI-Bootstrap directive
+ *
+ * Pass time format:
+ * <time tr-time="Date object or String" tr-time-format="'mediumDate'"></time>
+ *
+ * See formats: https://docs.angularjs.org/api/ng/filter/date
+ */
+angular
+  .module('core')
+  .directive('trTime', trTimeDirective);
 
-  /* @ngInject */
-  function trTimeDirective($log, $rootScope, $parse, locker) {
-    return {
-      restrict: 'A',
-      replace: false,
-      template: '<time ng-click="toggleMode($event)" aria-label="Change time presentation">' +
-                  '<span ng-if="timeModeAgo" am-time-ago="::sourceTime" uib-tooltip="{{ ::sourceTime | date:trTimeFormat }}" tooltip-placement="{{ ::tooltipPlacement }}"></span>' +
-                  '<span ng-if="!timeModeAgo">{{ ::sourceTime | date:trTimeFormat }}</span>' +
-                '</time>',
-      scope: {
-        trTime: '@',
-        trTimeTooltipPlacement: '@',
-        trTimeFormat: '=?', // `?` makes it optional
-      },
-      link: function (scope, element, attrs) {
+/* @ngInject */
+function trTimeDirective($log, $rootScope, $parse, locker) {
+  return {
+    restrict: 'A',
+    replace: false,
+    template: '<time ng-click="toggleMode($event)" aria-label="Change time presentation">' +
+                '<span ng-if="timeModeAgo" am-time-ago="::sourceTime" uib-tooltip="{{ ::sourceTime | date:trTimeFormat }}" tooltip-placement="{{ ::tooltipPlacement }}"></span>' +
+                '<span ng-if="!timeModeAgo">{{ ::sourceTime | date:trTimeFormat }}</span>' +
+              '</time>',
+    scope: {
+      trTime: '@',
+      trTimeTooltipPlacement: '@',
+      trTimeFormat: '=?', // `?` makes it optional
+    },
+    link: function (scope, element, attrs) {
 
-        if (!scope.trTime) {
-          $log.warn('No time passed for tr-time directive.');
-          return;
+      if (!scope.trTime) {
+        $log.warn('No time passed for tr-time directive.');
+        return;
+      }
+
+      // Default to 'medium' time format, see formats:
+      // @link https://docs.angularjs.org/api/ng/filter/date
+      scope.trTimeFormat = scope.trTimeFormat || 'medium';
+
+      // Set tooltip placement, default to 'bottom'
+      scope.tooltipPlacement = scope.trTimeTooltipPlacement || 'bottom';
+
+      // Avoid creating watchers for this time since it needs to be passed only once
+      // @link https://stackoverflow.com/questions/30193069/angularjs-directive-creates-watches/30194100#30194100
+      scope.sourceTime = $parse(attrs.trTime)(scope.$parent);
+
+      // Get setting from cache, use default (true) if it doesn't exist
+      scope.timeModeAgo = (locker.supported()) ? Boolean(locker.get('timeAgo', true)) : true;
+
+      // Sync mode if other directive changes time mode
+      scope.$on('timeModeAgoChanged', timeModeAgoChanged);
+      function timeModeAgoChanged($event, newTimeModeAgo) {
+        if (scope.timeModeAgo !== newTimeModeAgo) {
+          scope.timeModeAgo = newTimeModeAgo;
+        }
+      }
+
+      // Toggle viewing time between 'ago' and time format.
+      // Saves setting to localStorage if it's available
+      scope.toggleMode = function ($event) {
+        $event.preventDefault();
+        $event.stopPropagation();
+
+        scope.timeModeAgo = !scope.timeModeAgo;
+
+        // Save setting to cache
+        if (locker.supported()) {
+          locker.put('timeAgo', scope.timeModeAgo);
         }
 
-        // Default to 'medium' time format, see formats:
-        // @link https://docs.angularjs.org/api/ng/filter/date
-        scope.trTimeFormat = scope.trTimeFormat || 'medium';
+        // Tell other directives to update their mode as well
+        $rootScope.$broadcast('timeModeAgoChanged', scope.timeModeAgo);
+      };
 
-        // Set tooltip placement, default to 'bottom'
-        scope.tooltipPlacement = scope.trTimeTooltipPlacement || 'bottom';
-
-        // Avoid creating watchers for this time since it needs to be passed only once
-        // @link https://stackoverflow.com/questions/30193069/angularjs-directive-creates-watches/30194100#30194100
-        scope.sourceTime = $parse(attrs.trTime)(scope.$parent);
-
-        // Get setting from cache, use default (true) if it doesn't exist
-        scope.timeModeAgo = (locker.supported()) ? Boolean(locker.get('timeAgo', true)) : true;
-
-        // Sync mode if other directive changes time mode
-        scope.$on('timeModeAgoChanged', timeModeAgoChanged);
-        function timeModeAgoChanged($event, newTimeModeAgo) {
-          if (scope.timeModeAgo !== newTimeModeAgo) {
-            scope.timeModeAgo = newTimeModeAgo;
-          }
-        }
-
-        // Toggle viewing time between 'ago' and time format.
-        // Saves setting to localStorage if it's available
-        scope.toggleMode = function ($event) {
-          $event.preventDefault();
-          $event.stopPropagation();
-
-          scope.timeModeAgo = !scope.timeModeAgo;
-
-          // Save setting to cache
-          if (locker.supported()) {
-            locker.put('timeAgo', scope.timeModeAgo);
-          }
-
-          // Tell other directives to update their mode as well
-          $rootScope.$broadcast('timeModeAgoChanged', scope.timeModeAgo);
-        };
-
-      },
-    };
-  }
-}());
+    },
+  };
+}

--- a/modules/core/client/directives/tr-window-blur.client.directive.js
+++ b/modules/core/client/directives/tr-window-blur.client.directive.js
@@ -1,46 +1,44 @@
-(function () {
-  /**
-   * Directive to watch window blur events.
-   * See also `tr-window-focus.client.directive.js`
-   *
-   * Usage:
-   * `<body tr-window-blur="doSomething()">`
-   *
-   * Based on
-   * @link http://www.bennadel.com/blog/2934-handling-window-blur-and-focus-events-in-angularjs.htm
-   */
-  angular
-    .module('core')
-    .directive('trWindowBlur', trWindowBlurDirective);
+/**
+ * Directive to watch window blur events.
+ * See also `tr-window-focus.client.directive.js`
+ *
+ * Usage:
+ * `<body tr-window-blur="doSomething()">`
+ *
+ * Based on
+ * @link http://www.bennadel.com/blog/2934-handling-window-blur-and-focus-events-in-angularjs.htm
+ */
+angular
+  .module('core')
+  .directive('trWindowBlur', trWindowBlurDirective);
 
-  /* @ngInject */
-  function trWindowBlurDirective($window) {
-    const directive = {
-      link: link,
-      restrict: 'A',
-    };
+/* @ngInject */
+function trWindowBlurDirective($window) {
+  const directive = {
+    link: link,
+    restrict: 'A',
+  };
 
-    return directive;
+  return directive;
 
-    function link(scope, element, attributes) {
+  function link(scope, element, attributes) {
 
-      // Hook up blur-handler
-      const win = angular.element($window).on('blur', handleBlur);
+    // Hook up blur-handler
+    const win = angular.element($window).on('blur', handleBlur);
 
-      // When the scope is destroyed, we have to make sure to teardown
-      // the event binding so we don't get a leak.
-      scope.$on('$destroy', handleDestroy);
+    // When the scope is destroyed, we have to make sure to teardown
+    // the event binding so we don't get a leak.
+    scope.$on('$destroy', handleDestroy);
 
-      // Handle the blur event on the Window.
-      function handleBlur() {
-        scope.$apply(attributes.trWindowBlur);
-      }
-
-      // Teardown the directive.
-      function handleDestroy() {
-        win.off('blur', handleBlur);
-      }
-
+    // Handle the blur event on the Window.
+    function handleBlur() {
+      scope.$apply(attributes.trWindowBlur);
     }
+
+    // Teardown the directive.
+    function handleDestroy() {
+      win.off('blur', handleBlur);
+    }
+
   }
-}());
+}

--- a/modules/core/client/directives/tr-window-focus.client.directive.js
+++ b/modules/core/client/directives/tr-window-focus.client.directive.js
@@ -1,46 +1,44 @@
-(function () {
-  /**
-   * Directive to watch window blur events.
-   * See also `tr-window-blur.client.directive.js`
-   *
-   * Usage:
-   * `<body tr-window-focus="doSomething()">`
-   *
-   * Based on
-   * @link http://www.bennadel.com/blog/2934-handling-window-blur-and-focus-events-in-angularjs.htm
-   */
-  angular
-    .module('core')
-    .directive('trWindowFocus', trWindowFocusDirective);
+/**
+ * Directive to watch window blur events.
+ * See also `tr-window-blur.client.directive.js`
+ *
+ * Usage:
+ * `<body tr-window-focus="doSomething()">`
+ *
+ * Based on
+ * @link http://www.bennadel.com/blog/2934-handling-window-blur-and-focus-events-in-angularjs.htm
+ */
+angular
+  .module('core')
+  .directive('trWindowFocus', trWindowFocusDirective);
 
-  /* @ngInject */
-  function trWindowFocusDirective($window) {
-    const directive = {
-      link: link,
-      restrict: 'A',
-    };
+/* @ngInject */
+function trWindowFocusDirective($window) {
+  const directive = {
+    link: link,
+    restrict: 'A',
+  };
 
-    return directive;
+  return directive;
 
-    function link(scope, element, attributes) {
+  function link(scope, element, attributes) {
 
-      // Hook up focus-handler
-      const win = angular.element($window).on('focus', handleFocus);
+    // Hook up focus-handler
+    const win = angular.element($window).on('focus', handleFocus);
 
-      // When the scope is destroyed, we have to make sure to teardown
-      // the event binding so we don't get a leak.
-      scope.$on('$destroy', handleDestroy);
+    // When the scope is destroyed, we have to make sure to teardown
+    // the event binding so we don't get a leak.
+    scope.$on('$destroy', handleDestroy);
 
-      // Handle the focus event on the Window
-      function handleFocus() {
-        scope.$apply(attributes.trWindowFocus);
-      }
-
-      // Teardown the directive
-      function handleDestroy() {
-        win.off('focus', handleFocus);
-      }
-
+    // Handle the focus event on the Window
+    function handleFocus() {
+      scope.$apply(attributes.trWindowFocus);
     }
+
+    // Teardown the directive
+    function handleDestroy() {
+      win.off('focus', handleFocus);
+    }
+
   }
-}());
+}

--- a/modules/core/client/filters/age.client.filter.js
+++ b/modules/core/client/filters/age.client.filter.js
@@ -1,26 +1,24 @@
-(function () {
-  /**
-   * Turn mongo date string into years
-   *
-   * Input: '1986-05-30' or new Date(1986, 04, 30)
-   * (00 - January, 04 - May in new Date())
-   * Output: 28 years
-   *
-   * @link http://stackoverflow.com/a/24883386
-   * @link http://stackoverflow.com/a/21984136
-   */
-  angular
-    .module('core')
-    .filter('ageyears', ageYearsFilter);
+/**
+ * Turn mongo date string into years
+ *
+ * Input: '1986-05-30' or new Date(1986, 04, 30)
+ * (00 - January, 04 - May in new Date())
+ * Output: 28 years
+ *
+ * @link http://stackoverflow.com/a/24883386
+ * @link http://stackoverflow.com/a/21984136
+ */
+angular
+  .module('core')
+  .filter('ageyears', ageYearsFilter);
 
-  /* @ngInject */
-  function ageYearsFilter($filter) {
-    return function (dateStringOrDate) {
-      const dateObj = new Date($filter('date')(dateStringOrDate, 'yyyy-MM-dd'));
-      const ageDifMs = Date.now() - dateObj.getTime();
-      const ageDate = new Date(ageDifMs); // miliseconds from epoch
+/* @ngInject */
+function ageYearsFilter($filter) {
+  return function (dateStringOrDate) {
+    const dateObj = new Date($filter('date')(dateStringOrDate, 'yyyy-MM-dd'));
+    const ageDifMs = Date.now() - dateObj.getTime();
+    const ageDate = new Date(ageDifMs); // miliseconds from epoch
 
-      return Math.abs(ageDate.getUTCFullYear() - 1970) + ' years';
-    };
-  }
-}());
+    return Math.abs(ageDate.getUTCFullYear() - 1970) + ' years';
+  };
+}

--- a/modules/core/client/filters/plain-text-length.client.filter.js
+++ b/modules/core/client/filters/plain-text-length.client.filter.js
@@ -1,24 +1,22 @@
-(function () {
-  /**
-   * Return length of a string without html
-   * Very crude html stripping, which is enough for estimating if text is short/empty without html tags
-   *
-   * Usage in templates:
-   * {{ 'myString' | plainTextLength }}
-   *
-   * Usage via JS:
-   * $filter('plainTextLength')('myString')
-   *
-   * @link https://docs.angularjs.org/api/ng/filter/filter
-   * @link http://stackoverflow.com/a/17315483/1984644
-   */
-  angular
-    .module('core')
-    .filter('plainTextLength', plainTextLengthFilter);
+/**
+ * Return length of a string without html
+ * Very crude html stripping, which is enough for estimating if text is short/empty without html tags
+ *
+ * Usage in templates:
+ * {{ 'myString' | plainTextLength }}
+ *
+ * Usage via JS:
+ * $filter('plainTextLength')('myString')
+ *
+ * @link https://docs.angularjs.org/api/ng/filter/filter
+ * @link http://stackoverflow.com/a/17315483/1984644
+ */
+angular
+  .module('core')
+  .filter('plainTextLength', plainTextLengthFilter);
 
-  function plainTextLengthFilter() {
-    return function (string) {
-      return string && angular.isString(string) ? String(string).replace(/&nbsp;/g, ' ').replace(/<[^>]+>/gm, '').trim().length : 0;
-    };
-  }
-}());
+function plainTextLengthFilter() {
+  return function (string) {
+    return string && angular.isString(string) ? String(string).replace(/&nbsp;/g, ' ').replace(/<[^>]+>/gm, '').trim().length : 0;
+  };
+}

--- a/modules/core/client/filters/trusted-html.client.filter.js
+++ b/modules/core/client/filters/trusted-html.client.filter.js
@@ -1,12 +1,10 @@
-(function () {
-  angular
-    .module('core')
-    .filter('trustedHtml', trustedHtmlFilter);
+angular
+  .module('core')
+  .filter('trustedHtml', trustedHtmlFilter);
 
-  /* @ngInject */
-  function trustedHtmlFilter($sce) {
-    return function (input) {
-      return $sce.trustAsHtml(input);
-    };
-  }
-}());
+/* @ngInject */
+function trustedHtmlFilter($sce) {
+  return function (input) {
+    return $sce.trustAsHtml(input);
+  };
+}

--- a/modules/core/client/services/facebook.client.service.js
+++ b/modules/core/client/services/facebook.client.service.js
@@ -1,136 +1,134 @@
 /* global FB */
-(function () {
-  angular
-    .module('core')
-    .factory('Facebook', FacebookFactory);
+angular
+  .module('core')
+  .factory('Facebook', FacebookFactory);
 
-  /* @ngInject */
-  function FacebookFactory($log, $window, $document, $http, $rootScope, Authentication) {
+/* @ngInject */
+function FacebookFactory($log, $window, $document, $http, $rootScope, Authentication) {
 
-    const service = {
-      init: init,
-    };
+  const service = {
+    init: init,
+  };
 
-    return service;
+  return service;
 
-    /**
-     * Load Facebook javascript SDK
-     * Will invoke `fbAsyncInit` when done.
-     */
-    function init() {
+  /**
+   * Load Facebook javascript SDK
+   * Will invoke `fbAsyncInit` when done.
+   */
+  function init() {
 
-      // Stop loading if the app doesn't have Facebook app ID defined
-      if (!angular.isString($window.facebookAppId) || $window.facebookAppId === '') {
-        $log.info('No Facebook app ID; skipping `FB.init()`');
+    // Stop loading if the app doesn't have Facebook app ID defined
+    if (!angular.isString($window.facebookAppId) || $window.facebookAppId === '') {
+      $log.info('No Facebook app ID; skipping `FB.init()`');
+      return;
+    }
+
+    // Stop loading when:
+    // - user isn't authenticated
+    // - authenticated user isn't connected to FB
+    if (!Authentication.user || !Authentication.user.additionalProvidersData || !Authentication.user.additionalProvidersData.facebook) {
+      return;
+    }
+
+    // Run this function after SDK loads
+    $window.fbAsyncInit = fbAsyncInit;
+
+    // Initialize the `<script>`
+    (function (d) {
+      const id = 'facebook-jssdk';
+      const fjs = d.getElementsByTagName('script')[0];
+
+      // Don't add `<script>` tag twice
+      if (d.getElementById(id)) {
         return;
       }
 
-      // Stop loading when:
-      // - user isn't authenticated
-      // - authenticated user isn't connected to FB
-      if (!Authentication.user || !Authentication.user.additionalProvidersData || !Authentication.user.additionalProvidersData.facebook) {
-        return;
-      }
+      const js = d.createElement('script');
+      js.id = id;
+      js.async = true;
+      js.src = '//connect.facebook.net/en_US/sdk.js';
+      fjs.parentNode.insertBefore(js, fjs);
 
-      // Run this function after SDK loads
-      $window.fbAsyncInit = fbAsyncInit;
-
-      // Initialize the `<script>`
-      (function (d) {
-        const id = 'facebook-jssdk';
-        const fjs = d.getElementsByTagName('script')[0];
-
-        // Don't add `<script>` tag twice
-        if (d.getElementById(id)) {
-          return;
-        }
-
-        const js = d.createElement('script');
-        js.id = id;
-        js.async = true;
-        js.src = '//connect.facebook.net/en_US/sdk.js';
-        fjs.parentNode.insertBefore(js, fjs);
-
-      }($document[0]));
-
-    }
-
-    /**
-     * Executed when the SDK is loaded
-     * Initialize FB API and get user's authentication status (from FB)
-     */
-    function fbAsyncInit() {
-      FB.init({
-
-        // The app id of the web app;
-        // To register a new app visit Facebook App Dashboard
-        // https://developers.facebook.com/apps/
-        appId: $window.facebookAppId,
-
-        // Check the authentication status of user at the start up of the app?
-        // Above event listener `auth.statusChange` requires this to be `true`
-        status: true,
-
-        // Enable cookies to allow the server to access?
-        // the session
-        cookie: true,
-
-        // Parse XFBML?
-        xfbml: false,
-
-        // FB API version
-        // https://developers.facebook.com/docs/apps/changelog/
-        // https://developers.facebook.com/docs/apps/versions#howlong
-        version: 'v2.8',
-      });
-
-      // Get notified about user's authentication status to FB
-      // https://developers.facebook.com/docs/reference/javascript/FB.Event.subscribe/v2.8
-      // https://developers.facebook.com/docs/reference/javascript/FB.getLoginStatus/#status
-      FB.Event.subscribe('auth.statusChange', statusChangeCallback);
-
-      // Tell anything relying on `FB` that it's now available
-      $rootScope.$broadcast('facebookReady');
-    }
-
-    /**
-     * Handle FB login status
-     */
-    function statusChangeCallback(response) {
-      // `response.status` could be:
-      // - `connected`: logged in
-      // - `not_authorized`: logged in, but not authorized our app
-      // - `unknown`: logged out
-      if (response && response.status === 'connected') {
-        storeAuthResponse(response.authResponse);
-      }
-    }
-
-    /**
-     * Store new oAuth token to server
-     * authResponse:
-     * ```
-     * {
-     *   accessToken: String
-     *   expiresIn: Int
-     *   signedRequest: String
-     *   userID: String
-     * }
-     * ```
-     */
-    function storeAuthResponse(authResponse) {
-      if (!angular.isObject(authResponse)) {
-        return;
-      }
-
-      $http.put('/api/auth/facebook',
-        authResponse,
-        {
-          // Tells Angular-Loading-Bar to ignore this http request
-          // @link https://github.com/chieffancypants/angular-loading-bar#ignoring-particular-xhr-requests
-          ignoreLoadingBar: true,
-        });
-    }
+    }($document[0]));
 
   }
-}());
+
+  /**
+   * Executed when the SDK is loaded
+   * Initialize FB API and get user's authentication status (from FB)
+   */
+  function fbAsyncInit() {
+    FB.init({
+
+      // The app id of the web app;
+      // To register a new app visit Facebook App Dashboard
+      // https://developers.facebook.com/apps/
+      appId: $window.facebookAppId,
+
+      // Check the authentication status of user at the start up of the app?
+      // Above event listener `auth.statusChange` requires this to be `true`
+      status: true,
+
+      // Enable cookies to allow the server to access?
+      // the session
+      cookie: true,
+
+      // Parse XFBML?
+      xfbml: false,
+
+      // FB API version
+      // https://developers.facebook.com/docs/apps/changelog/
+      // https://developers.facebook.com/docs/apps/versions#howlong
+      version: 'v2.8',
+    });
+
+    // Get notified about user's authentication status to FB
+    // https://developers.facebook.com/docs/reference/javascript/FB.Event.subscribe/v2.8
+    // https://developers.facebook.com/docs/reference/javascript/FB.getLoginStatus/#status
+    FB.Event.subscribe('auth.statusChange', statusChangeCallback);
+
+    // Tell anything relying on `FB` that it's now available
+    $rootScope.$broadcast('facebookReady');
+  }
+
+  /**
+   * Handle FB login status
+   */
+  function statusChangeCallback(response) {
+    // `response.status` could be:
+    // - `connected`: logged in
+    // - `not_authorized`: logged in, but not authorized our app
+    // - `unknown`: logged out
+    if (response && response.status === 'connected') {
+      storeAuthResponse(response.authResponse);
+    }
+  }
+
+  /**
+   * Store new oAuth token to server
+   * authResponse:
+   * ```
+   * {
+   *   accessToken: String
+   *   expiresIn: Int
+   *   signedRequest: String
+   *   userID: String
+   * }
+   * ```
+   */
+  function storeAuthResponse(authResponse) {
+    if (!angular.isObject(authResponse)) {
+      return;
+    }
+
+    $http.put('/api/auth/facebook',
+      authResponse,
+      {
+        // Tells Angular-Loading-Bar to ignore this http request
+        // @link https://github.com/chieffancypants/angular-loading-bar#ignoring-particular-xhr-requests
+        ignoreLoadingBar: true,
+      });
+  }
+
+}

--- a/modules/core/client/services/firebase-messaging.client.service.js
+++ b/modules/core/client/services/firebase-messaging.client.service.js
@@ -1,159 +1,157 @@
-(function () {
-  angular
-    .module('core')
-    .factory('firebaseMessaging', firebaseMessaging);
+angular
+  .module('core')
+  .factory('firebaseMessaging', firebaseMessaging);
 
-  /* @ngInject */
-  function firebaseMessaging($window, $q, $timeout, SettingsService) {
+/* @ngInject */
+function firebaseMessaging($window, $q, $timeout, SettingsService) {
 
-    const appSettings = SettingsService.get();
+  const appSettings = SettingsService.get();
 
-    const SENDER_ID = appSettings && appSettings.fcmSenderId;
-    const SERVICE_WORKER_PATH = '/push-messaging-sw.js';
-    const SERVICE_WORKER_SCOPE = '/trustroots-push-messaging-scope';
+  const SENDER_ID = appSettings && appSettings.fcmSenderId;
+  const SERVICE_WORKER_PATH = '/push-messaging-sw.js';
+  const SERVICE_WORKER_SCOPE = '/trustroots-push-messaging-scope';
 
-    const firebase = require('firebase/app');
-    require('firebase/messaging');
-    let _messaging = null; // set in initMessaging()
-    const onTokenRefreshCallbacks = [];
-    const onMessageCallbacks = [];
+  const firebase = require('firebase/app');
+  require('firebase/messaging');
+  let _messaging = null; // set in initMessaging()
+  const onTokenRefreshCallbacks = [];
+  const onMessageCallbacks = [];
 
-    const firebaseMessaging = {
-      name: 'fcm',
-      shouldInitialize: !!SENDER_ID,
-      getToken: getToken,
-      requestPermission: requestPermission,
-      deleteToken: deleteToken,
-      onTokenRefresh: onTokenRefresh,
-      onMessage: onMessage,
-      removeServiceWorker: removeServiceWorker,
-    };
+  const firebaseMessaging = {
+    name: 'fcm',
+    shouldInitialize: !!SENDER_ID,
+    getToken: getToken,
+    requestPermission: requestPermission,
+    deleteToken: deleteToken,
+    onTokenRefresh: onTokenRefresh,
+    onMessage: onMessage,
+    removeServiceWorker: removeServiceWorker,
+  };
 
-    function getToken() {
-      return initMessaging().then(function (messaging) {
-        return messaging.getToken();
+  function getToken() {
+    return initMessaging().then(function (messaging) {
+      return messaging.getToken();
+    });
+  }
+
+  function requestPermission() {
+    return initMessaging().then(function (messaging) {
+      return messaging.requestPermission();
+    });
+  }
+
+  function deleteToken(token) {
+    return initMessaging().then(function (messaging) {
+      return messaging.deleteToken(token);
+    });
+  }
+
+  function onTokenRefresh(fn) {
+    onTokenRefreshCallbacks.push(fn);
+  }
+
+  function onMessage(fn) {
+    onMessageCallbacks.push(fn);
+  }
+
+  function removeServiceWorker() {
+    return getServiceWorkers().then(function (workers) {
+      workers.forEach(function (worker) {
+        worker.unregister();
       });
-    }
+    });
+  }
 
-    function requestPermission() {
-      return initMessaging().then(function (messaging) {
-        return messaging.requestPermission();
+  function getServiceWorkers() {
+    return $q.when($window.navigator.serviceWorker.getRegistrations()).then(function (registrations) {
+      return registrations.filter(function (worker) {
+        return worker.scope.endsWith(SERVICE_WORKER_SCOPE);
       });
-    }
+    });
+  }
 
-    function deleteToken(token) {
-      return initMessaging().then(function (messaging) {
-        return messaging.deleteToken(token);
-      });
-    }
-
-    function onTokenRefresh(fn) {
-      onTokenRefreshCallbacks.push(fn);
-    }
-
-    function onMessage(fn) {
-      onMessageCallbacks.push(fn);
-    }
-
-    function removeServiceWorker() {
-      return getServiceWorkers().then(function (workers) {
-        workers.forEach(function (worker) {
-          worker.unregister();
-        });
-      });
-    }
-
-    function getServiceWorkers() {
-      return $q.when($window.navigator.serviceWorker.getRegistrations()).then(function (registrations) {
-        return registrations.filter(function (worker) {
-          return worker.scope.endsWith(SERVICE_WORKER_SCOPE);
-        });
-      });
-    }
-
-    function getOrCreateWorker() {
-      return getServiceWorkers().then(function (workers) {
-        if (workers.length === 0) {
-          return $q.when($window.navigator.serviceWorker
-            .register(SERVICE_WORKER_PATH, { scope: SERVICE_WORKER_SCOPE }));
-        } else {
-          return $q.resolve(workers[0]); // use first one available
-        }
-      });
-    }
-
-    function initMessaging() {
-      if (!firebaseMessaging.shouldInitialize) {
-        return $q.reject(new Error('firebaseMessaging is not available, ensure fcm.senderId is set in config'));
+  function getOrCreateWorker() {
+    return getServiceWorkers().then(function (workers) {
+      if (workers.length === 0) {
+        return $q.when($window.navigator.serviceWorker
+          .register(SERVICE_WORKER_PATH, { scope: SERVICE_WORKER_SCOPE }));
+      } else {
+        return $q.resolve(workers[0]); // use first one available
       }
+    });
+  }
 
-      if (_messaging) return $q.resolve(_messaging);
+  function initMessaging() {
+    if (!firebaseMessaging.shouldInitialize) {
+      return $q.reject(new Error('firebaseMessaging is not available, ensure fcm.senderId is set in config'));
+    }
 
-      return getOrCreateWorker().then(function (worker) {
+    if (_messaging) return $q.resolve(_messaging);
 
-        // got initialized since call to create worker...
-        if (_messaging) return _messaging;
+    return getOrCreateWorker().then(function (worker) {
 
-        firebase.initializeApp({
-          messagingSenderId: SENDER_ID,
+      // got initialized since call to create worker...
+      if (_messaging) return _messaging;
+
+      firebase.initializeApp({
+        messagingSenderId: SENDER_ID,
+      });
+
+      _messaging = angularize(firebase.messaging());
+
+      _messaging.useServiceWorker(worker);
+
+      _messaging.onTokenRefresh(function () {
+        const args = arguments;
+        onTokenRefreshCallbacks.forEach(function (fn) {
+          fn.apply(null, args);
         });
+      });
 
-        _messaging = angularize(firebase.messaging());
+      _messaging.onMessage(function () {
+        const args = arguments;
+        onMessageCallbacks.forEach(function (fn) {
+          fn.apply(null, args);
+        });
+      });
 
-        _messaging.useServiceWorker(worker);
+      return _messaging;
+    });
 
-        _messaging.onTokenRefresh(function () {
+  }
+
+  /**
+  *  Make the firebase messaging client work with angular promises
+  *  and the digest cycle.
+  */
+  function angularize(messaging) {
+
+    function wrapCallback(fn) {
+      return function (callback) {
+        fn.call(messaging, function () {
           const args = arguments;
-          onTokenRefreshCallbacks.forEach(function (fn) {
-            fn.apply(null, args);
+          $timeout(function () {
+            callback.apply(null, args);
           });
         });
-
-        _messaging.onMessage(function () {
-          const args = arguments;
-          onMessageCallbacks.forEach(function (fn) {
-            fn.apply(null, args);
-          });
-        });
-
-        return _messaging;
-      });
-
-    }
-
-    /**
-    *  Make the firebase messaging client work with angular promises
-    *  and the digest cycle.
-    */
-    function angularize(messaging) {
-
-      function wrapCallback(fn) {
-        return function (callback) {
-          fn.call(messaging, function () {
-            const args = arguments;
-            $timeout(function () {
-              callback.apply(null, args);
-            });
-          });
-        };
-      }
-
-      function wrapFunction(fn) {
-        return function () {
-          return $q.when(fn.apply(messaging, arguments));
-        };
-      }
-
-      return {
-        onTokenRefresh: wrapCallback(messaging.onTokenRefresh),
-        onMessage: wrapCallback(messaging.onMessage),
-        getToken: wrapFunction(messaging.getToken),
-        requestPermission: wrapFunction(messaging.requestPermission),
-        deleteToken: wrapFunction(messaging.deleteToken),
-        useServiceWorker: messaging.useServiceWorker.bind(messaging),
       };
     }
 
-    return firebaseMessaging;
+    function wrapFunction(fn) {
+      return function () {
+        return $q.when(fn.apply(messaging, arguments));
+      };
+    }
+
+    return {
+      onTokenRefresh: wrapCallback(messaging.onTokenRefresh),
+      onMessage: wrapCallback(messaging.onMessage),
+      getToken: wrapFunction(messaging.getToken),
+      requestPermission: wrapFunction(messaging.requestPermission),
+      deleteToken: wrapFunction(messaging.deleteToken),
+      useServiceWorker: messaging.useServiceWorker.bind(messaging),
+    };
   }
-}());
+
+  return firebaseMessaging;
+}

--- a/modules/core/client/services/languages.client.service.js
+++ b/modules/core/client/services/languages.client.service.js
@@ -1,31 +1,29 @@
-(function () {
-  angular
-    .module('core')
-    .factory('Languages', LanguagesFactory);
+angular
+  .module('core')
+  .factory('Languages', LanguagesFactory);
 
-  /* @ngInject */
-  function LanguagesFactory($window) {
+/* @ngInject */
+function LanguagesFactory($window) {
 
-    const service = {
-      get: get,
-    };
+  const service = {
+    get: get,
+  };
 
-    return service;
+  return service;
 
-    function get(type) {
-      if (type === 'array') {
-        const langsArr = [];
+  function get(type) {
+    if (type === 'array') {
+      const langsArr = [];
 
-        angular.forEach($window.languages, function (value, key) {
-          this.push({ key: key, name: value });
-        }, langsArr);
+      angular.forEach($window.languages, function (value, key) {
+        this.push({ key: key, name: value });
+      }, langsArr);
 
-        return langsArr;
-      }
-
-      // type === 'object':
-      return $window.languages;
+      return langsArr;
     }
 
+    // type === 'object':
+    return $window.languages;
   }
-}());
+
+}

--- a/modules/core/client/services/location.client.service.js
+++ b/modules/core/client/services/location.client.service.js
@@ -1,209 +1,207 @@
-(function () {
+/**
+ * Service for querying MapBox geocoder
+ */
+angular
+  .module('core')
+  .factory('LocationService', LocationService);
+
+/* @ngInject */
+function LocationService($log, $http, SettingsFactory) {
+
+  const appSettings = SettingsFactory.get();
+
+  // Defaults location to be used with maps (Europe)
+  const defaultLocation = {
+    lat: 48.6908333333,
+    lng: 9.14055555556,
+    zoom: 6,
+  };
+
+  const service = {
+    getDefaultLocation: getDefaultLocation,
+    getBounds: getBounds,
+    getCenter: getCenter,
+    shortTitle: shortTitle,
+    suggestions: suggestions,
+  };
+
   /**
-   * Service for querying MapBox geocoder
+   * Default map center
+   * Return Angular-UI-Leaflet compatible map center with optionally pre-set zoom level
+   *
+   * Leaflet expects center to be:
+   * {
+   *   lat: Float,
+   *   lng: Float,
+   *   center: Int
+   * }
    */
-  angular
-    .module('core')
-    .factory('LocationService', LocationService);
-
-  /* @ngInject */
-  function LocationService($log, $http, SettingsFactory) {
-
-    const appSettings = SettingsFactory.get();
-
-    // Defaults location to be used with maps (Europe)
-    const defaultLocation = {
-      lat: 48.6908333333,
-      lng: 9.14055555556,
-      zoom: 6,
+  function getDefaultLocation(zoom) {
+    return {
+      lat: defaultLocation.lat,
+      lng: defaultLocation.lng,
+      zoom: parseInt(zoom || defaultLocation.zoom, 10),
     };
-
-    const service = {
-      getDefaultLocation: getDefaultLocation,
-      getBounds: getBounds,
-      getCenter: getCenter,
-      shortTitle: shortTitle,
-      suggestions: suggestions,
-    };
-
-    /**
-     * Default map center
-     * Return Angular-UI-Leaflet compatible map center with optionally pre-set zoom level
-     *
-     * Leaflet expects center to be:
-     * {
-     *   lat: Float,
-     *   lng: Float,
-     *   center: Int
-     * }
-     */
-    function getDefaultLocation(zoom) {
-      return {
-        lat: defaultLocation.lat,
-        lng: defaultLocation.lng,
-        zoom: parseInt(zoom || defaultLocation.zoom, 10),
-      };
-    }
-
-    /**
-     * Return Angular-UI-Leaflet compatible bounding box object from Carmen Geojson object
-     * @link https://github.com/mapbox/carmen/blob/master/carmen-geojson.md
-     *
-     * Leaflet expects bounds object to be:
-     * {
-     *   'northEast': {
-     *     'lat':59.60109549032134,
-     *     'lng':42.099609375
-     *   },
-     *   'southWest':{
-     *     'lat':52.796119005678506,
-     *     'lng':25.24658203125
-     *   }
-     * }
-     */
-    function getBounds(geolocation) {
-      if (!geolocation || !geolocation.bbox || !angular.isArray(geolocation.bbox) || geolocation.bbox.length !== 4) {
-        const center = geolocation.center;
-        if (!geolocation || !center || !angular.isArray(center) || center.length !== 2) {
-          return false;
-        } else {
-          const borderFromCenter = .002;
-          return getBoundsObject(
-            parseFloat(center[1]) + borderFromCenter,
-            parseFloat(center[0]) - borderFromCenter,
-            parseFloat(center[1]) - borderFromCenter,
-            parseFloat(center[0]) + borderFromCenter);
-        }
-      }
-      return getBoundsObject(
-        parseFloat(geolocation.bbox[3]),
-        parseFloat(geolocation.bbox[2]),
-        parseFloat(geolocation.bbox[1]),
-        parseFloat(geolocation.bbox[0]));
-    }
-
-    function getBoundsObject(northEastLat, northEastLng, southWestLat, southWestLng) {
-      return {
-        'northEast': {
-          'lat': northEastLat,
-          'lng': northEastLng,
-        },
-        'southWest': {
-          'lat': southWestLat,
-          'lng': southWestLng,
-        },
-      };
-    }
-
-    /**
-     * Return Angular-UI-Leaflet compatible center object from Carmen Geojson object
-     * @link https://github.com/mapbox/carmen/blob/master/carmen-geojson.md
-     *
-     * Leaflet expects center to be:
-     * {
-     *   lat: Float,
-     *   lng: Float,
-     *   center: Int
-     * }
-     */
-    function getCenter(geolocation) {
-      let coords;
-
-      if (geolocation.center) {
-        coords = geolocation.center;
-      } else if (geolocation.geometry && geolocation.geometry.coordinates) {
-        coords = geolocation.geometry.coordinates;
-      }
-
-      // Nothing found, return old or false
-      if (!coords || !angular.isArray(coords) || coords.length !== 2) {
-        return false;
-      }
-
-      // Return coordinates
-      return {
-        lng: parseFloat(coords[0]),
-        lat: parseFloat(coords[1]),
-      };
-    }
-
-    /**
-     * Search field's typeahead -suggestions
-     *
-     * @link https://www.mapbox.com/api-documentation/#geocoding
-     *
-     * @param val String Search query
-     * @param types String (optional) Filter results by one or more type.
-     *                     Options are  country,  region,  postcode,  place,  locality,  neighborhood,  address,  poi.
-     *                     Multiple options can be comma-separated.
-     *                     Defaults to `country,region,place,locality,neighborhood`
-     */
-    function suggestions(val, types) {
-      if (!appSettings.mapbox || !appSettings.mapbox.publicKey) {
-        $log.warn('No Mapbox settings found; cannot do geocoding!');
-        return Promise.resolve([]);
-      }
-
-      if (val == null || val.length <= 1) {
-        return Promise.resolve([]);
-      }
-
-      return $http.get(
-        'https://api.mapbox.com/geocoding/v5/mapbox.places/' + encodeURIComponent(val) + '.json'
-        + '?access_token=' + appSettings.mapbox.publicKey
-        + '&language=en'
-        + (types ? '&types=' + types : ''),
-        {
-          // Tells Angular-Loading-Bar to ignore this http request
-          // @link https://github.com/chieffancypants/angular-loading-bar#ignoring-particular-xhr-requests
-          ignoreLoadingBar: true,
-        })
-        .then(function (response) {
-          if (response.status === 200 && response.data.features && response.data.features.length > 0) {
-            return response.data.features.map(function (geolocation) {
-              geolocation.trTitle = shortTitle(geolocation);
-              return geolocation;
-            });
-          } else {
-            return Promise.resolve([]);
-          }
-        });
-    }
-
-    /**
-     * Compile a nice title from geolocation, eg. "Jyväskylä, Finland"
-     * @link https://www.mapbox.com/api-documentation/#geocoding
-     * @link https://github.com/mapbox/carmen/blob/master/carmen-geojson.md
-     *
-     * @param geolocation Object Carmen GeoJSON
-     * @return String
-     */
-    function shortTitle(geolocation) {
-      let title = '';
-
-      if (geolocation.text) {
-        title = geolocation.text;
-
-        // Relevant context strings
-        if (geolocation.context) {
-          const contextLength = geolocation.context.length;
-          for (let i = 0; i < contextLength; i++) {
-            if (geolocation.context[i].id.substring(0, 6) === 'place.') {
-              title += ', ' + geolocation.context[i].text;
-            } else if (geolocation.context[i].id.substring(0, 8) === 'country.') {
-              title += ', ' + geolocation.context[i].text;
-            }
-          }
-        }
-
-      } else if (geolocation.place_name) {
-        title = geolocation.place_name;
-      }
-
-      return title;
-    }
-
-
-    return service;
   }
-}());
+
+  /**
+   * Return Angular-UI-Leaflet compatible bounding box object from Carmen Geojson object
+   * @link https://github.com/mapbox/carmen/blob/master/carmen-geojson.md
+   *
+   * Leaflet expects bounds object to be:
+   * {
+   *   'northEast': {
+   *     'lat':59.60109549032134,
+   *     'lng':42.099609375
+   *   },
+   *   'southWest':{
+   *     'lat':52.796119005678506,
+   *     'lng':25.24658203125
+   *   }
+   * }
+   */
+  function getBounds(geolocation) {
+    if (!geolocation || !geolocation.bbox || !angular.isArray(geolocation.bbox) || geolocation.bbox.length !== 4) {
+      const center = geolocation.center;
+      if (!geolocation || !center || !angular.isArray(center) || center.length !== 2) {
+        return false;
+      } else {
+        const borderFromCenter = .002;
+        return getBoundsObject(
+          parseFloat(center[1]) + borderFromCenter,
+          parseFloat(center[0]) - borderFromCenter,
+          parseFloat(center[1]) - borderFromCenter,
+          parseFloat(center[0]) + borderFromCenter);
+      }
+    }
+    return getBoundsObject(
+      parseFloat(geolocation.bbox[3]),
+      parseFloat(geolocation.bbox[2]),
+      parseFloat(geolocation.bbox[1]),
+      parseFloat(geolocation.bbox[0]));
+  }
+
+  function getBoundsObject(northEastLat, northEastLng, southWestLat, southWestLng) {
+    return {
+      'northEast': {
+        'lat': northEastLat,
+        'lng': northEastLng,
+      },
+      'southWest': {
+        'lat': southWestLat,
+        'lng': southWestLng,
+      },
+    };
+  }
+
+  /**
+   * Return Angular-UI-Leaflet compatible center object from Carmen Geojson object
+   * @link https://github.com/mapbox/carmen/blob/master/carmen-geojson.md
+   *
+   * Leaflet expects center to be:
+   * {
+   *   lat: Float,
+   *   lng: Float,
+   *   center: Int
+   * }
+   */
+  function getCenter(geolocation) {
+    let coords;
+
+    if (geolocation.center) {
+      coords = geolocation.center;
+    } else if (geolocation.geometry && geolocation.geometry.coordinates) {
+      coords = geolocation.geometry.coordinates;
+    }
+
+    // Nothing found, return old or false
+    if (!coords || !angular.isArray(coords) || coords.length !== 2) {
+      return false;
+    }
+
+    // Return coordinates
+    return {
+      lng: parseFloat(coords[0]),
+      lat: parseFloat(coords[1]),
+    };
+  }
+
+  /**
+   * Search field's typeahead -suggestions
+   *
+   * @link https://www.mapbox.com/api-documentation/#geocoding
+   *
+   * @param val String Search query
+   * @param types String (optional) Filter results by one or more type.
+   *                     Options are  country,  region,  postcode,  place,  locality,  neighborhood,  address,  poi.
+   *                     Multiple options can be comma-separated.
+   *                     Defaults to `country,region,place,locality,neighborhood`
+   */
+  function suggestions(val, types) {
+    if (!appSettings.mapbox || !appSettings.mapbox.publicKey) {
+      $log.warn('No Mapbox settings found; cannot do geocoding!');
+      return Promise.resolve([]);
+    }
+
+    if (val == null || val.length <= 1) {
+      return Promise.resolve([]);
+    }
+
+    return $http.get(
+      'https://api.mapbox.com/geocoding/v5/mapbox.places/' + encodeURIComponent(val) + '.json'
+      + '?access_token=' + appSettings.mapbox.publicKey
+      + '&language=en'
+      + (types ? '&types=' + types : ''),
+      {
+        // Tells Angular-Loading-Bar to ignore this http request
+        // @link https://github.com/chieffancypants/angular-loading-bar#ignoring-particular-xhr-requests
+        ignoreLoadingBar: true,
+      })
+      .then(function (response) {
+        if (response.status === 200 && response.data.features && response.data.features.length > 0) {
+          return response.data.features.map(function (geolocation) {
+            geolocation.trTitle = shortTitle(geolocation);
+            return geolocation;
+          });
+        } else {
+          return Promise.resolve([]);
+        }
+      });
+  }
+
+  /**
+   * Compile a nice title from geolocation, eg. "Jyväskylä, Finland"
+   * @link https://www.mapbox.com/api-documentation/#geocoding
+   * @link https://github.com/mapbox/carmen/blob/master/carmen-geojson.md
+   *
+   * @param geolocation Object Carmen GeoJSON
+   * @return String
+   */
+  function shortTitle(geolocation) {
+    let title = '';
+
+    if (geolocation.text) {
+      title = geolocation.text;
+
+      // Relevant context strings
+      if (geolocation.context) {
+        const contextLength = geolocation.context.length;
+        for (let i = 0; i < contextLength; i++) {
+          if (geolocation.context[i].id.substring(0, 6) === 'place.') {
+            title += ', ' + geolocation.context[i].text;
+          } else if (geolocation.context[i].id.substring(0, 8) === 'country.') {
+            title += ', ' + geolocation.context[i].text;
+          }
+        }
+      }
+
+    } else if (geolocation.place_name) {
+      title = geolocation.place_name;
+    }
+
+    return title;
+  }
+
+
+  return service;
+}

--- a/modules/core/client/services/maplayers.client.service.js
+++ b/modules/core/client/services/maplayers.client.service.js
@@ -1,182 +1,180 @@
-(function () {
+/**
+ * Service for getting map layers for Leaflet
+ *
+ * Configure `mapbox` object at environment configs
+ *
+ * If Mapbox `user` or `publicKey` are set false,
+ * fall back to OSM and MapQuest
+ */
+angular
+  .module('core')
+  .factory('MapLayersFactory', MapLayersFactory);
+
+/* @ngInject */
+function MapLayersFactory(SettingsFactory, LocationService) {
+
+  const appSettings = SettingsFactory.get();
+
+  // Is Mapbox configuration available
+  const isMapboxAvailable = (appSettings.mapbox && angular.isObject(appSettings.mapbox.maps) && appSettings.mapbox.user && appSettings.mapbox.publicKey);
+
+  // Location for "improve this map"-links
+  const location = LocationService.getDefaultLocation(3);
+
+  const service = {
+    getLayers: getLayers,
+  };
+
+  return service;
+
+
   /**
-   * Service for getting map layers for Leaflet
-   *
-   * Configure `mapbox` object at environment configs
-   *
-   * If Mapbox `user` or `publicKey` are set false,
-   * fall back to OSM and MapQuest
+   * Return object for Mapbox layer
    */
-  angular
-    .module('core')
-    .factory('MapLayersFactory', MapLayersFactory);
+  function getMapboxLayer(label, TRStyle, layerConf) {
 
-  /* @ngInject */
-  function MapLayersFactory(SettingsFactory, LocationService) {
+    if (!isMapboxAvailable || !layerConf) return;
 
-    const appSettings = SettingsFactory.get();
-
-    // Is Mapbox configuration available
-    const isMapboxAvailable = (appSettings.mapbox && angular.isObject(appSettings.mapbox.maps) && appSettings.mapbox.user && appSettings.mapbox.publicKey);
-
-    // Location for "improve this map"-links
-    const location = LocationService.getDefaultLocation(3);
-
-    const service = {
-      getLayers: getLayers,
+    const layer = {
+      name: label || 'Mapbox',
+      type: 'xyz',
+      layerParams: {
+        map: layerConf.map,
+        user: layerConf.user || appSettings.mapbox.user,
+        token: appSettings.mapbox.publicKey,
+      },
+      layerOptions: {
+        attribution: '<a href="https://www.mapbox.com/about/maps/" target="_blank" rel="noopener">© Mapbox © OpenStreetMap</a>',
+        continuousWorld: true,
+        TRStyle: TRStyle || 'streets', // Not native Leaflet key, required by our layer switch
+      },
     };
 
-    return service;
+    if (layerConf.legacy) {
+      // Legacy tiles URL
+      layer.url = 'https://{s}.tiles.mapbox.com/v4/{user}.{map}/{z}/{x}/{y}.png?access_token={token}&secure=1';
+    } else {
+      // Publicly available Mapbox styles URL
+      layer.url = 'https://api.mapbox.com/styles/v1/{user}/{map}/tiles/{z}/{x}/{y}?access_token={token}';
+    }
 
+    // This feedback layer id is good for private styles
+    let feedbackLayer = appSettings.mapbox.user + '.' + layerConf.map;
 
-    /**
-     * Return object for Mapbox layer
-     */
-    function getMapboxLayer(label, TRStyle, layerConf) {
+    // These feedback layer id's are required for public styles
+    if (!layerConf.legacy && TRStyle === 'satellite') {
+      feedbackLayer = 'mapbox.satellite';
+    } else if (!layerConf.legacy) {
+      feedbackLayer = 'mapbox.streets';
+    }
 
-      if (!isMapboxAvailable || !layerConf) return;
+    // Add feedback link to attribution info
+    layer.layerOptions.attribution +=
+      ' <a href="https://www.mapbox.com/map-feedback/#' +
+      feedbackLayer + '/' +
+      location.lng + '/' +
+      location.lat + '/' +
+      location.zoom + '" ' +
+      'target="_blank" rel="noopener" class="improve-map">' +
+      'Improve the underlying map' +
+      '</a>';
 
-      const layer = {
-        name: label || 'Mapbox',
+    return layer;
+  }
+
+  /**
+   * Return object containing different Leaflet layers
+   */
+  function getLayers(options) {
+
+    const layers = {};
+
+    // Set layer types to return
+    // Defaults to return only `streets` layer
+    options = angular.merge({
+      streets: true,
+      satellite: false,
+      outdoors: false,
+    }, options || {});
+
+    // Streets
+    if (options.streets && isMapboxAvailable && appSettings.mapbox.maps.streets) {
+      // Streets: Mapbox
+      layers.streets = getMapboxLayer(
+        'Streets',
+        'streets',
+        appSettings.mapbox.maps.streets,
+      );
+      // Streets fallback
+    } else if (options.streets) {
+      // Streets: OpenStreetMap
+      layers.streets = {
+        name: 'Streets',
         type: 'xyz',
-        layerParams: {
-          map: layerConf.map,
-          user: layerConf.user || appSettings.mapbox.user,
-          token: appSettings.mapbox.publicKey,
-        },
+        url: '//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
         layerOptions: {
-          attribution: '<a href="https://www.mapbox.com/about/maps/" target="_blank" rel="noopener">© Mapbox © OpenStreetMap</a>',
+          subdomains: ['a', 'b', 'c'],
+          attribution:
+            '<a href="https://www.openstreetmap.org/" target="_blank" ' +
+            'rel="noopener">© OpenStreetMap</a> ' +
+            '<a href="https://www.openstreetmap.org/login#map=' +
+            location.zoom + '/' + location.lat + '/' + location.lng +
+            '" target="_blank" class="improve-map">' +
+            'Improve the underlying map' +
+            '</a>',
           continuousWorld: true,
-          TRStyle: TRStyle || 'streets', // Not native Leaflet key, required by our layer switch
+          TRStyle: 'streets', // Not native Leaflet key, required by our layer switch
         },
       };
-
-      if (layerConf.legacy) {
-        // Legacy tiles URL
-        layer.url = 'https://{s}.tiles.mapbox.com/v4/{user}.{map}/{z}/{x}/{y}.png?access_token={token}&secure=1';
-      } else {
-        // Publicly available Mapbox styles URL
-        layer.url = 'https://api.mapbox.com/styles/v1/{user}/{map}/tiles/{z}/{x}/{y}?access_token={token}';
-      }
-
-      // This feedback layer id is good for private styles
-      let feedbackLayer = appSettings.mapbox.user + '.' + layerConf.map;
-
-      // These feedback layer id's are required for public styles
-      if (!layerConf.legacy && TRStyle === 'satellite') {
-        feedbackLayer = 'mapbox.satellite';
-      } else if (!layerConf.legacy) {
-        feedbackLayer = 'mapbox.streets';
-      }
-
-      // Add feedback link to attribution info
-      layer.layerOptions.attribution +=
-        ' <a href="https://www.mapbox.com/map-feedback/#' +
-        feedbackLayer + '/' +
-        location.lng + '/' +
-        location.lat + '/' +
-        location.zoom + '" ' +
-        'target="_blank" rel="noopener" class="improve-map">' +
-        'Improve the underlying map' +
-        '</a>';
-
-      return layer;
     }
 
-    /**
-     * Return object containing different Leaflet layers
-     */
-    function getLayers(options) {
-
-      const layers = {};
-
-      // Set layer types to return
-      // Defaults to return only `streets` layer
-      options = angular.merge({
-        streets: true,
-        satellite: false,
-        outdoors: false,
-      }, options || {});
-
-      // Streets
-      if (options.streets && isMapboxAvailable && appSettings.mapbox.maps.streets) {
-        // Streets: Mapbox
-        layers.streets = getMapboxLayer(
-          'Streets',
-          'streets',
-          appSettings.mapbox.maps.streets,
-        );
-        // Streets fallback
-      } else if (options.streets) {
-        // Streets: OpenStreetMap
-        layers.streets = {
-          name: 'Streets',
-          type: 'xyz',
-          url: '//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-          layerOptions: {
-            subdomains: ['a', 'b', 'c'],
-            attribution:
-              '<a href="https://www.openstreetmap.org/" target="_blank" ' +
-              'rel="noopener">© OpenStreetMap</a> ' +
-              '<a href="https://www.openstreetmap.org/login#map=' +
-              location.zoom + '/' + location.lat + '/' + location.lng +
-              '" target="_blank" class="improve-map">' +
-              'Improve the underlying map' +
-              '</a>',
-            continuousWorld: true,
-            TRStyle: 'streets', // Not native Leaflet key, required by our layer switch
-          },
-        };
-      }
-
-      // Satellite
-      if (options.satellite && isMapboxAvailable && appSettings.mapbox.maps.satellite) {
-        // Satellite: Mapbox
-        layers.satellite = getMapboxLayer(
-          'Satellite',
-          'satellite',
-          appSettings.mapbox.maps.satellite,
-        );
-      } else if (options.satellite) {
-        // Satellite fallback: NASA Earth Data
-        // @link https://earthdata.nasa.gov/about/science-system-description/eosdis-components/global-imagery-browse-services-gibs
-        // @link https://wiki.earthdata.nasa.gov/display/GIBS/GIBS+API+for+Developers#GIBSAPIforDevelopers-ServiceEndpointsandGetCapabilities
-        // @link https://github.com/nasa-gibs/gibs-web-examples/blob/master/examples/leaflet/webmercator-epsg3857.js
-        layers.satellite = {
-          name: 'Satellite',
-          type: 'xyz',
-          url: '//gibs-{s}.earthdata.nasa.gov/wmts/epsg3857/best/{layer}/default/{time}/{tileMatrixSet}/{z}/{y}/{x}.jpg',
-          layerOptions: {
-            layer: 'Landsat_WELD_CorrectedReflectance_TrueColor_Global_Annual',
-            tileMatrixSet: 'GoogleMapsCompatible_Level12',
-            time: '2009-08-22',
-            subdomains: ['a', 'b', 'c'],
-            attribution: '<a href="https://wiki.earthdata.nasa.gov/display/GIBS" target="_blank" rel="noopener">© NASA Earth Data</a>',
-            noWrap: true,
-            continuousWorld: true,
-            tileSize: 256,
-            // Prevent Leaflet from retrieving non-existent tiles on the borders
-            bounds: [
-              [-85.0511287776, -179.999999975],
-              [85.0511287776, 179.999999975],
-            ],
-            TRStyle: 'satellite', // Not native Leaflet key, required by our layer switch
-          },
-        };
-      }
-
-      // Outdoors (without fallback)
-      if (options.outdoors && isMapboxAvailable && appSettings.mapbox.maps.outdoors) {
-        // Outdoors: Mapbox
-        layers.outdoors = getMapboxLayer(
-          'Outdoors',
-          'streets',
-          appSettings.mapbox.maps.outdoors,
-        );
-      }
-
-      return layers;
+    // Satellite
+    if (options.satellite && isMapboxAvailable && appSettings.mapbox.maps.satellite) {
+      // Satellite: Mapbox
+      layers.satellite = getMapboxLayer(
+        'Satellite',
+        'satellite',
+        appSettings.mapbox.maps.satellite,
+      );
+    } else if (options.satellite) {
+      // Satellite fallback: NASA Earth Data
+      // @link https://earthdata.nasa.gov/about/science-system-description/eosdis-components/global-imagery-browse-services-gibs
+      // @link https://wiki.earthdata.nasa.gov/display/GIBS/GIBS+API+for+Developers#GIBSAPIforDevelopers-ServiceEndpointsandGetCapabilities
+      // @link https://github.com/nasa-gibs/gibs-web-examples/blob/master/examples/leaflet/webmercator-epsg3857.js
+      layers.satellite = {
+        name: 'Satellite',
+        type: 'xyz',
+        url: '//gibs-{s}.earthdata.nasa.gov/wmts/epsg3857/best/{layer}/default/{time}/{tileMatrixSet}/{z}/{y}/{x}.jpg',
+        layerOptions: {
+          layer: 'Landsat_WELD_CorrectedReflectance_TrueColor_Global_Annual',
+          tileMatrixSet: 'GoogleMapsCompatible_Level12',
+          time: '2009-08-22',
+          subdomains: ['a', 'b', 'c'],
+          attribution: '<a href="https://wiki.earthdata.nasa.gov/display/GIBS" target="_blank" rel="noopener">© NASA Earth Data</a>',
+          noWrap: true,
+          continuousWorld: true,
+          tileSize: 256,
+          // Prevent Leaflet from retrieving non-existent tiles on the borders
+          bounds: [
+            [-85.0511287776, -179.999999975],
+            [85.0511287776, 179.999999975],
+          ],
+          TRStyle: 'satellite', // Not native Leaflet key, required by our layer switch
+        },
+      };
     }
 
+    // Outdoors (without fallback)
+    if (options.outdoors && isMapboxAvailable && appSettings.mapbox.maps.outdoors) {
+      // Outdoors: Mapbox
+      layers.outdoors = getMapboxLayer(
+        'Outdoors',
+        'streets',
+        appSettings.mapbox.maps.outdoors,
+      );
+    }
+
+    return layers;
   }
-}());
+
+}

--- a/modules/core/client/services/mapmarkers.client.service.js
+++ b/modules/core/client/services/mapmarkers.client.service.js
@@ -1,119 +1,117 @@
-(function () {
+/**
+ * Service for getting icons, markers and other objects for Leaflet maps
+ */
+angular
+  .module('core')
+  .factory('MapMarkersFactory', MapMarkersFactory);
+
+/* @ngInject */
+function MapMarkersFactory($window) {
+
+  // Size of the map icon in pixels (bigger for smaller screens)
+  const markerIconSize = $window.innerWidth < 768 ? 30 : 20;
+
+  // Base path for icon images
+  const path = '/img/map/';
+
+  // Leaflet.js
+  const Leaflet = $window.L;
+
+  const service = {
+    getIconConfig: getIconConfig,
+    getIcon: getIcon,
+    getOfferCircle: getOfferCircle,
+  };
+
+  return service;
+
   /**
-   * Service for getting icons, markers and other objects for Leaflet maps
+   * Get marker icon object
+   *
+   * http://leafletjs.com/reference-1.2.0.html#icon
+   *
+   * @param {Object} offer - Offer with `status`
+   * @return {Object} Leaflet icon object
    */
-  angular
-    .module('core')
-    .factory('MapMarkersFactory', MapMarkersFactory);
+  function getIcon(offer) {
+    return Leaflet.icon(getIconConfig(offer));
+  }
 
-  /* @ngInject */
-  function MapMarkersFactory($window) {
+  /**
+   * Get marker icon config
+   *
+   * http://leafletjs.com/reference-1.2.0.html#icon
+   *
+   * @param {Object} offer - Offer with `status`
+   * @return {Object} Leaflet icon options
+   */
+  function getIconConfig(offer) {
 
-    // Size of the map icon in pixels (bigger for smaller screens)
-    const markerIconSize = $window.innerWidth < 768 ? 30 : 20;
+    // Set defaults
+    offer.type = offer.type || 'other';
+    offer.status = offer.status || 'yes';
 
-    // Base path for icon images
-    const path = '/img/map/';
+    // Default icon settings
+    const config = {
+      // Default icon image
+      iconUrl: path + 'marker-icon.svg',
 
-    // Leaflet.js
-    const Leaflet = $window.L;
+      // ARIA for Accessibility
+      ariaLabel: 'Other',
 
-    const service = {
-      getIconConfig: getIconConfig,
-      getIcon: getIcon,
-      getOfferCircle: getOfferCircle,
+      // size of the icon in px
+      iconSize: [
+        markerIconSize,
+        markerIconSize,
+      ],
+
+      // point of the icon which will correspond to marker's location
+      iconAnchor: [
+        parseInt(markerIconSize / 2, 10),
+        parseInt(markerIconSize / 2, 10),
+      ],
     };
 
-    return service;
-
-    /**
-     * Get marker icon object
-     *
-     * http://leafletjs.com/reference-1.2.0.html#icon
-     *
-     * @param {Object} offer - Offer with `status`
-     * @return {Object} Leaflet icon object
-     */
-    function getIcon(offer) {
-      return Leaflet.icon(getIconConfig(offer));
+    if (offer.type === 'host' && offer.status === 'yes') {
+      config.iconUrl = path + 'marker-icon-yes.svg';
+      config.ariaLabel = 'Yes host';
+    } else if (offer.type === 'host' && offer.status === 'maybe') {
+      config.iconUrl = path + 'marker-icon-maybe.svg';
+      config.ariaLabel = 'Maybe host';
+    } else if (offer.type === 'meet') {
+      config.iconUrl = path + 'marker-icon-meet.svg';
+      config.ariaLabel = 'Meet host';
     }
 
-    /**
-     * Get marker icon config
-     *
-     * http://leafletjs.com/reference-1.2.0.html#icon
-     *
-     * @param {Object} offer - Offer with `status`
-     * @return {Object} Leaflet icon options
-     */
-    function getIconConfig(offer) {
+    return config;
+  }
 
-      // Set defaults
-      offer.type = offer.type || 'other';
-      offer.status = offer.status || 'yes';
+  /**
+   * Leaflet path configuration for circle under offer markers
+   *
+   * @param {Object} defaults - pass any key to add or replace in default circle config
+   */
+  function getOfferCircle(defaults) {
+    return angular.extend({
+      weight: 2,
+      color: '#989898',
+      fillColor: '#b1b1b1',
+      fillOpacity: 0.5,
+      radius: 500, // Meters
+      type: 'circle',
+      clickable: false,
 
-      // Default icon settings
-      const config = {
-        // Default icon image
-        iconUrl: path + 'marker-icon.svg',
+      // Circle will not emit mouse events and will act as a part of the underlying map
+      interactive: false,
 
-        // ARIA for Accessibility
-        ariaLabel: 'Other',
+      // Note that by default circle is places at "Null Island"
+      // @link https://en.wikipedia.org/wiki/Null_Island
+      // Accepts Leaflet.LatLng
+      // @linkhttp://leafletjs.com/reference-1.2.0.html#latlng
+      latlngs: [0, 0],
 
-        // size of the icon in px
-        iconSize: [
-          markerIconSize,
-          markerIconSize,
-        ],
-
-        // point of the icon which will correspond to marker's location
-        iconAnchor: [
-          parseInt(markerIconSize / 2, 10),
-          parseInt(markerIconSize / 2, 10),
-        ],
-      };
-
-      if (offer.type === 'host' && offer.status === 'yes') {
-        config.iconUrl = path + 'marker-icon-yes.svg';
-        config.ariaLabel = 'Yes host';
-      } else if (offer.type === 'host' && offer.status === 'maybe') {
-        config.iconUrl = path + 'marker-icon-maybe.svg';
-        config.ariaLabel = 'Maybe host';
-      } else if (offer.type === 'meet') {
-        config.iconUrl = path + 'marker-icon-meet.svg';
-        config.ariaLabel = 'Meet host';
-      }
-
-      return config;
-    }
-
-    /**
-     * Leaflet path configuration for circle under offer markers
-     *
-     * @param {Object} defaults - pass any key to add or replace in default circle config
-     */
-    function getOfferCircle(defaults) {
-      return angular.extend({
-        weight: 2,
-        color: '#989898',
-        fillColor: '#b1b1b1',
-        fillOpacity: 0.5,
-        radius: 500, // Meters
-        type: 'circle',
-        clickable: false,
-
-        // Circle will not emit mouse events and will act as a part of the underlying map
-        interactive: false,
-
-        // Note that by default circle is places at "Null Island"
-        // @link https://en.wikipedia.org/wiki/Null_Island
-        // Accepts Leaflet.LatLng
-        // @linkhttp://leafletjs.com/reference-1.2.0.html#latlng
-        latlngs: [0, 0],
-
-      }, defaults || {});
-
-    }
+    }, defaults || {});
 
   }
-}());
+
+}

--- a/modules/core/client/services/message-center-client.service.js
+++ b/modules/core/client/services/message-center-client.service.js
@@ -8,109 +8,107 @@
  * See also modules/core/client/directives/message-center.client.directive.js
  */
 
-(function () {
-  /**
-   * Service for error/success/info etc notifications
-   *
-   * See usage instructions from https://github.com/e0ipso/message-center
-   */
-  angular
-    .module('core')
-    .provider('$messageCenterService', MessageCenterServiceProvider)
-    .service('messageCenterService', MessageCenterService);
+/**
+ * Service for error/success/info etc notifications
+ *
+ * See usage instructions from https://github.com/e0ipso/message-center
+ */
+angular
+  .module('core')
+  .provider('$messageCenterService', MessageCenterServiceProvider)
+  .service('messageCenterService', MessageCenterService);
 
-  /* @ngInject */
-  function MessageCenterServiceProvider() {
-    const _this = this;
-    _this.options = { timeout: 6000 };
-    _this.setGlobalOptions = function (options) {
-      _this.options = options;
-    };
-    _this.getOptions = function () {
-      return _this.options;
-    };
-    this.$get = function () {
-      return {
-        setGlobalOptions: _this.setGlobalOptions,
-        options: _this.options,
-        getOptions: _this.getOptions,
-      };
-    };
-  }
-
-  /* @ngInject */
-  function MessageCenterService($rootScope, $sce, $timeout, $messageCenterService) {
+/* @ngInject */
+function MessageCenterServiceProvider() {
+  const _this = this;
+  _this.options = { timeout: 6000 };
+  _this.setGlobalOptions = function (options) {
+    _this.options = options;
+  };
+  _this.getOptions = function () {
+    return _this.options;
+  };
+  this.$get = function () {
     return {
-      mcMessages: this.mcMessages || [],
-      offlistener: this.offlistener || undefined,
-      status: {
-        unseen: 'unseen',
-        shown: 'shown',
-        /** @var Odds are that you will show a message and right after that
-         * change your route/state. If that happens your message will only be
-         * seen for a fraction of a second. To avoid that use the "next"
-         * status, that will make the message available to the next page */
-        next: 'next',
-        /** @var Do not delete this message automatically. */
-        permanent: 'permanent',
-      },
-      add: function (type, message, options) {
-        const availableTypes = ['info', 'warning', 'danger', 'success'];
-        const service = this;
-        options = options || {};
-        options = angular.extend({}, $messageCenterService.getOptions(), options);
-        if (availableTypes.indexOf(type) === -1) {
-          // eslint-disable-next-line no-throw-literal
-          throw 'Invalid message type';
-        }
-        const messageObject = {
-          type: type,
-          status: options.status || this.status.unseen,
-          processed: false,
-          close: function () {
-            return service.remove(this);
-          },
-        };
-        messageObject.message = options.html ? $sce.trustAsHtml(message) : message;
-        messageObject.html = !!options.html;
-        if (angular.isDefined(options.timeout)) {
-          messageObject.timer = $timeout(function () {
-            messageObject.close();
-          }, options.timeout);
-        }
-        this.mcMessages.push(messageObject);
-        return messageObject;
-      },
-      remove: function (message) {
-        const index = this.mcMessages.indexOf(message);
-        this.mcMessages.splice(index, 1);
-      },
-      reset: function () {
-        this.mcMessages = [];
-      },
-      removeShown: function () {
-        for (let index = this.mcMessages.length - 1; index >= 0; index--) {
-          if (this.mcMessages[index].status === this.status.shown) {
-            this.remove(this.mcMessages[index]);
-          }
-        }
-      },
-      markShown: function () {
-        for (let index = this.mcMessages.length - 1; index >= 0; index--) {
-          if (!this.mcMessages[index].processed) {
-            if (this.mcMessages[index].status === this.status.unseen) {
-              this.mcMessages[index].status = this.status.shown;
-              this.mcMessages[index].processed = true;
-            }
-            else if (this.mcMessages[index].status === this.status.next) {
-              this.mcMessages[index].status = this.status.unseen;
-            }
-          }
-        }
-      },
-      flush: function () {
-        $rootScope.mcMessages = this.mcMessages;
-      },
+      setGlobalOptions: _this.setGlobalOptions,
+      options: _this.options,
+      getOptions: _this.getOptions,
     };
-  }
-}());
+  };
+}
+
+/* @ngInject */
+function MessageCenterService($rootScope, $sce, $timeout, $messageCenterService) {
+  return {
+    mcMessages: this.mcMessages || [],
+    offlistener: this.offlistener || undefined,
+    status: {
+      unseen: 'unseen',
+      shown: 'shown',
+      /** @var Odds are that you will show a message and right after that
+       * change your route/state. If that happens your message will only be
+       * seen for a fraction of a second. To avoid that use the "next"
+       * status, that will make the message available to the next page */
+      next: 'next',
+      /** @var Do not delete this message automatically. */
+      permanent: 'permanent',
+    },
+    add: function (type, message, options) {
+      const availableTypes = ['info', 'warning', 'danger', 'success'];
+      const service = this;
+      options = options || {};
+      options = angular.extend({}, $messageCenterService.getOptions(), options);
+      if (availableTypes.indexOf(type) === -1) {
+        // eslint-disable-next-line no-throw-literal
+        throw 'Invalid message type';
+      }
+      const messageObject = {
+        type: type,
+        status: options.status || this.status.unseen,
+        processed: false,
+        close: function () {
+          return service.remove(this);
+        },
+      };
+      messageObject.message = options.html ? $sce.trustAsHtml(message) : message;
+      messageObject.html = !!options.html;
+      if (angular.isDefined(options.timeout)) {
+        messageObject.timer = $timeout(function () {
+          messageObject.close();
+        }, options.timeout);
+      }
+      this.mcMessages.push(messageObject);
+      return messageObject;
+    },
+    remove: function (message) {
+      const index = this.mcMessages.indexOf(message);
+      this.mcMessages.splice(index, 1);
+    },
+    reset: function () {
+      this.mcMessages = [];
+    },
+    removeShown: function () {
+      for (let index = this.mcMessages.length - 1; index >= 0; index--) {
+        if (this.mcMessages[index].status === this.status.shown) {
+          this.remove(this.mcMessages[index]);
+        }
+      }
+    },
+    markShown: function () {
+      for (let index = this.mcMessages.length - 1; index >= 0; index--) {
+        if (!this.mcMessages[index].processed) {
+          if (this.mcMessages[index].status === this.status.unseen) {
+            this.mcMessages[index].status = this.status.shown;
+            this.mcMessages[index].processed = true;
+          }
+          else if (this.mcMessages[index].status === this.status.next) {
+            this.mcMessages[index].status = this.status.unseen;
+          }
+        }
+      }
+    },
+    flush: function () {
+      $rootScope.mcMessages = this.mcMessages;
+    },
+  };
+}

--- a/modules/core/client/services/native-app-bridge.client.service.js
+++ b/modules/core/client/services/native-app-bridge.client.service.js
@@ -1,198 +1,196 @@
-(function () {
+/**
+ * @ngdoc factory
+ * @name core.factory:trNativeAppBridge
+ * @description
+ * Service for communicating with Native Trustroots mobile app
+ */
+angular
+  .module('core')
+  .factory('trNativeAppBridge', trNativeAppBridgeFactory);
+
+/* @ngInject */
+function trNativeAppBridgeFactory($q, $rootScope, $log, $window, $timeout, $location) {
+
+  const service = {
+    activate: activate,
+    getAppInfo: getAppInfo,
+    isNativeMobileApp: isNativeMobileApp,
+    signalUnAuthenticated: signalUnAuthenticated,
+    signalAuthenticated: signalAuthenticated,
+  };
+
+  return service;
+
   /**
-   * @ngdoc factory
-   * @name core.factory:trNativeAppBridge
-   * @description
-   * Service for communicating with Native Trustroots mobile app
+   * Tells if the site is wrapped inside native mobile app
+   *
+   * @returns {Boolea}
    */
-  angular
-    .module('core')
-    .factory('trNativeAppBridge', trNativeAppBridgeFactory);
-
-  /* @ngInject */
-  function trNativeAppBridgeFactory($q, $rootScope, $log, $window, $timeout, $location) {
-
-    const service = {
-      activate: activate,
-      getAppInfo: getAppInfo,
-      isNativeMobileApp: isNativeMobileApp,
-      signalUnAuthenticated: signalUnAuthenticated,
-      signalAuthenticated: signalAuthenticated,
-    };
-
-    return service;
-
-    /**
-     * Tells if the site is wrapped inside native mobile app
-     *
-     * @returns {Boolea}
-     */
-    function isNativeMobileApp() {
-      return !!$window.isNativeMobileApp;
-    }
-
-    /**
-     * Activate event listener listening for mobile app wrapping the site in
-     * WebView signaling us it's ready.
-     *
-     * @returns {Promise}
-     */
-    function activate() {
-      return $q(function (resolve) {
-        logToNativeApp('trNativeAppBridgeFactory activate');
-        // eslint-disable-next-line angular/document-service
-        document.addEventListener('message', function (event) {
-          // event = event.originalEvent || event;
-          if (event && event.data === 'trMobileAppInit' && !isNativeMobileApp()) {
-            // document.removeEventListener('message');
-
-            bootstrapBridge();
-
-            resolve($window.trMobileApp || { 'res': 'No data' });
-          }
-        });
-      });
-    }
-
-    /**
-     * When mobile app wrapping the site in WebView signals us it's ready,
-     * attempt to bootstrap app bridge.
-     */
-    function bootstrapBridge() {
-      logToNativeApp('Bootstrap native app bridge initialised');
-
-      // Not in native mobile, stop here
-      if (!$window.trMobileApp || !angular.isObject($window.trMobileApp)) {
-        logToNativeApp('Bootstrap native app bridge: not a mobile app');
-        return;
-      }
-
-      // This line has to be before any internal functions of this service,
-      // as those functions check this Boolean is truthy.
-      $window.isNativeMobileApp = true;
-
-      // Signal Native app it can stop polling us with `trMobileAppInit` message
-      postMessageToApp('trNativeAppBridgeInitialized');
-
-      // Look in the DOM for new urls after each state change
-      $rootScope.$on('$stateChangeSuccess', renderOutgoingUrls);
-
-      logToNativeApp('Bootstrap native app bridge done');
-    }
-
-    /**
-     * Hooks onto all outgoing urls and instead of letting them open in current
-     * browser instance (i.e. React Native WebView), sends a custom event to
-     * the app, which then in turn handles opening the URL in the phone.
-     */
-    function renderOutgoingUrls() {
-      logToNativeApp('Render outbound urls');
-
-      const elementPattern = [
-        'a[href^="http://"]',
-        ',', // And
-        'a[href^="https://"]',
-        ',', // And
-        'a[href^="mailto://"]',
-        ',', // And
-        'a[href^="tel://"]',
-        ',', // And
-        'a[href^="tel://"]',
-        // Not:
-        ':not(.tr-app-urlified)',
-        ':not(a[href^="' + $location.protocol() + '://' + $location.host() + '"])',
-        ':not(a[ui-sref])',
-      ].join('');
-
-      // $timetout makes sure we have DOM rendered by Angular
-      $timeout(function () {
-        angular.element(elementPattern).each(function () {
-          angular.element(this)
-            .addClass('tr-app-urlified')
-            .click(function (e) {
-              const url = angular.element(this).attr('href');
-              if (url) {
-                e.preventDefault();
-                postMessageToApp('openUrl', {
-                  url: url,
-                });
-              }
-            });
-        });
-      });
-    }
-
-    /**
-     * Read device & app info, should be something like:
-     * ```
-     * {
-     *   "version": "0.2.0",
-     *   "expoVersion": "1.20.0",
-     *   "deviceName": "E39",
-     *   "deviceYearClass": 2012,
-     *   "os": "android"
-     * }
-     * ```
-     *
-     * @return {Object}
-     */
-    function getAppInfo() {
-      return $window.trMobileApp || {};
-    }
-
-    /**
-     * Send "unAuthenticated" signal to mobile app
-     */
-    function signalUnAuthenticated() {
-      if (!isNativeMobileApp()) {
-        return;
-      }
-      postMessageToApp('unAuthenticated');
-    }
-
-    /**
-     * Send "authenticated" signal to mobile app
-     */
-    function signalAuthenticated() {
-      if (!isNativeMobileApp()) {
-        return;
-      }
-      postMessageToApp('authenticated');
-    }
-
-    /**
-     * Send log info signal to native app so that we know there what underlaying app is doing
-     */
-    function logToNativeApp(str) {
-      $log.log(str);
-      postMessageToApp('log', { log: '[WebView]: ' + str });
-    }
-
-    /**
-     * Uses `window.postMessage()` to signal a messages to the native app
-     *
-     * At native app this page is wrapped in React Native WebView.
-     *
-     * Value in postMessage has to be string.
-     */
-    function postMessageToApp(action, data) {
-      if (!isNativeMobileApp() ||
-          !action ||
-          !angular.isString(action) ||
-          !angular.isFunction($window.postMessage)) {
-        return;
-      }
-
-      data = data && angular.isObject(data) ? data : {};
-
-      const message = angular.extend({
-        action: action,
-      }, data);
-
-      // Note that `angular.toJson()` won't handle Date objects nicely on Safari
-      // https://docs.angularjs.org/api/ng/function/angular.toJson
-      $window.postMessage(angular.toJson(message));
-    }
-
+  function isNativeMobileApp() {
+    return !!$window.isNativeMobileApp;
   }
-}());
+
+  /**
+   * Activate event listener listening for mobile app wrapping the site in
+   * WebView signaling us it's ready.
+   *
+   * @returns {Promise}
+   */
+  function activate() {
+    return $q(function (resolve) {
+      logToNativeApp('trNativeAppBridgeFactory activate');
+      // eslint-disable-next-line angular/document-service
+      document.addEventListener('message', function (event) {
+        // event = event.originalEvent || event;
+        if (event && event.data === 'trMobileAppInit' && !isNativeMobileApp()) {
+          // document.removeEventListener('message');
+
+          bootstrapBridge();
+
+          resolve($window.trMobileApp || { 'res': 'No data' });
+        }
+      });
+    });
+  }
+
+  /**
+   * When mobile app wrapping the site in WebView signals us it's ready,
+   * attempt to bootstrap app bridge.
+   */
+  function bootstrapBridge() {
+    logToNativeApp('Bootstrap native app bridge initialised');
+
+    // Not in native mobile, stop here
+    if (!$window.trMobileApp || !angular.isObject($window.trMobileApp)) {
+      logToNativeApp('Bootstrap native app bridge: not a mobile app');
+      return;
+    }
+
+    // This line has to be before any internal functions of this service,
+    // as those functions check this Boolean is truthy.
+    $window.isNativeMobileApp = true;
+
+    // Signal Native app it can stop polling us with `trMobileAppInit` message
+    postMessageToApp('trNativeAppBridgeInitialized');
+
+    // Look in the DOM for new urls after each state change
+    $rootScope.$on('$stateChangeSuccess', renderOutgoingUrls);
+
+    logToNativeApp('Bootstrap native app bridge done');
+  }
+
+  /**
+   * Hooks onto all outgoing urls and instead of letting them open in current
+   * browser instance (i.e. React Native WebView), sends a custom event to
+   * the app, which then in turn handles opening the URL in the phone.
+   */
+  function renderOutgoingUrls() {
+    logToNativeApp('Render outbound urls');
+
+    const elementPattern = [
+      'a[href^="http://"]',
+      ',', // And
+      'a[href^="https://"]',
+      ',', // And
+      'a[href^="mailto://"]',
+      ',', // And
+      'a[href^="tel://"]',
+      ',', // And
+      'a[href^="tel://"]',
+      // Not:
+      ':not(.tr-app-urlified)',
+      ':not(a[href^="' + $location.protocol() + '://' + $location.host() + '"])',
+      ':not(a[ui-sref])',
+    ].join('');
+
+    // $timetout makes sure we have DOM rendered by Angular
+    $timeout(function () {
+      angular.element(elementPattern).each(function () {
+        angular.element(this)
+          .addClass('tr-app-urlified')
+          .click(function (e) {
+            const url = angular.element(this).attr('href');
+            if (url) {
+              e.preventDefault();
+              postMessageToApp('openUrl', {
+                url: url,
+              });
+            }
+          });
+      });
+    });
+  }
+
+  /**
+   * Read device & app info, should be something like:
+   * ```
+   * {
+   *   "version": "0.2.0",
+   *   "expoVersion": "1.20.0",
+   *   "deviceName": "E39",
+   *   "deviceYearClass": 2012,
+   *   "os": "android"
+   * }
+   * ```
+   *
+   * @return {Object}
+   */
+  function getAppInfo() {
+    return $window.trMobileApp || {};
+  }
+
+  /**
+   * Send "unAuthenticated" signal to mobile app
+   */
+  function signalUnAuthenticated() {
+    if (!isNativeMobileApp()) {
+      return;
+    }
+    postMessageToApp('unAuthenticated');
+  }
+
+  /**
+   * Send "authenticated" signal to mobile app
+   */
+  function signalAuthenticated() {
+    if (!isNativeMobileApp()) {
+      return;
+    }
+    postMessageToApp('authenticated');
+  }
+
+  /**
+   * Send log info signal to native app so that we know there what underlaying app is doing
+   */
+  function logToNativeApp(str) {
+    $log.log(str);
+    postMessageToApp('log', { log: '[WebView]: ' + str });
+  }
+
+  /**
+   * Uses `window.postMessage()` to signal a messages to the native app
+   *
+   * At native app this page is wrapped in React Native WebView.
+   *
+   * Value in postMessage has to be string.
+   */
+  function postMessageToApp(action, data) {
+    if (!isNativeMobileApp() ||
+        !action ||
+        !angular.isString(action) ||
+        !angular.isFunction($window.postMessage)) {
+      return;
+    }
+
+    data = data && angular.isObject(data) ? data : {};
+
+    const message = angular.extend({
+      action: action,
+    }, data);
+
+    // Note that `angular.toJson()` won't handle Date objects nicely on Safari
+    // https://docs.angularjs.org/api/ng/function/angular.toJson
+    $window.postMessage(angular.toJson(message));
+  }
+
+}

--- a/modules/core/client/services/push.client.service.js
+++ b/modules/core/client/services/push.client.service.js
@@ -1,246 +1,244 @@
 import questionModalTemplateUrl from '@/modules/core/client/views/push-notification-question-modal.client.view.html';
 
-(function () {
-  angular
-    .module('core')
-    .factory('push', push);
+angular
+  .module('core')
+  .factory('push', push);
 
-  /* @ngInject */
-  function push(
-    firebaseMessaging,
-    Authentication,
-    messageCenterService,
-    $http,
-    $window,
-    $uibModal,
-    locker,
-    $q) {
+/* @ngInject */
+function push(
+  firebaseMessaging,
+  Authentication,
+  messageCenterService,
+  $http,
+  $window,
+  $uibModal,
+  locker,
+  $q) {
 
-    const LOCKER_KEY = 'tr.push';
+  const LOCKER_KEY = 'tr.push';
 
-    const push = {
-      isSupported: getIsSupported(),
-      isBusy: false,
-      isEnabled: loadEnabled(),
-      isBlocked: getIsBlocked(),
+  const push = {
+    isSupported: getIsSupported(),
+    isBusy: false,
+    isEnabled: loadEnabled(),
+    isBlocked: getIsBlocked(),
 
-      init: function () {
-        if (firebaseMessaging.shouldInitialize) {
-          return setup();
-        } else {
-          return $q.resolve();
-        }
-      },
-
-      /**
-      * Enable local browser push notifications
-      */
-      enable: function () {
-        if (!push.isSupported) return $q.reject(new Error('push is unsupported'));
-        saveEnabled(true);
-        return enable();
-      },
-
-      /**
-      * Disable local browser push notifications
-      */
-      disable: function () {
-        if (!push.isSupported) return $q.reject(new Error('push is unsupported'));
-        saveEnabled(false);
-        return disable();
-      },
-
-    };
-
-    const store = {
-      token: null, // so we can remove it when needed
-    };
-
-    firebaseMessaging.onTokenRefresh(setup);
-
-    firebaseMessaging.onMessage(function (payload) {
-      // eslint-disable-next-line no-new
-      new $window.Notification(payload.notification.title, {
-        body: payload.notification.body,
-      });
-    });
-
-    $window.onbeforeunload = clearServiceWorkersIfNeeded;
-
-    return push;
-
-    function getIsSupported() {
-      return !!($window.Notification &&
-                $window.navigator.serviceWorker &&
-                $window.PushManager);
-    }
-
-    function getIsBlocked() {
-      return $window.Notification && $window.Notification.permission === 'denied';
-    }
-
-    function setup() {
-      if (!push.isSupported) {
-        push.isEnabled = false;
-        saveEnabled(false);
+    init: function () {
+      if (firebaseMessaging.shouldInitialize) {
+        return setup();
+      } else {
         return $q.resolve();
       }
-      // make sure user intention matches reality
-      if (loadEnabled()) {
-        return enable();
-      } else {
-        askUser();
-        return disable();
-      }
-    }
+    },
 
     /**
-     * Ask user if they want to turn push notifications on
-     */
-    function askUser() {
-      const pushAskedKey = LOCKER_KEY + '.asked';
+    * Enable local browser push notifications
+    */
+    enable: function () {
+      if (!push.isSupported) return $q.reject(new Error('push is unsupported'));
+      saveEnabled(true);
+      return enable();
+    },
 
-      // Do not ask if:
-      // - locker isn't supported (we can't store status)
-      // - we've asked already (stored with `locker`)
-      // - no authenticated user
-      if (!locker.supported() || locker.get(pushAskedKey) || !Authentication.user) {
-        return;
-      }
+    /**
+    * Disable local browser push notifications
+    */
+    disable: function () {
+      if (!push.isSupported) return $q.reject(new Error('push is unsupported'));
+      saveEnabled(false);
+      return disable();
+    },
 
-      $uibModal.open({
-        templateUrl: questionModalTemplateUrl,
-        controller: function ($scope, $uibModalInstance) {
-          const vm = this;
+  };
 
-          // Yes! Turn push notifications on
-          vm.yes = function () {
-            // Enable push notifications
-            enable();
+  const store = {
+    token: null, // so we can remove it when needed
+  };
 
-            // Close modal
-            $uibModalInstance.dismiss();
-          };
+  firebaseMessaging.onTokenRefresh(setup);
 
-          // When modal is closed/dismissed
-          $scope.$on('modal.closing', function () {
-            // Store info that we've now asked and user reacted
-            locker.put(pushAskedKey, 'yes');
-          });
+  firebaseMessaging.onMessage(function (payload) {
+    // eslint-disable-next-line no-new
+    new $window.Notification(payload.notification.title, {
+      body: payload.notification.body,
+    });
+  });
 
-        },
-        controllerAs: 'askPushNotificationsModal',
-        animation: true,
-      });
-    }
+  $window.onbeforeunload = clearServiceWorkersIfNeeded;
 
-    function loadEnabled() {
-      return locker.supported() && locker.get(LOCKER_KEY) === 'on';
-    }
+  return push;
 
-    function saveEnabled(enabled) {
-      if (locker.supported()) {
-        if (enabled) {
-          locker.put(LOCKER_KEY, 'on');
-        } else {
-          locker.forget(LOCKER_KEY);
-        }
-      }
-      return enabled;
-    }
-
-    function receivedToken(token) {
-      if (userHasToken(token)) {
-        // token already registered on server
-        return $q.resolve();
-      } else {
-        return addTokenToServer(token);
-      }
-    }
-
-    function enable() {
-      push.isBusy = true;
-      return firebaseMessaging.getToken()
-        .then(function (token) {
-          store.token = token;
-          if (token) {
-            return receivedToken(token).then(function () {
-              push.isEnabled = true;
-              push.isBusy = false;
-            });
-          } else {
-            // no token yet, have to ask user nicely
-            return firebaseMessaging.requestPermission().then(enable);
-          }
-        }).catch(function (err) {
-          if (err.code === 'messaging/notifications-blocked' ||
-              err.code === 'messaging/permission-blocked') {
-            push.isBlocked = true;
-          }
-          push.isBusy = false;
-          return $q.reject(err || new Error('Unknown error'));
-        });
-    }
-
-    function disable() {
-      if (!store.token) return $q.resolve();
-      push.isBusy = true;
-      return firebaseMessaging.deleteToken(
-        store.token,
-      ).then(function () {
-        return removeTokenFromServer(store.token);
-      }).then(function () {
-        push.isBusy = false;
-        store.token = null;
-        push.isEnabled = false;
-      }).catch(function (err) {
-        push.isBusy = false;
-        return $q.reject(err);
-      });
-    }
-
-    function userHasToken(token) {
-      return !!Authentication.user.pushRegistration.find(function (registration) {
-        return registration.token === token;
-      });
-    }
-
-    function addTokenToServer(token) {
-      return $http.post('/api/users/push/registrations', { token: token, platform: 'web' })
-        .then(function (res) {
-          Authentication.user = res.data.user;
-        }).catch(handleServerError);
-    }
-
-    function removeTokenFromServer(token) {
-      return $http.delete('/api/users/push/registrations/' + token)
-        .then(function (res) {
-          Authentication.user = res.data.user;
-        }).catch(handleServerError);
-    }
-
-    function handleServerError(response) {
-      let errorMessage;
-      if (response) {
-        errorMessage = 'Error: ' + ((response.data && response.data.message) || 'Something went wrong.');
-      } else {
-        errorMessage = 'Something went wrong.';
-      }
-      messageCenterService.add('danger', errorMessage);
-      return $q.reject(new Error(errorMessage));
-    }
-
-    function clearServiceWorkersIfNeeded() {
-      if (!push.isSupported) return;
-      /*
-        remove any service workers that are not needed
-        we cannot do it before this as firebase throws a wobbly if it
-        can't find the previous service worker
-      */
-      if (!loadEnabled()) {
-        firebaseMessaging.removeServiceWorker();
-      }
-    }
-
+  function getIsSupported() {
+    return !!($window.Notification &&
+              $window.navigator.serviceWorker &&
+              $window.PushManager);
   }
-}());
+
+  function getIsBlocked() {
+    return $window.Notification && $window.Notification.permission === 'denied';
+  }
+
+  function setup() {
+    if (!push.isSupported) {
+      push.isEnabled = false;
+      saveEnabled(false);
+      return $q.resolve();
+    }
+    // make sure user intention matches reality
+    if (loadEnabled()) {
+      return enable();
+    } else {
+      askUser();
+      return disable();
+    }
+  }
+
+  /**
+   * Ask user if they want to turn push notifications on
+   */
+  function askUser() {
+    const pushAskedKey = LOCKER_KEY + '.asked';
+
+    // Do not ask if:
+    // - locker isn't supported (we can't store status)
+    // - we've asked already (stored with `locker`)
+    // - no authenticated user
+    if (!locker.supported() || locker.get(pushAskedKey) || !Authentication.user) {
+      return;
+    }
+
+    $uibModal.open({
+      templateUrl: questionModalTemplateUrl,
+      controller: function ($scope, $uibModalInstance) {
+        const vm = this;
+
+        // Yes! Turn push notifications on
+        vm.yes = function () {
+          // Enable push notifications
+          enable();
+
+          // Close modal
+          $uibModalInstance.dismiss();
+        };
+
+        // When modal is closed/dismissed
+        $scope.$on('modal.closing', function () {
+          // Store info that we've now asked and user reacted
+          locker.put(pushAskedKey, 'yes');
+        });
+
+      },
+      controllerAs: 'askPushNotificationsModal',
+      animation: true,
+    });
+  }
+
+  function loadEnabled() {
+    return locker.supported() && locker.get(LOCKER_KEY) === 'on';
+  }
+
+  function saveEnabled(enabled) {
+    if (locker.supported()) {
+      if (enabled) {
+        locker.put(LOCKER_KEY, 'on');
+      } else {
+        locker.forget(LOCKER_KEY);
+      }
+    }
+    return enabled;
+  }
+
+  function receivedToken(token) {
+    if (userHasToken(token)) {
+      // token already registered on server
+      return $q.resolve();
+    } else {
+      return addTokenToServer(token);
+    }
+  }
+
+  function enable() {
+    push.isBusy = true;
+    return firebaseMessaging.getToken()
+      .then(function (token) {
+        store.token = token;
+        if (token) {
+          return receivedToken(token).then(function () {
+            push.isEnabled = true;
+            push.isBusy = false;
+          });
+        } else {
+          // no token yet, have to ask user nicely
+          return firebaseMessaging.requestPermission().then(enable);
+        }
+      }).catch(function (err) {
+        if (err.code === 'messaging/notifications-blocked' ||
+            err.code === 'messaging/permission-blocked') {
+          push.isBlocked = true;
+        }
+        push.isBusy = false;
+        return $q.reject(err || new Error('Unknown error'));
+      });
+  }
+
+  function disable() {
+    if (!store.token) return $q.resolve();
+    push.isBusy = true;
+    return firebaseMessaging.deleteToken(
+      store.token,
+    ).then(function () {
+      return removeTokenFromServer(store.token);
+    }).then(function () {
+      push.isBusy = false;
+      store.token = null;
+      push.isEnabled = false;
+    }).catch(function (err) {
+      push.isBusy = false;
+      return $q.reject(err);
+    });
+  }
+
+  function userHasToken(token) {
+    return !!Authentication.user.pushRegistration.find(function (registration) {
+      return registration.token === token;
+    });
+  }
+
+  function addTokenToServer(token) {
+    return $http.post('/api/users/push/registrations', { token: token, platform: 'web' })
+      .then(function (res) {
+        Authentication.user = res.data.user;
+      }).catch(handleServerError);
+  }
+
+  function removeTokenFromServer(token) {
+    return $http.delete('/api/users/push/registrations/' + token)
+      .then(function (res) {
+        Authentication.user = res.data.user;
+      }).catch(handleServerError);
+  }
+
+  function handleServerError(response) {
+    let errorMessage;
+    if (response) {
+      errorMessage = 'Error: ' + ((response.data && response.data.message) || 'Something went wrong.');
+    } else {
+      errorMessage = 'Something went wrong.';
+    }
+    messageCenterService.add('danger', errorMessage);
+    return $q.reject(new Error(errorMessage));
+  }
+
+  function clearServiceWorkersIfNeeded() {
+    if (!push.isSupported) return;
+    /*
+      remove any service workers that are not needed
+      we cannot do it before this as firebase throws a wobbly if it
+      can't find the previous service worker
+    */
+    if (!loadEnabled()) {
+      firebaseMessaging.removeServiceWorker();
+    }
+  }
+
+}

--- a/modules/core/client/services/settings.client.service.js
+++ b/modules/core/client/services/settings.client.service.js
@@ -1,56 +1,52 @@
-(function () {
-  angular
-    .module('core')
-    .factory('SettingsService', SettingsService);
+angular
+  .module('core')
+  .factory('SettingsService', SettingsService);
 
-  /* @ngInject */
-  function SettingsService($window) {
-    let settings = {};
-    const service = {
-      get: get,
-      settings: settings,
-    };
-    return service;
+/* @ngInject */
+function SettingsService($window) {
+  let settings = {};
+  const service = {
+    get: get,
+    settings: settings,
+  };
+  return service;
 
-    function get() {
-      // Settings passed from the backend
-      settings = $window.settings;
+  function get() {
+    // Settings passed from the backend
+    settings = $window.settings;
 
-      // Gimme settings
-      return settings;
-    }
+    // Gimme settings
+    return settings;
   }
-}());
+}
 
 
 // TODO: Clean this out (deprecated)
 
-(function () {
-  angular
-    .module('core')
-    .factory('SettingsFactory', SettingsFactory);
+angular
+  .module('core')
+  .factory('SettingsFactory', SettingsFactory);
 
-  /* @ngInject */
-  function SettingsFactory($window) {
-    let settings = {};
-    const service = {
-      get: get,
-      settings: settings,
-    };
-    return service;
+/* @ngInject */
+function SettingsFactory($window) {
+  let settings = {};
+  const service = {
+    get: get,
+    settings: settings,
+  };
+  return service;
 
-    function get() {
-      // Settings passed from the backend
-      settings = $window.settings;
+  function get() {
+    // Settings passed from the backend
+    settings = $window.settings;
 
-      // Extend with defaults
-      angular.extend(settings, {
-        // Default timeout for 'message-center' success/alert messages
-        flashTimeout: 6000,
-      });
+    // Extend with defaults
+    angular.extend(settings, {
+      // Default timeout for 'message-center' success/alert messages
+      flashTimeout: 6000,
+    });
 
-      // Gimme settings
-      return settings;
-    }
+    // Gimme settings
+    return settings;
   }
-}());
+}

--- a/modules/core/tests/client/age.client.filter.tests.js
+++ b/modules/core/tests/client/age.client.filter.tests.js
@@ -3,25 +3,23 @@ import AppConfig from '@/modules/core/client/app/config';
 /**
  * Age filter tests
  */
-(function () {
-  describe('Age Filter Tests', function () {
+describe('Age Filter Tests', function () {
 
-    // Load the main application module
-    beforeEach(angular.mock.module(AppConfig.appModuleName));
+  // Load the main application module
+  beforeEach(angular.mock.module(AppConfig.appModuleName));
 
-    // Note that 10 is November in Date
-    const dateObj = new Date(1985, 10, 22);
-    const ageDifMs = Date.now() - dateObj.getTime();
-    const ageDate = new Date(ageDifMs); // miliseconds from epoch
-    const ageYears = Math.abs(ageDate.getUTCFullYear() - 1970);
+  // Note that 10 is November in Date
+  const dateObj = new Date(1985, 10, 22);
+  const ageDifMs = Date.now() - dateObj.getTime();
+  const ageDate = new Date(ageDifMs); // miliseconds from epoch
+  const ageYears = Math.abs(ageDate.getUTCFullYear() - 1970);
 
-    it('should return age in years from a date string', inject(function (ageyearsFilter) {
-      expect(ageyearsFilter('1985-11-22')).toBe(ageYears + ' years');
-    }));
+  it('should return age in years from a date string', inject(function (ageyearsFilter) {
+    expect(ageyearsFilter('1985-11-22')).toBe(ageYears + ' years');
+  }));
 
-    it('should return age in years from a date object', inject(function (ageyearsFilter) {
-      expect(ageyearsFilter(new Date(1985, 10, 22))).toBe(ageYears + ' years');
-    }));
+  it('should return age in years from a date object', inject(function (ageyearsFilter) {
+    expect(ageyearsFilter(new Date(1985, 10, 22))).toBe(ageYears + ' years');
+  }));
 
-  });
-}());
+});

--- a/modules/core/tests/client/app.client.controller.tests.js
+++ b/modules/core/tests/client/app.client.controller.tests.js
@@ -3,77 +3,75 @@ import AppConfig from '@/modules/core/client/app/config';
 /**
  * App client controller tests
  */
-(function () {
-  describe('App Controller Tests', function () {
-    // Initialize global variables
-    let $scope;
-    let $state;
-    let Authentication;
-    let SettingsFactory;
-    let Languages;
+describe('App Controller Tests', function () {
+  // Initialize global variables
+  let $scope;
+  let $state;
+  let Authentication;
+  let SettingsFactory;
+  let Languages;
 
-    // Load the main application module
-    beforeEach(angular.mock.module(AppConfig.appModuleName));
+  // Load the main application module
+  beforeEach(angular.mock.module(AppConfig.appModuleName));
 
-    beforeEach(inject(function ($controller, $rootScope, _$state_, _Authentication_, _SettingsFactory_, _Languages_) {
-      $scope = $rootScope.$new();
+  beforeEach(inject(function ($controller, $rootScope, _$state_, _Authentication_, _SettingsFactory_, _Languages_) {
+    $scope = $rootScope.$new();
 
-      // Point global variables to injected services
-      Authentication = _Authentication_;
-      SettingsFactory = _SettingsFactory_;
-      Languages = _Languages_;
-      $state = _$state_;
+    // Point global variables to injected services
+    Authentication = _Authentication_;
+    SettingsFactory = _SettingsFactory_;
+    Languages = _Languages_;
+    $state = _$state_;
 
 
-      // Mock logged in user
-      Authentication.user = {
-        roles: ['user'],
-      };
+    // Mock logged in user
+    Authentication.user = {
+      roles: ['user'],
+    };
 
-      // Mock settings
-      SettingsFactory = {
-        get: function () {
-          return {};
-        },
-      };
-      spyOn(SettingsFactory, 'get');
+    // Mock settings
+    SettingsFactory = {
+      get: function () {
+        return {};
+      },
+    };
+    spyOn(SettingsFactory, 'get');
 
-      // Mock languages
-      Languages = {
-        get: function () {
-          return {};
-        },
-      };
-      spyOn(Languages, 'get');
+    // Mock languages
+    Languages = {
+      get: function () {
+        return {};
+      },
+    };
+    spyOn(Languages, 'get');
 
-      // Spy on state go
-      spyOn($state, 'go');
+    // Spy on state go
+    spyOn($state, 'go');
 
-      // Initialize the App controller.
-      $controller('AppController as vm', {
-        $scope: $scope,
-        SettingsFactory: SettingsFactory,
-        Languages: Languages,
-      });
-    }));
-
-    it('should expose app settings', function () {
-      expect(SettingsFactory.get).toHaveBeenCalled();
-      // expect($scope.vm.appSettings).toBeTruthy();
+    // Initialize the App controller.
+    $controller('AppController as vm', {
+      $scope: $scope,
+      SettingsFactory: SettingsFactory,
+      Languages: Languages,
     });
+  }));
 
-    it('should expose languages', function () {
-      expect(Languages.get).toHaveBeenCalledWith('object');
-      // expect($scope.vm.languageNames).toBeTruthy();
-    });
-
-    it('should expose photo credits', function () {
-      expect($scope.vm.photoCredits).toBeTruthy();
-      expect($scope.vm.photoCreditsCount).toEqual(0);
-    });
-
-    it('should expose the user', function () {
-      expect($scope.vm.user).toBeTruthy();
-    });
+  it('should expose app settings', function () {
+    expect(SettingsFactory.get).toHaveBeenCalled();
+    // expect($scope.vm.appSettings).toBeTruthy();
   });
-}());
+
+  it('should expose languages', function () {
+    expect(Languages.get).toHaveBeenCalledWith('object');
+    // expect($scope.vm.languageNames).toBeTruthy();
+  });
+
+  it('should expose photo credits', function () {
+    expect($scope.vm.photoCredits).toBeTruthy();
+    expect($scope.vm.photoCreditsCount).toEqual(0);
+  });
+
+  it('should expose the user', function () {
+    expect($scope.vm.user).toBeTruthy();
+  });
+});

--- a/modules/core/tests/client/plain-text-length.client.filter.tests.js
+++ b/modules/core/tests/client/plain-text-length.client.filter.tests.js
@@ -3,32 +3,30 @@ import AppConfig from '@/modules/core/client/app/config';
 /**
  * PlainTextLength filter tests
  */
-(function () {
-  describe('PlainTextLength Filter Tests', function () {
+describe('PlainTextLength Filter Tests', function () {
 
-    // Load the main application module
-    beforeEach(angular.mock.module(AppConfig.appModuleName));
+  // Load the main application module
+  beforeEach(angular.mock.module(AppConfig.appModuleName));
 
-    it('should return length for a string', inject(function (plainTextLengthFilter) {
-      expect(plainTextLengthFilter('test')).toBe(4);
-      expect(plainTextLengthFilter('')).toBe(0);
-    }));
+  it('should return length for a string', inject(function (plainTextLengthFilter) {
+    expect(plainTextLengthFilter('test')).toBe(4);
+    expect(plainTextLengthFilter('')).toBe(0);
+  }));
 
-    it('should return length for a string after stripping out html', inject(function (plainTextLengthFilter) {
-      expect(plainTextLengthFilter('<h1>HTML</h1><p><b>test&nbsp; test  </b></p>')).toBe(14);
-    }));
+  it('should return length for a string after stripping out html', inject(function (plainTextLengthFilter) {
+    expect(plainTextLengthFilter('<h1>HTML</h1><p><b>test&nbsp; test  </b></p>')).toBe(14);
+  }));
 
-    it('should return 0 length for non string values', inject(function (plainTextLengthFilter) {
-      expect(plainTextLengthFilter(false)).toBe(0);
-      expect(plainTextLengthFilter({ test: 'test' })).toBe(0);
-      expect(plainTextLengthFilter(null)).toBe(0);
-      expect(plainTextLengthFilter(['A', 'B', 'C'])).toBe(0);
-      expect(plainTextLengthFilter(1 + 2)).toBe(0);
-    }));
+  it('should return 0 length for non string values', inject(function (plainTextLengthFilter) {
+    expect(plainTextLengthFilter(false)).toBe(0);
+    expect(plainTextLengthFilter({ test: 'test' })).toBe(0);
+    expect(plainTextLengthFilter(null)).toBe(0);
+    expect(plainTextLengthFilter(['A', 'B', 'C'])).toBe(0);
+    expect(plainTextLengthFilter(1 + 2)).toBe(0);
+  }));
 
-    it('should return length for a string after stripping white space', inject(function (plainTextLengthFilter) {
-      expect(plainTextLengthFilter('   test   ')).toBe(4);
-    }));
+  it('should return length for a string after stripping white space', inject(function (plainTextLengthFilter) {
+    expect(plainTextLengthFilter('   test   ')).toBe(4);
+  }));
 
-  });
-}());
+});

--- a/modules/core/tests/client/push.client.service.tests.js
+++ b/modules/core/tests/client/push.client.service.tests.js
@@ -3,261 +3,259 @@ import AppConfig from '@/modules/core/client/app/config';
 /**
  * Push service
  */
-(function () {
-  describe('Push Service Tests', function () {
+describe('Push Service Tests', function () {
 
-    let $httpBackend;
-    let firebaseMessaging;
-    let locker;
+  let $httpBackend;
+  let firebaseMessaging;
+  let locker;
 
-    const firebase = createFirebaseMock();
+  const firebase = createFirebaseMock();
 
-    // Load the main application module
-    beforeEach(angular.mock.module(AppConfig.appModuleName, firebase.moduleName));
+  // Load the main application module
+  beforeEach(angular.mock.module(AppConfig.appModuleName, firebase.moduleName));
 
-    beforeEach(firebase.reset);
+  beforeEach(firebase.reset);
 
-    const notifications = [];
+  const notifications = [];
 
-    beforeEach(inject(function (
-      _$httpBackend_, _locker_, $window, Authentication, _firebaseMessaging_) {
+  beforeEach(inject(function (
+    _$httpBackend_, _locker_, $window, Authentication, _firebaseMessaging_) {
 
-      $httpBackend = _$httpBackend_;
-      locker = _locker_;
-      firebaseMessaging = _firebaseMessaging_;
-      Authentication.user = {
-        pushRegistration: [],
-      };
-      notifications.length = 0;
-      firebaseMessaging.shouldInitialize = false;
-      $window.Notification = function (title, options) {
-        notifications.push({ title: title, options: options });
-      };
-    }));
+    $httpBackend = _$httpBackend_;
+    locker = _locker_;
+    firebaseMessaging = _firebaseMessaging_;
+    Authentication.user = {
+      pushRegistration: [],
+    };
+    notifications.length = 0;
+    firebaseMessaging.shouldInitialize = false;
+    $window.Notification = function (title, options) {
+      notifications.push({ title: title, options: options });
+    };
+  }));
 
-    afterEach(function () {
-      locker.clean();
-    });
-
-    afterEach(function () {
-      $httpBackend.verifyNoOutstandingExpectation();
-      $httpBackend.verifyNoOutstandingRequest();
-    });
-
-    it('will save to server if enabled', inject(function (
-      push, Authentication) {
-      if (!push.isSupported) return;
-
-      const token = 'mynicetoken';
-      firebase.token = token;
-
-      $httpBackend.expect('POST', '/api/users/push/registrations',
-        { token: token, platform: 'web' })
-        .respond(200, {
-          user: {
-            pushRegistration: [{ token: token, platform: 'web', created: Date.now() }],
-          },
-        });
-
-      push.enable();
-
-      $httpBackend.flush();
-      expect(firebase.requestPermissionCalled).toBe(1);
-      expect(firebase.permissionGranted).toBe(true);
-      expect(Authentication.user.pushRegistration.length).toBe(1);
-      expect(Authentication.user.pushRegistration[0].token).toBe(token);
-      expect(locker.get('tr.push')).toBe('on');
-    }));
-
-    it('will save to server during initialization if on but not present', inject(function (
-      push, Authentication) {
-      if (!push.isSupported) return;
-
-      const token = 'mynicetokenforinitializing';
-
-      $httpBackend.expect('POST', '/api/users/push/registrations',
-        { token: token, platform: 'web' })
-        .respond(200, {
-          user: {
-            pushRegistration: [{
-              token: token,
-              platform: 'web',
-              created: Date.now(),
-            }],
-          },
-        });
-
-      // if we turn it on...
-      locker.put('tr.push', 'on');
-      firebase.permissionGranted = true;
-      firebase.token = token;
-
-      // .. and enable it to be initialized
-      firebaseMessaging.shouldInitialize = true;
-
-      // we will cause it to register on the server
-      push.init();
-
-      expect(Authentication.user.pushRegistration.length).toBe(0);
-
-      $httpBackend.flush();
-
-      expect(Authentication.user.pushRegistration.length).toBe(1);
-      expect(Authentication.user.pushRegistration[0].token).toBe(token);
-    }));
-
-    it('can be disabled and will be removed from server', inject(function (
-      push, Authentication, locker, $rootScope) {
-      if (!push.isSupported) return;
-
-      const token = 'sometokenfordisabling';
-
-      // Preregister it
-      firebase.token = token;
-      firebase.permissionGranted = true;
-      Authentication.user.pushRegistration.push({
-        token: token, platform: 'web',
-      });
-
-      expect(push.isEnabled).toBe(false);
-
-      // first enable it ...
-
-      push.enable();
-      $rootScope.$apply();
-
-      expect(firebase.requestPermissionCalled).toBe(0);
-      expect(Authentication.user.pushRegistration.length).toBe(1);
-      expect(locker.get('tr.push')).toBe('on');
-      expect(push.isEnabled).toBe(true);
-
-      // ... now disable it again
-
-      $httpBackend.expect('DELETE', '/api/users/push/registrations/' + token)
-        .respond(200, {
-          user: {
-            pushRegistration: [],
-          },
-        });
-
-      push.disable();
-      $httpBackend.flush();
-
-      expect(Authentication.user.pushRegistration.length).toBe(0);
-      expect(locker.get('tr.push')).toBeFalsy();
-      expect(firebase.deletedTokens.length).toBe(1);
-      expect(firebase.deletedTokens[0]).toBe(token);
-      expect(push.isEnabled).toBe(false);
-
-    }));
-
-    it('will not save to server if enabling and already registered', inject(function (
-      push, Authentication, $rootScope) {
-      if (!push.isSupported) return;
-
-      const token = 'sometoken';
-      // Preregister it
-      firebase.token = token;
-      firebase.permissionGranted = true;
-      Authentication.user.pushRegistration.push({
-        token: token, platform: 'web',
-      });
-      push.enable();
-      $rootScope.$apply();
-      expect(firebase.requestPermissionCalled).toBe(0);
-      expect(push.isEnabled).toBe(true);
-      expect(locker.get('tr.push')).toBe('on');
-    }));
-
-    it('should trigger a notification when a message is received', inject(function (push) {
-      if (!push.isSupported) return;
-      firebase.triggerOnMessage({
-        notification: {
-          title: 'foo',
-          body: 'yay',
-        },
-      });
-      expect(notifications.length).toBe(1);
-      expect(notifications[0].title).toBe('foo');
-      expect(notifications[0].options.body).toBe('yay');
-    }));
-
+  afterEach(function () {
+    locker.clean();
   });
 
-  function createFirebaseMock() {
+  afterEach(function () {
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+  });
 
-    const onMessageCallbacks = [];
-    const onTokenRefreshCallbacks = [];
+  it('will save to server if enabled', inject(function (
+    push, Authentication) {
+    if (!push.isSupported) return;
 
-    const firebase = {
-      deletedTokens: [],
-      reset: reset,
-      moduleName: 'firebaseMessagingMock',
+    const token = 'mynicetoken';
+    firebase.token = token;
 
-      triggerOnMessage: function () {
-        const args = arguments;
-        onMessageCallbacks.forEach(function (fn) {
-          fn.apply(null, args);
-        });
+    $httpBackend.expect('POST', '/api/users/push/registrations',
+      { token: token, platform: 'web' })
+      .respond(200, {
+        user: {
+          pushRegistration: [{ token: token, platform: 'web', created: Date.now() }],
+        },
+      });
+
+    push.enable();
+
+    $httpBackend.flush();
+    expect(firebase.requestPermissionCalled).toBe(1);
+    expect(firebase.permissionGranted).toBe(true);
+    expect(Authentication.user.pushRegistration.length).toBe(1);
+    expect(Authentication.user.pushRegistration[0].token).toBe(token);
+    expect(locker.get('tr.push')).toBe('on');
+  }));
+
+  it('will save to server during initialization if on but not present', inject(function (
+    push, Authentication) {
+    if (!push.isSupported) return;
+
+    const token = 'mynicetokenforinitializing';
+
+    $httpBackend.expect('POST', '/api/users/push/registrations',
+      { token: token, platform: 'web' })
+      .respond(200, {
+        user: {
+          pushRegistration: [{
+            token: token,
+            platform: 'web',
+            created: Date.now(),
+          }],
+        },
+      });
+
+    // if we turn it on...
+    locker.put('tr.push', 'on');
+    firebase.permissionGranted = true;
+    firebase.token = token;
+
+    // .. and enable it to be initialized
+    firebaseMessaging.shouldInitialize = true;
+
+    // we will cause it to register on the server
+    push.init();
+
+    expect(Authentication.user.pushRegistration.length).toBe(0);
+
+    $httpBackend.flush();
+
+    expect(Authentication.user.pushRegistration.length).toBe(1);
+    expect(Authentication.user.pushRegistration[0].token).toBe(token);
+  }));
+
+  it('can be disabled and will be removed from server', inject(function (
+    push, Authentication, locker, $rootScope) {
+    if (!push.isSupported) return;
+
+    const token = 'sometokenfordisabling';
+
+    // Preregister it
+    firebase.token = token;
+    firebase.permissionGranted = true;
+    Authentication.user.pushRegistration.push({
+      token: token, platform: 'web',
+    });
+
+    expect(push.isEnabled).toBe(false);
+
+    // first enable it ...
+
+    push.enable();
+    $rootScope.$apply();
+
+    expect(firebase.requestPermissionCalled).toBe(0);
+    expect(Authentication.user.pushRegistration.length).toBe(1);
+    expect(locker.get('tr.push')).toBe('on');
+    expect(push.isEnabled).toBe(true);
+
+    // ... now disable it again
+
+    $httpBackend.expect('DELETE', '/api/users/push/registrations/' + token)
+      .respond(200, {
+        user: {
+          pushRegistration: [],
+        },
+      });
+
+    push.disable();
+    $httpBackend.flush();
+
+    expect(Authentication.user.pushRegistration.length).toBe(0);
+    expect(locker.get('tr.push')).toBeFalsy();
+    expect(firebase.deletedTokens.length).toBe(1);
+    expect(firebase.deletedTokens[0]).toBe(token);
+    expect(push.isEnabled).toBe(false);
+
+  }));
+
+  it('will not save to server if enabling and already registered', inject(function (
+    push, Authentication, $rootScope) {
+    if (!push.isSupported) return;
+
+    const token = 'sometoken';
+    // Preregister it
+    firebase.token = token;
+    firebase.permissionGranted = true;
+    Authentication.user.pushRegistration.push({
+      token: token, platform: 'web',
+    });
+    push.enable();
+    $rootScope.$apply();
+    expect(firebase.requestPermissionCalled).toBe(0);
+    expect(push.isEnabled).toBe(true);
+    expect(locker.get('tr.push')).toBe('on');
+  }));
+
+  it('should trigger a notification when a message is received', inject(function (push) {
+    if (!push.isSupported) return;
+    firebase.triggerOnMessage({
+      notification: {
+        title: 'foo',
+        body: 'yay',
       },
+    });
+    expect(notifications.length).toBe(1);
+    expect(notifications[0].title).toBe('foo');
+    expect(notifications[0].options.body).toBe('yay');
+  }));
 
-      triggerOnTokenRefresh: function () {
-        const args = arguments;
-        onTokenRefreshCallbacks.forEach(function (fn) {
-          fn.apply(null, args);
-        });
-      },
+});
 
-    };
+function createFirebaseMock() {
 
-    function reset() {
-      onMessageCallbacks.length = 0;
-      onTokenRefreshCallbacks.length = 0;
-      firebase.token = null;
-      firebase.permissionGranted = false;
-      firebase.deletedTokens.length = 0;
-      firebase.requestPermissionCalled = 0;
-      firebase.removeServiceWorkerCalled = 0;
-    }
+  const onMessageCallbacks = [];
+  const onTokenRefreshCallbacks = [];
 
-    angular.module(firebase.moduleName, [])
+  const firebase = {
+    deletedTokens: [],
+    reset: reset,
+    moduleName: 'firebaseMessagingMock',
 
-      // this will replace the real one
-      .factory('firebaseMessaging', create);
+    triggerOnMessage: function () {
+      const args = arguments;
+      onMessageCallbacks.forEach(function (fn) {
+        fn.apply(null, args);
+      });
+    },
 
-    function create($q) {
-      return {
-        name: 'fcm-mock',
-        shouldInitialize: false, // means core does not set it up for us
-        getToken: function () {
-          if (firebase.permissionGranted) {
-            return $q.resolve(firebase.token);
-          } else {
-            return $q.resolve(null);
-          }
-        },
-        requestPermission: function () {
-          firebase.permissionGranted = true;
-          firebase.requestPermissionCalled++;
-          return $q.resolve();
-        },
-        deleteToken: function (token) {
-          firebase.deletedTokens.push(token);
-          return $q.resolve();
-        },
-        onTokenRefresh: function (fn) {
-          onTokenRefreshCallbacks.push(fn);
-        },
-        onMessage: function (fn) {
-          onMessageCallbacks.push(fn);
-        },
-        removeServiceWorker: function () {
-          firebase.removeServiceWorkerCalled++;
-        },
-      };
-    }
+    triggerOnTokenRefresh: function () {
+      const args = arguments;
+      onTokenRefreshCallbacks.forEach(function (fn) {
+        fn.apply(null, args);
+      });
+    },
 
-    return firebase;
+  };
 
+  function reset() {
+    onMessageCallbacks.length = 0;
+    onTokenRefreshCallbacks.length = 0;
+    firebase.token = null;
+    firebase.permissionGranted = false;
+    firebase.deletedTokens.length = 0;
+    firebase.requestPermissionCalled = 0;
+    firebase.removeServiceWorkerCalled = 0;
   }
-}());
+
+  angular.module(firebase.moduleName, [])
+
+    // this will replace the real one
+    .factory('firebaseMessaging', create);
+
+  function create($q) {
+    return {
+      name: 'fcm-mock',
+      shouldInitialize: false, // means core does not set it up for us
+      getToken: function () {
+        if (firebase.permissionGranted) {
+          return $q.resolve(firebase.token);
+        } else {
+          return $q.resolve(null);
+        }
+      },
+      requestPermission: function () {
+        firebase.permissionGranted = true;
+        firebase.requestPermissionCalled++;
+        return $q.resolve();
+      },
+      deleteToken: function (token) {
+        firebase.deletedTokens.push(token);
+        return $q.resolve();
+      },
+      onTokenRefresh: function (fn) {
+        onTokenRefreshCallbacks.push(fn);
+      },
+      onMessage: function (fn) {
+        onMessageCallbacks.push(fn);
+      },
+      removeServiceWorker: function () {
+        firebase.removeServiceWorkerCalled++;
+      },
+    };
+  }
+
+  return firebase;
+
+}

--- a/modules/core/tests/client/trusted-html.client.filter.tests.js
+++ b/modules/core/tests/client/trusted-html.client.filter.tests.js
@@ -3,15 +3,13 @@ import AppConfig from '@/modules/core/client/app/config';
 /**
  * Trusted HTML filter tests
  */
-(function () {
-  describe('Trusted HTML Filter Tests', function () {
+describe('Trusted HTML Filter Tests', function () {
 
-    // Load the main application module
-    beforeEach(angular.mock.module(AppConfig.appModuleName));
+  // Load the main application module
+  beforeEach(angular.mock.module(AppConfig.appModuleName));
 
-    it('should return string with html', inject(function (trustedHtmlFilter) {
-      expect(trustedHtmlFilter('<b>HTML content</b>').$$unwrapTrustedValue()).toEqual('<b>HTML content</b>');
-    }));
+  it('should return string with html', inject(function (trustedHtmlFilter) {
+    expect(trustedHtmlFilter('<b>HTML content</b>').$$unwrapTrustedValue()).toEqual('<b>HTML content</b>');
+  }));
 
-  });
-}());
+});

--- a/modules/messages/client/config/messages.client.routes.js
+++ b/modules/messages/client/config/messages.client.routes.js
@@ -1,48 +1,46 @@
 import inboxTemplateUrl from '@/modules/messages/client/views/inbox.client.view.html';
 import messageThreadTemplateUrl from '@/modules/messages/client/views/thread.client.view.html';
 
-(function () {
-  angular
-    .module('messages')
-    .config(MessagesRoutes);
+angular
+  .module('messages')
+  .config(MessagesRoutes);
 
-  /* @ngInject */
-  function MessagesRoutes($stateProvider) {
+/* @ngInject */
+function MessagesRoutes($stateProvider) {
 
-    // Messages state routing
-    $stateProvider.
-      state('inbox', {
-        url: '/messages',
-        templateUrl: inboxTemplateUrl,
-        controller: 'InboxController',
-        controllerAs: 'inbox',
-        requiresAuth: true,
-        data: {
-          pageTitle: 'Messages',
-        },
-      }).
-      state('messageThread', {
-        url: '/messages/:username',
-        templateUrl: messageThreadTemplateUrl,
-        controller: 'MessagesThreadController',
-        controllerAs: 'thread',
-        requiresAuth: true,
-        footerHidden: true,
-        resolve: {
-          // A string value resolves to a service
-          UserProfilesService: 'UserProfilesService',
-          SettingsService: 'SettingsService',
+  // Messages state routing
+  $stateProvider.
+    state('inbox', {
+      url: '/messages',
+      templateUrl: inboxTemplateUrl,
+      controller: 'InboxController',
+      controllerAs: 'inbox',
+      requiresAuth: true,
+      data: {
+        pageTitle: 'Messages',
+      },
+    }).
+    state('messageThread', {
+      url: '/messages/:username',
+      templateUrl: messageThreadTemplateUrl,
+      controller: 'MessagesThreadController',
+      controllerAs: 'thread',
+      requiresAuth: true,
+      footerHidden: true,
+      resolve: {
+        // A string value resolves to a service
+        UserProfilesService: 'UserProfilesService',
+        SettingsService: 'SettingsService',
 
-          userTo: function (UserProfilesService, $stateParams) {
-            return UserProfilesService.get({ username: $stateParams.username });
-          },
-          appSettings: function (SettingsService) {
-            return SettingsService.get();
-          },
+        userTo: function (UserProfilesService, $stateParams) {
+          return UserProfilesService.get({ username: $stateParams.username });
         },
-        data: {
-          pageTitle: 'Messages',
+        appSettings: function (SettingsService) {
+          return SettingsService.get();
         },
-      });
-  }
-}());
+      },
+      data: {
+        pageTitle: 'Messages',
+      },
+    });
+}

--- a/modules/messages/client/controllers/inbox.client.controller.js
+++ b/modules/messages/client/controllers/inbox.client.controller.js
@@ -1,92 +1,90 @@
-(function () {
-  angular
-    .module('messages')
-    .controller('InboxController', InboxController);
+angular
+  .module('messages')
+  .controller('InboxController', InboxController);
 
-  /* @ngInject */
-  function InboxController($rootScope, $state, $analytics, Authentication, Messages, $log) {
+/* @ngInject */
+function InboxController($rootScope, $state, $analytics, Authentication, Messages, $log) {
 
-    // ViewModel
-    const vm = this;
+  // ViewModel
+  const vm = this;
 
-    // Exposed to the view
-    vm.threads = [];
-    vm.messageHandler = new Messages();
-    vm.moreMessages = moreMessages;
-    vm.otherParticipant = otherParticipant;
-    vm.openThread = openThread;
+  // Exposed to the view
+  vm.threads = [];
+  vm.messageHandler = new Messages();
+  vm.moreMessages = moreMessages;
+  vm.otherParticipant = otherParticipant;
+  vm.openThread = openThread;
 
-    // Fetches first page of messages
-    vm.messageHandler.fetchMessages().$promise
-      .then(function (data) {
-        addMessages(data);
-      }, function () {
-        $log.warn('Could not fetch messages.');
-      });
+  // Fetches first page of messages
+  vm.messageHandler.fetchMessages().$promise
+    .then(function (data) {
+      addMessages(data);
+    }, function () {
+      $log.warn('Could not fetch messages.');
+    });
 
-    activate();
+  activate();
 
-    function activate() {
-      // Tell unread-messages directive to sync itself
-      $rootScope.$broadcast('syncUnreadMessagesCount');
-    }
-
-    // Appends returned messages to model
-    function addMessages(data) {
-      angular.forEach(data, function (msg) {
-        vm.threads.unshift(msg);
-      });
-    }
-
-    /**
-     * Gets next page of messages
-     * Activates when the last thread element hits the bottom view port
-     */
-    function moreMessages(waypointsDown) {
-      if (vm.messageHandler.nextPage && waypointsDown) {
-        vm.messageHandler.fetchMessages().$promise.then(function (data) {
-          addMessages(data);
-        });
-
-        $analytics.eventTrack('inbox-pagination', {
-          category: 'messages.inbox',
-          label: 'Inbox page ' + vm.messageHandler.nextPage,
-        });
-      }
-    }
-
-    /**
-     * Solve which of two thread participants is "the other", not logged in user
-     * This is needed since thread handle has two fields for users 'userTo' and 'userFrom'
-     * and either one can be 'the other', depending who replied the latest.
-     *
-     * Return either displayName or user object
-     */
-    function otherParticipant(thread, value) {
-      const other = (thread.userFrom && thread.userFrom._id === Authentication.user._id) ? thread.userTo : thread.userFrom;
-
-      if (!other) {
-        return;
-      }
-
-      if (value && value === 'displayName') {
-        return other.displayName;
-      } else if (value && value === 'username') {
-        return other.username;
-      } else {
-        // User object
-        return other;
-      }
-    }
-
-    /*
-     * Open thread
-     */
-    function openThread(user) {
-      if (angular.isDefined(user.username)) {
-        $state.go('messageThread', { username: user.username });
-      }
-    }
-
+  function activate() {
+    // Tell unread-messages directive to sync itself
+    $rootScope.$broadcast('syncUnreadMessagesCount');
   }
-}());
+
+  // Appends returned messages to model
+  function addMessages(data) {
+    angular.forEach(data, function (msg) {
+      vm.threads.unshift(msg);
+    });
+  }
+
+  /**
+   * Gets next page of messages
+   * Activates when the last thread element hits the bottom view port
+   */
+  function moreMessages(waypointsDown) {
+    if (vm.messageHandler.nextPage && waypointsDown) {
+      vm.messageHandler.fetchMessages().$promise.then(function (data) {
+        addMessages(data);
+      });
+
+      $analytics.eventTrack('inbox-pagination', {
+        category: 'messages.inbox',
+        label: 'Inbox page ' + vm.messageHandler.nextPage,
+      });
+    }
+  }
+
+  /**
+   * Solve which of two thread participants is "the other", not logged in user
+   * This is needed since thread handle has two fields for users 'userTo' and 'userFrom'
+   * and either one can be 'the other', depending who replied the latest.
+   *
+   * Return either displayName or user object
+   */
+  function otherParticipant(thread, value) {
+    const other = (thread.userFrom && thread.userFrom._id === Authentication.user._id) ? thread.userTo : thread.userFrom;
+
+    if (!other) {
+      return;
+    }
+
+    if (value && value === 'displayName') {
+      return other.displayName;
+    } else if (value && value === 'username') {
+      return other.username;
+    } else {
+      // User object
+      return other;
+    }
+  }
+
+  /*
+   * Open thread
+   */
+  function openThread(user) {
+    if (angular.isDefined(user.username)) {
+      $state.go('messageThread', { username: user.username });
+    }
+  }
+
+}

--- a/modules/messages/client/controllers/thread.client.controller.js
+++ b/modules/messages/client/controllers/thread.client.controller.js
@@ -1,392 +1,390 @@
-(function () {
-  /*
- * checklist:
- * - scope init variable - needed?
- * - scaffolding order
- * - directive scaffolding ord.
- * - check $apply and $timeout order
- * - check if vm.isInitialized should come much later?
- */
+/*
+* checklist:
+* - scope init variable - needed?
+* - scaffolding order
+* - directive scaffolding ord.
+* - check $apply and $timeout order
+* - check if vm.isInitialized should come much later?
+*/
 
-  angular
-    .module('messages')
-    .controller('MessagesThreadController', MessagesThreadController);
+angular
+  .module('messages')
+  .controller('MessagesThreadController', MessagesThreadController);
 
-  /* @ngInject */
-  function MessagesThreadController($rootScope, $scope, $stateParams, $state, $timeout, $filter, $analytics, Authentication, Messages, MessagesRead, messageCenterService, locker, userTo) {
+/* @ngInject */
+function MessagesThreadController($rootScope, $scope, $stateParams, $state, $timeout, $filter, $analytics, Authentication, Messages, MessagesRead, messageCenterService, locker, userTo) {
 
-    // Go back to inbox on these cases
-    // - No recepient defined
-    // - Not signed in
-    // - Sending messages to yourself
-    if (!$stateParams.username || !Authentication.user || Authentication.user._id === userTo._id) {
-      $state.go('inbox');
-    }
+  // Go back to inbox on these cases
+  // - No recepient defined
+  // - Not signed in
+  // - Sending messages to yourself
+  if (!$stateParams.username || !Authentication.user || Authentication.user._id === userTo._id) {
+    $state.go('inbox');
+  }
 
-    // Vars
-    let elemThread;
-    let syncReadTimer;
-    let flaggedAsRead = [];
-    const messageIdsInView = [];
-    let editorContentChangedTimeout;
+  // Vars
+  let elemThread;
+  let syncReadTimer;
+  let flaggedAsRead = [];
+  const messageIdsInView = [];
+  let editorContentChangedTimeout;
 
-    // Make cache id unique for this user
-    const cachePrefix = 'messages.thread.' + Authentication.user._id + '-' + $stateParams.username;
+  // Make cache id unique for this user
+  const cachePrefix = 'messages.thread.' + Authentication.user._id + '-' + $stateParams.username;
 
-    // View model
-    const vm = this;
+  // View model
+  const vm = this;
 
-    // Exposed to the view
-    vm.userFrom = Authentication.user;
-    vm.userTo = userTo;
-    vm.isSending = false;
-    vm.isInitialized = false;
-    vm.isQuickReplyPanelHidden = true;
-    vm.messages = [];
-    vm.messageHandler = new Messages();
-    vm.profileDescriptionLength = Authentication.user.description ? $filter('plainTextLength')(Authentication.user.description) : 0;
-    vm.sendMessage = sendMessage;
-    vm.moreMessages = moreMessages;
-    vm.messageRead = messageRead;
-    vm.focusToWriting = focusToWriting;
-    vm.sendHostingReply = sendHostingReply;
-    vm.hostingReplyStatus = hostingReplyStatus;
-    vm.editorContentChanged = editorContentChanged;
-    vm.content = '';
+  // Exposed to the view
+  vm.userFrom = Authentication.user;
+  vm.userTo = userTo;
+  vm.isSending = false;
+  vm.isInitialized = false;
+  vm.isQuickReplyPanelHidden = true;
+  vm.messages = [];
+  vm.messageHandler = new Messages();
+  vm.profileDescriptionLength = Authentication.user.description ? $filter('plainTextLength')(Authentication.user.description) : 0;
+  vm.sendMessage = sendMessage;
+  vm.moreMessages = moreMessages;
+  vm.messageRead = messageRead;
+  vm.focusToWriting = focusToWriting;
+  vm.sendHostingReply = sendHostingReply;
+  vm.hostingReplyStatus = hostingReplyStatus;
+  vm.editorContentChanged = editorContentChanged;
+  vm.content = '';
 
-    activate();
+  activate();
+
+  /**
+   * Initialize controller
+   */
+  function activate() {
+    // Tell unread-messages directive to sync itself
+    $rootScope.$broadcast('syncUnreadMessagesCount');
 
     /**
-     * Initialize controller
+     * Is local/sessionStorage supported? This might fail in browser's incognito mode
+     *
+     * If it is, unfinished messages are cached to SessionStorage
+     * Check for a previously saved message here
+     *
+     * See also sendMessage(), where message is clared
      */
-    function activate() {
-      // Tell unread-messages directive to sync itself
-      $rootScope.$broadcast('syncUnreadMessagesCount');
+    if (locker.supported()) {
+      // Get message from cache, use default if it doesn't exist
+      vm.content = locker.driver('session').get(cachePrefix, '');
+    }
 
-      /**
-       * Is local/sessionStorage supported? This might fail in browser's incognito mode
-       *
-       * If it is, unfinished messages are cached to SessionStorage
-       * Check for a previously saved message here
-       *
-       * See also sendMessage(), where message is clared
-       */
-      if (locker.supported()) {
-        // Get message from cache, use default if it doesn't exist
-        vm.content = locker.driver('session').get(cachePrefix, '');
-      }
+    // Fetches first page of messages after receiving user has finished loading (we need the userId from there)
+    userTo.$promise.then(function () {
+      fetchMessages().$promise.then(function (data) {
 
-      // Fetches first page of messages after receiving user has finished loading (we need the userId from there)
-      userTo.$promise.then(function () {
-        fetchMessages().$promise.then(function (data) {
+        addMessages(data);
+        vm.isInitialized = true;
 
-          addMessages(data);
-          vm.isInitialized = true;
-
-          if (data.length > 0) {
-            const userReplied = checkAuthUserReplied(data);
-            if (!userReplied) {
-              vm.isQuickReplyPanelHidden = false;
-            }
+        if (data.length > 0) {
+          const userReplied = checkAuthUserReplied(data);
+          if (!userReplied) {
+            vm.isQuickReplyPanelHidden = false;
           }
-
-          // Timeout makes sure thread-dimensions-directive has finished loading
-          // and there would thus be something actually listening to these broadcasts:
-          $timeout(function () {
-            $scope.$broadcast('threadRefreshLayout');
-            if (data.length > 0) {
-              $scope.$broadcast('threadScrollToBottom');
-            }
-          });
-
-        });
-      },
-      // No user...
-      function (error) {
-        // User not found...
-        if (error.status === 404) {
-          vm.isInitialized = true;
-        // Other Unexpected errors...
-        } else {
-          messageCenterService.add('warning', error.message || 'Cannot load messages. Please refresh the page and try again.', { timeout: 20000 });
-        }
-      });
-
-    }
-
-    /**
-     * Sends a predefined quickreply
-     *
-     * @param {String} reply - 'yes' for positive, 'no' for negative
-     */
-    function sendHostingReply(reply) {
-      vm.isQuickReplyPanelHidden = true;
-
-      let quickReplyMessage;
-
-      if (reply === 'yes') {
-        quickReplyMessage = 'Yes, I can host!';
-      } else {
-        quickReplyMessage = 'Sorry, I can\'t host';
-      }
-
-      // Send a normal message with predefined content
-      sendMessage(
-        // This attribute must be whitelisted in `sanitizeOptions` at
-        // `modules/core/server/services/text.server.service.js`
-        '<p data-hosting="' + reply + '">' +
-          '<b><i>' +
-            quickReplyMessage +
-          '</i></b>' +
-        '</p>',
-      );
-
-      $analytics.eventTrack('messages.hostingreply.' + reply, {
-        category: 'messages.hostingreply',
-        label: 'Message hosting hosting reply "' + reply + '"',
-      });
-    }
-
-    /**
-     * Set focus to message textfield and hide quickreply buttons
-     */
-    function focusToWriting() {
-      vm.isQuickReplyPanelHidden = true;
-      angular.element('#message-reply-content').focus();
-    }
-
-    /**
-     * Used to determine if message contains hosting request reply
-     *
-     * @param {String} messageContent - Message to be analysed
-     * @returns {String} - 'unknown' if it doesn't, 'yes' if it does and reply is positive, 'no' if it does and reply is negative
-     */
-    function hostingReplyStatus(messageContent) {
-
-      // Message has a hosting request reply and it's positive
-      if (messageContent.substr(0, 21) === '<p data-hosting="yes"') {
-        return 'yes';
-      }
-
-      // Message has a hosting request reply and it's negative
-      if (messageContent.substr(0, 20) === '<p data-hosting="no"') {
-        return 'no';
-      }
-
-      // Message doesn't have hosting request reply
-      return 'unknown';
-    }
-
-    /**
-    *
-    * Check if Authenticated Receiver Replied to a request
-    */
-    function checkAuthUserReplied(data) {
-      for (let i = 0; i < data.length; i++) {
-        if (Authentication.user._id === data[i].userFrom._id) {
-          return true;
-        }
-      }
-      return false;
-    }
-
-    /**
-     * When contents at the editor change, update layout
-     */
-    function editorContentChanged() {
-      // Add (or reset) timeout to prevent calling this too often
-      $timeout.cancel(editorContentChangedTimeout);
-      editorContentChangedTimeout = $timeout(refreshAndScrollToBottom, 300);
-    }
-
-    /**
-     * Call underlaying thread-dimensions directive to update+scroll
-     */
-    function refreshAndScrollToBottom() {
-      $scope.$broadcast('threadRefreshLayout');
-      $scope.$broadcast('threadScrollToBottom');
-
-      // Save message to a cache (see sendMessage() where it's emptiet and vm-list for the getter)
-      if (locker.supported()) {
-        locker.driver('session').put(cachePrefix, vm.content);
-      }
-    }
-
-    /**
-     * Attach userID for backend calls
-     */
-    function fetchMessages() {
-      return (
-        vm.messageHandler.fetchMessages({
-          userId: userTo._id,
-        })
-      );
-    }
-
-    /**
-     * Appends returned messages to model
-     */
-    function addMessages(data) {
-
-      // Loop trough received data (for loop is the fastest)
-      for (let i = 0; i < data.length; i++) {
-
-        // Check if message by this ID doesn't exist yet
-        // messageIdsInView is used as a key storage for quick reference of messages already in view
-        if (messageIdsInView.indexOf(data[i]._id) === -1) {
-          messageIdsInView.push(data[i]._id);
-          vm.messages.push(data[i]);
-        }
-      }
-
-      // Finally refresh the layout
-      $timeout(function () {
-        $scope.$broadcast('threadRefreshLayout');
-      });
-
-    }
-
-    /**
-     * Gets next page of messages
-     * Activates when the first(top most) message hits the top viewport
-     */
-    function moreMessages() {
-      if (vm.messageHandler.nextPage && !vm.messageHandler.paginationTimeout) {
-
-        vm.isQuickReplyPanelHidden = true;
-
-        if (!elemThread) elemThread = angular.element('#messages-thread');
-
-        const oldHeight = elemThread[0].scrollHeight;
-
-        fetchMessages().$promise.then(function (data) {
-          addMessages(data);
-          setScrollPosition(oldHeight);
-        });
-
-        $analytics.eventTrack('thread-pagination', {
-          category: 'messages.thread',
-          label: 'Message thread page ' + (vm.messageHandler.nextPage ? vm.messageHandler.nextPage.page : 0),
-        });
-      }
-    }
-
-    /**
-     * Restores scroll position after pagination
-     * Timeout is in place to force function to execute after digest cycle to properly calculate scroll height.
-     */
-    function setScrollPosition(oldHeight) {
-      $timeout(function () {
-        const newHeight = elemThread[0].scrollHeight;
-        angular.element(elemThread.scrollTop(newHeight - oldHeight));
-      });
-    }
-
-
-    /**
-     * Send messages marked as read (at frontend) to the backend
-     * Has 1s timeout to slow down continuous pinging of the API
-     */
-    function activateSyncRead() {
-      // Cancel previously set timer
-      if (syncReadTimer) $timeout.cancel(syncReadTimer);
-      // syncRead happens with 1s delay
-      // (and gets postponed by 1s if new activateSyncRead() happens)
-      if (flaggedAsRead.length > 0) {
-        syncReadTimer = $timeout(syncRead, 1000);
-      }
-    }
-
-    /**
-     * Send messages marked at read to the API and then empty buffer
-     */
-    function syncRead() {
-      MessagesRead.query({
-        messageIds: flaggedAsRead,
-      }, function () {
-        flaggedAsRead = [];
-        // Tell app controller to sync this counter
-        $rootScope.$broadcast('syncUnreadMessagesCount');
-      });
-    }
-
-    /**
-     * Mark message read at the frontend
-     * This function inits each time message div passes viewport
-     * Read message id is stored at array which will be sent to backend and emptied
-     *
-     * @todo: kill observer after message is marked read
-     * @todo: having this as a function is a performance issue
-     */
-    function messageRead(message, scrollingUp, scrollingDown) {
-
-      // It was read earlier
-      if (message.read === true) return true;
-
-      // Own messages are always read
-      if (message.userFrom._id === Authentication.user._id) return true;
-
-      // It got marked read just now
-      const read = (scrollingUp === true || scrollingDown === true);
-      if (message.userFrom._id !== Authentication.user._id && !message.read && read) {
-        message.read = true;
-        flaggedAsRead.push(message._id);
-        activateSyncRead();
-      }
-
-      return read;
-    }
-
-    /**
-     * Send a message
-     */
-    function sendMessage(msg) {
-      vm.isSending = true;
-
-      // Make sure the message isn't empty.
-      // Sometimes we'll have some empty blocks due wysiwyg
-      if (!msg) {
-        if ($filter('plainTextLength')(vm.content) === 0) {
-          vm.isSending = false;
-          messageCenterService.add('warning', 'Please write a message first...');
-          return;
-        }
-      }
-
-      // eslint-disable-next-line new-cap
-      const message = new vm.messageHandler.ajaxCall({
-        content: msg,
-        userTo: userTo._id,
-        read: false,
-      });
-
-      message.$save(function (response) {
-
-        vm.isSending = false;
-
-        // Remove message from cache
-        if (locker.supported()) {
-          locker.driver('session').forget(cachePrefix);
         }
 
-        // Remove this when socket is back!
-        vm.messages.unshift(response);
-
-        $analytics.eventTrack('message.send', {
-          category: 'messages',
-          label: 'Message send',
-        });
-
-        // $timeout ensures scroll happens only after DOM has finished rendering
+        // Timeout makes sure thread-dimensions-directive has finished loading
+        // and there would thus be something actually listening to these broadcasts:
         $timeout(function () {
-          $scope.$broadcast('threadScrollToBottom');
+          $scope.$broadcast('threadRefreshLayout');
+          if (data.length > 0) {
+            $scope.$broadcast('threadScrollToBottom');
+          }
         });
 
-      }, function (errorResponse) {
-        vm.isSending = false;
-        messageCenterService.add('danger', (errorResponse.data && errorResponse.data.message) ? errorResponse.data.message : 'Could not send the message. Please try again.');
       });
-    }
+    },
+    // No user...
+    function (error) {
+      // User not found...
+      if (error.status === 404) {
+        vm.isInitialized = true;
+      // Other Unexpected errors...
+      } else {
+        messageCenterService.add('warning', error.message || 'Cannot load messages. Please refresh the page and try again.', { timeout: 20000 });
+      }
+    });
 
   }
-}());
+
+  /**
+   * Sends a predefined quickreply
+   *
+   * @param {String} reply - 'yes' for positive, 'no' for negative
+   */
+  function sendHostingReply(reply) {
+    vm.isQuickReplyPanelHidden = true;
+
+    let quickReplyMessage;
+
+    if (reply === 'yes') {
+      quickReplyMessage = 'Yes, I can host!';
+    } else {
+      quickReplyMessage = 'Sorry, I can\'t host';
+    }
+
+    // Send a normal message with predefined content
+    sendMessage(
+      // This attribute must be whitelisted in `sanitizeOptions` at
+      // `modules/core/server/services/text.server.service.js`
+      '<p data-hosting="' + reply + '">' +
+        '<b><i>' +
+          quickReplyMessage +
+        '</i></b>' +
+      '</p>',
+    );
+
+    $analytics.eventTrack('messages.hostingreply.' + reply, {
+      category: 'messages.hostingreply',
+      label: 'Message hosting hosting reply "' + reply + '"',
+    });
+  }
+
+  /**
+   * Set focus to message textfield and hide quickreply buttons
+   */
+  function focusToWriting() {
+    vm.isQuickReplyPanelHidden = true;
+    angular.element('#message-reply-content').focus();
+  }
+
+  /**
+   * Used to determine if message contains hosting request reply
+   *
+   * @param {String} messageContent - Message to be analysed
+   * @returns {String} - 'unknown' if it doesn't, 'yes' if it does and reply is positive, 'no' if it does and reply is negative
+   */
+  function hostingReplyStatus(messageContent) {
+
+    // Message has a hosting request reply and it's positive
+    if (messageContent.substr(0, 21) === '<p data-hosting="yes"') {
+      return 'yes';
+    }
+
+    // Message has a hosting request reply and it's negative
+    if (messageContent.substr(0, 20) === '<p data-hosting="no"') {
+      return 'no';
+    }
+
+    // Message doesn't have hosting request reply
+    return 'unknown';
+  }
+
+  /**
+  *
+  * Check if Authenticated Receiver Replied to a request
+  */
+  function checkAuthUserReplied(data) {
+    for (let i = 0; i < data.length; i++) {
+      if (Authentication.user._id === data[i].userFrom._id) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * When contents at the editor change, update layout
+   */
+  function editorContentChanged() {
+    // Add (or reset) timeout to prevent calling this too often
+    $timeout.cancel(editorContentChangedTimeout);
+    editorContentChangedTimeout = $timeout(refreshAndScrollToBottom, 300);
+  }
+
+  /**
+   * Call underlaying thread-dimensions directive to update+scroll
+   */
+  function refreshAndScrollToBottom() {
+    $scope.$broadcast('threadRefreshLayout');
+    $scope.$broadcast('threadScrollToBottom');
+
+    // Save message to a cache (see sendMessage() where it's emptiet and vm-list for the getter)
+    if (locker.supported()) {
+      locker.driver('session').put(cachePrefix, vm.content);
+    }
+  }
+
+  /**
+   * Attach userID for backend calls
+   */
+  function fetchMessages() {
+    return (
+      vm.messageHandler.fetchMessages({
+        userId: userTo._id,
+      })
+    );
+  }
+
+  /**
+   * Appends returned messages to model
+   */
+  function addMessages(data) {
+
+    // Loop trough received data (for loop is the fastest)
+    for (let i = 0; i < data.length; i++) {
+
+      // Check if message by this ID doesn't exist yet
+      // messageIdsInView is used as a key storage for quick reference of messages already in view
+      if (messageIdsInView.indexOf(data[i]._id) === -1) {
+        messageIdsInView.push(data[i]._id);
+        vm.messages.push(data[i]);
+      }
+    }
+
+    // Finally refresh the layout
+    $timeout(function () {
+      $scope.$broadcast('threadRefreshLayout');
+    });
+
+  }
+
+  /**
+   * Gets next page of messages
+   * Activates when the first(top most) message hits the top viewport
+   */
+  function moreMessages() {
+    if (vm.messageHandler.nextPage && !vm.messageHandler.paginationTimeout) {
+
+      vm.isQuickReplyPanelHidden = true;
+
+      if (!elemThread) elemThread = angular.element('#messages-thread');
+
+      const oldHeight = elemThread[0].scrollHeight;
+
+      fetchMessages().$promise.then(function (data) {
+        addMessages(data);
+        setScrollPosition(oldHeight);
+      });
+
+      $analytics.eventTrack('thread-pagination', {
+        category: 'messages.thread',
+        label: 'Message thread page ' + (vm.messageHandler.nextPage ? vm.messageHandler.nextPage.page : 0),
+      });
+    }
+  }
+
+  /**
+   * Restores scroll position after pagination
+   * Timeout is in place to force function to execute after digest cycle to properly calculate scroll height.
+   */
+  function setScrollPosition(oldHeight) {
+    $timeout(function () {
+      const newHeight = elemThread[0].scrollHeight;
+      angular.element(elemThread.scrollTop(newHeight - oldHeight));
+    });
+  }
+
+
+  /**
+   * Send messages marked as read (at frontend) to the backend
+   * Has 1s timeout to slow down continuous pinging of the API
+   */
+  function activateSyncRead() {
+    // Cancel previously set timer
+    if (syncReadTimer) $timeout.cancel(syncReadTimer);
+    // syncRead happens with 1s delay
+    // (and gets postponed by 1s if new activateSyncRead() happens)
+    if (flaggedAsRead.length > 0) {
+      syncReadTimer = $timeout(syncRead, 1000);
+    }
+  }
+
+  /**
+   * Send messages marked at read to the API and then empty buffer
+   */
+  function syncRead() {
+    MessagesRead.query({
+      messageIds: flaggedAsRead,
+    }, function () {
+      flaggedAsRead = [];
+      // Tell app controller to sync this counter
+      $rootScope.$broadcast('syncUnreadMessagesCount');
+    });
+  }
+
+  /**
+   * Mark message read at the frontend
+   * This function inits each time message div passes viewport
+   * Read message id is stored at array which will be sent to backend and emptied
+   *
+   * @todo: kill observer after message is marked read
+   * @todo: having this as a function is a performance issue
+   */
+  function messageRead(message, scrollingUp, scrollingDown) {
+
+    // It was read earlier
+    if (message.read === true) return true;
+
+    // Own messages are always read
+    if (message.userFrom._id === Authentication.user._id) return true;
+
+    // It got marked read just now
+    const read = (scrollingUp === true || scrollingDown === true);
+    if (message.userFrom._id !== Authentication.user._id && !message.read && read) {
+      message.read = true;
+      flaggedAsRead.push(message._id);
+      activateSyncRead();
+    }
+
+    return read;
+  }
+
+  /**
+   * Send a message
+   */
+  function sendMessage(msg) {
+    vm.isSending = true;
+
+    // Make sure the message isn't empty.
+    // Sometimes we'll have some empty blocks due wysiwyg
+    if (!msg) {
+      if ($filter('plainTextLength')(vm.content) === 0) {
+        vm.isSending = false;
+        messageCenterService.add('warning', 'Please write a message first...');
+        return;
+      }
+    }
+
+    // eslint-disable-next-line new-cap
+    const message = new vm.messageHandler.ajaxCall({
+      content: msg,
+      userTo: userTo._id,
+      read: false,
+    });
+
+    message.$save(function (response) {
+
+      vm.isSending = false;
+
+      // Remove message from cache
+      if (locker.supported()) {
+        locker.driver('session').forget(cachePrefix);
+      }
+
+      // Remove this when socket is back!
+      vm.messages.unshift(response);
+
+      $analytics.eventTrack('message.send', {
+        category: 'messages',
+        label: 'Message send',
+      });
+
+      // $timeout ensures scroll happens only after DOM has finished rendering
+      $timeout(function () {
+        $scope.$broadcast('threadScrollToBottom');
+      });
+
+    }, function (errorResponse) {
+      vm.isSending = false;
+      messageCenterService.add('danger', (errorResponse.data && errorResponse.data.message) ? errorResponse.data.message : 'Could not send the message. Please try again.');
+    });
+  }
+
+}

--- a/modules/messages/client/directives/thread-dimensions.client.directive.js
+++ b/modules/messages/client/directives/thread-dimensions.client.directive.js
@@ -1,128 +1,126 @@
-(function () {
-  angular
-    .module('messages')
-    .directive('threadDimensions', threadDimensionsDirective);
+angular
+  .module('messages')
+  .directive('threadDimensions', threadDimensionsDirective);
 
-  /* @ngInject */
-  function threadDimensionsDirective($window, $timeout) {
+/* @ngInject */
+function threadDimensionsDirective($window, $timeout) {
 
-    return {
-      link: function (scope, elemContainer) {
+  return {
+    link: function (scope, elemContainer) {
 
-        // vars used with $timeout to cancel() timeouts.
-        let refreshLayoutTimeout;
-        let scrollToBottomTimeout;
-        let onScrollTimeout;
-        let isInitialized = false;
+      // vars used with $timeout to cancel() timeouts.
+      let refreshLayoutTimeout;
+      let scrollToBottomTimeout;
+      let onScrollTimeout;
+      let isInitialized = false;
 
-        // Directive is attached to #thread-container element (var elemContainer)
-        // Rest of the elements are siblings (except <html> of course)
+      // Directive is attached to #thread-container element (var elemContainer)
+      // Rest of the elements are siblings (except <html> of course)
 
-        const elemThread = angular.element('#messages-thread');
-        const elemReply = angular.element('#message-reply');
-        let elemReplyHeight = elemReply.height();
-        const elemHtml = angular.element('html');
-        const elemQuickReply = angular.element('#message-quick-reply');
+      const elemThread = angular.element('#messages-thread');
+      const elemReply = angular.element('#message-reply');
+      let elemReplyHeight = elemReply.height();
+      const elemHtml = angular.element('html');
+      const elemQuickReply = angular.element('#message-quick-reply');
 
-        /**
-         * Fire resize() at <html> so that jQuery-Waypoints wakes up and can thus
-         * check what's visible on the screen and mark visible messages read.
-         */
-        elemThread.bind('scroll', function () {
-          if (onScrollTimeout) $timeout.cancel(onScrollTimeout);
-          onScrollTimeout = $timeout(function () {
-            elemHtml.resize();
-          }, 300);
+      /**
+       * Fire resize() at <html> so that jQuery-Waypoints wakes up and can thus
+       * check what's visible on the screen and mark visible messages read.
+       */
+      elemThread.bind('scroll', function () {
+        if (onScrollTimeout) $timeout.cancel(onScrollTimeout);
+        onScrollTimeout = $timeout(function () {
+          elemHtml.resize();
+        }, 300);
+      });
+
+      /**
+       * Timeout wrapper for refreshLayout() function
+       */
+      function activateRefreshLayout() {
+        // Add (or reset) timeout to prevent calling this too often
+        $timeout.cancel(refreshLayoutTimeout);
+        refreshLayoutTimeout = $timeout(refreshLayout, 300);
+      }
+
+      /**
+       * Scroll thread to bottom to show latest messages
+       */
+      const scrollToBottom = function () {
+        elemThread.scrollTop(elemThread[0].scrollHeight);
+      };
+
+      /**
+       * Timeout wrapper for scrollToBottom() function
+       */
+      function activateScrollToBottom() {
+        // Add (or reset) timeout to prevent calling this too often
+        $timeout.cancel(scrollToBottomTimeout);
+        scrollToBottomTimeout = $timeout(scrollToBottom, 300);
+      }
+
+
+      /**
+       * Refresh layout
+       *
+       * Keep thread in good condition when screen resizes/orientation changes/message textrea grows
+       * This sorta should be at .less files, but the message thread is such an complicated peace of UI...
+       * Mostly this is needed due growing text field
+       */
+      function refreshLayout() {
+
+        if (!isInitialized) {
+          isInitialized = true;
+          $timeout(function () {
+            elemContainer.css({ 'opacity': '1.0' });
+          });
+        }
+
+        // Global for directive due it's used elsewhere as well
+        elemReplyHeight = elemReply.height();
+
+        const elemContainerWidth = elemContainer.width();
+
+        // container has 15px padding on both sides when window is bigger than screen-sm-max (768px)
+        const elemContainerPadding = ($window.innerWidth < 768) ? -15 : 30;
+
+        const combinedHeight = elemReplyHeight + (elemReplyHeight / 3);
+
+        elemQuickReply.css({
+          bottom: combinedHeight,
         });
 
-        /**
-         * Timeout wrapper for refreshLayout() function
-         */
-        function activateRefreshLayout() {
-          // Add (or reset) timeout to prevent calling this too often
-          $timeout.cancel(refreshLayoutTimeout);
-          refreshLayoutTimeout = $timeout(refreshLayout, 300);
-        }
-
-        /**
-         * Scroll thread to bottom to show latest messages
-         */
-        const scrollToBottom = function () {
-          elemThread.scrollTop(elemThread[0].scrollHeight);
-        };
-
-        /**
-         * Timeout wrapper for scrollToBottom() function
-         */
-        function activateScrollToBottom() {
-          // Add (or reset) timeout to prevent calling this too often
-          $timeout.cancel(scrollToBottomTimeout);
-          scrollToBottomTimeout = $timeout(scrollToBottom, 300);
-        }
-
-
-        /**
-         * Refresh layout
-         *
-         * Keep thread in good condition when screen resizes/orientation changes/message textrea grows
-         * This sorta should be at .less files, but the message thread is such an complicated peace of UI...
-         * Mostly this is needed due growing text field
-         */
-        function refreshLayout() {
-
-          if (!isInitialized) {
-            isInitialized = true;
-            $timeout(function () {
-              elemContainer.css({ 'opacity': '1.0' });
-            });
-          }
-
-          // Global for directive due it's used elsewhere as well
-          elemReplyHeight = elemReply.height();
-
-          const elemContainerWidth = elemContainer.width();
-
+        elemThread.css({
           // container has 15px padding on both sides when window is bigger than screen-sm-max (768px)
-          const elemContainerPadding = ($window.innerWidth < 768) ? -15 : 30;
-
-          const combinedHeight = elemReplyHeight + (elemReplyHeight / 3);
-
-          elemQuickReply.css({
-            bottom: combinedHeight,
-          });
-
-          elemThread.css({
-            // container has 15px padding on both sides when window is bigger than screen-sm-max (768px)
-            width: elemContainerWidth - elemContainerPadding,
-            // Bottom part of the message thread should touch top part of textarea
-            bottom: combinedHeight + elemQuickReply.height(),
-          });
-
-          // Reply area has always padding 30 on the right
-          elemReply.width(elemContainerWidth - 30);
-        }
-
-        /**
-         * Listeners & event bindings
-         */
-        scope.$on('threadRefreshLayout', function () {
-          activateRefreshLayout();
+          width: elemContainerWidth - elemContainerPadding,
+          // Bottom part of the message thread should touch top part of textarea
+          bottom: combinedHeight + elemQuickReply.height(),
         });
 
-        scope.$on('threadScrollToBottom', function () {
-          activateScrollToBottom();
-        });
+        // Reply area has always padding 30 on the right
+        elemReply.width(elemContainerWidth - 30);
+      }
 
-        angular.element($window)
-          .on('resize', activateRefreshLayout)
-          .bind('orientationchange', activateRefreshLayout);
-
-        // At init, run these
+      /**
+       * Listeners & event bindings
+       */
+      scope.$on('threadRefreshLayout', function () {
         activateRefreshLayout();
-        activateScrollToBottom();
-        scope.$emit('threadDimensinsLoaded');
+      });
 
-      }, // link()
-    };
-  }
-}());
+      scope.$on('threadScrollToBottom', function () {
+        activateScrollToBottom();
+      });
+
+      angular.element($window)
+        .on('resize', activateRefreshLayout)
+        .bind('orientationchange', activateRefreshLayout);
+
+      // At init, run these
+      activateRefreshLayout();
+      activateScrollToBottom();
+      scope.$emit('threadDimensinsLoaded');
+
+    }, // link()
+  };
+}

--- a/modules/messages/client/directives/threads.client.directive.js
+++ b/modules/messages/client/directives/threads.client.directive.js
@@ -1,20 +1,18 @@
-(function () {
-  angular
-    .module('messages')
-    .directive('threads', threadsDirective);
+angular
+  .module('messages')
+  .directive('threads', threadsDirective);
 
-  /* @ngInject */
-  function threadsDirective() {
-    return {
-      link: function (scope, elem, attr) {
-        const element = elem[0];
+/* @ngInject */
+function threadsDirective() {
+  return {
+    link: function (scope, elem, attr) {
+      const element = elem[0];
 
-        elem.bind('scroll', function () {
-          if (element.scrollTop <= 0) {
-            scope.$apply(attr.moremessages);
-          }
-        });
-      },
-    };
-  }
-}());
+      elem.bind('scroll', function () {
+        if (element.scrollTop <= 0) {
+          scope.$apply(attr.moremessages);
+        }
+      });
+    },
+  };
+}

--- a/modules/messages/client/directives/unread-count.client.directive.js
+++ b/modules/messages/client/directives/unread-count.client.directive.js
@@ -1,88 +1,86 @@
-(function () {
-  /**
-   * Directive show unread messages counter
-   *
-   * Usage:
-   * `<div messages-unread-count></div>`
-   *
-   * Adding this directive one or more times will cause `PollMessagesCount`
-   * service to poll for new messages.
-   */
-  angular
-    .module('messages')
-    .directive('messagesUnreadCount', messagesUnreadCountDirective);
+/**
+ * Directive show unread messages counter
+ *
+ * Usage:
+ * `<div messages-unread-count></div>`
+ *
+ * Adding this directive one or more times will cause `PollMessagesCount`
+ * service to poll for new messages.
+ */
+angular
+  .module('messages')
+  .directive('messagesUnreadCount', messagesUnreadCountDirective);
 
-  /* @ngInject */
-  function messagesUnreadCountDirective(PollMessagesCount, Authentication) {
+/* @ngInject */
+function messagesUnreadCountDirective(PollMessagesCount, Authentication) {
 
-    const directive = {
-      restrict: 'A',
-      replace: true,
-      scope: true,
-      template: '<span class="notification-badge" ng-show="unread > 0" ng-bind="unread" aria-label="{{unread}} unread messages" tabindex="0"></span>',
-      link: link,
-    };
+  const directive = {
+    restrict: 'A',
+    replace: true,
+    scope: true,
+    template: '<span class="notification-badge" ng-show="unread > 0" ng-bind="unread" aria-label="{{unread}} unread messages" tabindex="0"></span>',
+    link: link,
+  };
 
-    return directive;
+  return directive;
 
-    function link(scope) {
+  function link(scope) {
 
-      const favicon1xElem = angular.element('#favicon');
-      const favicon2xElem = angular.element('#favicon2x');
-      const faviconPath = '/img/';
+    const favicon1xElem = angular.element('#favicon');
+    const favicon2xElem = angular.element('#favicon2x');
+    const faviconPath = '/img/';
 
-      scope.unread = PollMessagesCount.getUnreadCount();
+    scope.unread = PollMessagesCount.getUnreadCount();
 
-      activate();
+    activate();
 
-      /**
-       * Initialize checking for unread messages
-       */
-      function activate() {
-        if (!Authentication.user || !Authentication.user.public) {
-          // If user wasn't authenticated or public, set up watch
-          const activationWatch = scope.$on('userUpdated', function () {
-            // Did user become public with that update?
-            if (Authentication.user.public) {
-              // Remove this watch
-              activationWatch();
-              // Init activation
-              activate();
-            }
-          });
+    /**
+     * Initialize checking for unread messages
+     */
+    function activate() {
+      if (!Authentication.user || !Authentication.user.public) {
+        // If user wasn't authenticated or public, set up watch
+        const activationWatch = scope.$on('userUpdated', function () {
+          // Did user become public with that update?
+          if (Authentication.user.public) {
+            // Remove this watch
+            activationWatch();
+            // Init activation
+            activate();
+          }
+        });
 
-          // Check for unread messages only if user is authenticated + public
-          // Otherwise, stop here.
-          return;
-        }
-
-        // Initialize polling on intervals
-        PollMessagesCount.initPolling();
-
-        // Check for unread messages on init
-        PollMessagesCount.poll();
-
-        // When we have new messages, act upon them
-        const clearUnreadCountUpdated = scope.$on('unreadCountUpdated', onUnreadCountUpdated);
-
-        // Clean out `$on` watcher when directive is removed from DOM
-        scope.$on('$destroy', clearUnreadCountUpdated);
+        // Check for unread messages only if user is authenticated + public
+        // Otherwise, stop here.
+        return;
       }
 
-      function onUnreadCountUpdated($event, newUnreadCount) {
-        scope.unread = newUnreadCount;
+      // Initialize polling on intervals
+      PollMessagesCount.initPolling();
 
-        if (newUnreadCount > 0) {
-          // Change favicon to special notification icon
-          favicon1xElem.prop('href', faviconPath + 'favicon-notification.png');
-          favicon2xElem.prop('href', faviconPath + 'favicon-notification@2x.png');
-        } else {
-          // Change favicon back to normal
-          favicon1xElem.prop('href', faviconPath + 'favicon.png');
-          favicon2xElem.prop('href', faviconPath + 'favicon@2x.png');
-        }
-      }
+      // Check for unread messages on init
+      PollMessagesCount.poll();
 
+      // When we have new messages, act upon them
+      const clearUnreadCountUpdated = scope.$on('unreadCountUpdated', onUnreadCountUpdated);
+
+      // Clean out `$on` watcher when directive is removed from DOM
+      scope.$on('$destroy', clearUnreadCountUpdated);
     }
+
+    function onUnreadCountUpdated($event, newUnreadCount) {
+      scope.unread = newUnreadCount;
+
+      if (newUnreadCount > 0) {
+        // Change favicon to special notification icon
+        favicon1xElem.prop('href', faviconPath + 'favicon-notification.png');
+        favicon2xElem.prop('href', faviconPath + 'favicon-notification@2x.png');
+      } else {
+        // Change favicon back to normal
+        favicon1xElem.prop('href', faviconPath + 'favicon.png');
+        favicon2xElem.prop('href', faviconPath + 'favicon@2x.png');
+      }
+    }
+
   }
-}());
+}

--- a/modules/messages/client/services/messages-count-poll.client.service.js
+++ b/modules/messages/client/services/messages-count-poll.client.service.js
@@ -1,102 +1,100 @@
-(function () {
+/**
+ * PollMessagesCount service used for automatically polling for unread message counter
+ *
+ * For service to communicate with message count REST API endpoints, see `MessagesCount` service.
+ */
+angular
+  .module('messages')
+  .factory('PollMessagesCount', PollMessagesCountFactory);
+
+/* @ngInject */
+function PollMessagesCountFactory($interval, $rootScope, MessagesCount, Authentication) {
+
+  const highFrequency = 2 * 60 * 1000; // once every 2 minutes
+  const lowFrequency = 5 * 60 * 1000; // once every 5 minutes
+  let frequency = highFrequency;
+  let isPolling = false;
+  let unreadCount = 0;
+  let pollingInterval;
+
+  // Return the public API
+  return {
+    setFrequency: setFrequency,
+    getUnreadCount: getUnreadCount,
+    initPolling: initPolling,
+    poll: poll,
+  };
+
   /**
-   * PollMessagesCount service used for automatically polling for unread message counter
-   *
-   * For service to communicate with message count REST API endpoints, see `MessagesCount` service.
+   * Initialize polling for unread messages
    */
-  angular
-    .module('messages')
-    .factory('PollMessagesCount', PollMessagesCountFactory);
-
-  /* @ngInject */
-  function PollMessagesCountFactory($interval, $rootScope, MessagesCount, Authentication) {
-
-    const highFrequency = 2 * 60 * 1000; // once every 2 minutes
-    const lowFrequency = 5 * 60 * 1000; // once every 5 minutes
-    let frequency = highFrequency;
-    let isPolling = false;
-    let unreadCount = 0;
-    let pollingInterval;
-
-    // Return the public API
-    return {
-      setFrequency: setFrequency,
-      getUnreadCount: getUnreadCount,
-      initPolling: initPolling,
-      poll: poll,
-    };
-
-    /**
-     * Initialize polling for unread messages
-     */
-    function initPolling() {
-      if (angular.isDefined(pollingInterval)) {
-        return;
-      }
-
-      // Activate listener
-      $rootScope.$on('syncUnreadMessagesCount', poll);
-
-      // Check for unread messages in intervals
-      setPollingInterval();
+  function initPolling() {
+    if (angular.isDefined(pollingInterval)) {
+      return;
     }
 
-    /**
-     * Re-set intervall to current frequency
-     */
-    function setPollingInterval() {
-      // Clear out possible old interval
-      if (angular.isDefined(pollingInterval)) {
-        $interval.cancel(pollingInterval);
-        pollingInterval = undefined;
-      }
+    // Activate listener
+    $rootScope.$on('syncUnreadMessagesCount', poll);
 
-      // Set new interval
-      pollingInterval = $interval(poll, frequency);
-    }
-
-    /**
-     * Check for unread messages
-     */
-    function poll() {
-      if (isPolling) {
-        return;
-      }
-      isPolling = true;
-      MessagesCount.get(function (data) {
-        isPolling = false;
-
-        const newUnreadCount = (data && data.unread) ? parseInt(data.unread, 10) : 0;
-
-        if (unreadCount !== newUnreadCount) {
-          unreadCount = newUnreadCount;
-          $rootScope.$broadcast('unreadCountUpdated', newUnreadCount);
-        }
-      });
-    }
-
-    /**
-     * Return current unread count
-     */
-    function getUnreadCount() {
-      return unreadCount;
-    }
-
-    /**
-     * Set the frequency
-     */
-    function setFrequency(frequencyString) {
-      const newFrequency = (frequencyString === 'low') ? lowFrequency : highFrequency;
-
-      if (newFrequency !== frequency) {
-        frequency = newFrequency;
-        setPollingInterval();
-        // When turning to high frequency, poll on frequency change
-        if (frequencyString === 'high' && Authentication.user && Authentication.user.public) {
-          poll();
-        }
-      }
-    }
-
+    // Check for unread messages in intervals
+    setPollingInterval();
   }
-}());
+
+  /**
+   * Re-set intervall to current frequency
+   */
+  function setPollingInterval() {
+    // Clear out possible old interval
+    if (angular.isDefined(pollingInterval)) {
+      $interval.cancel(pollingInterval);
+      pollingInterval = undefined;
+    }
+
+    // Set new interval
+    pollingInterval = $interval(poll, frequency);
+  }
+
+  /**
+   * Check for unread messages
+   */
+  function poll() {
+    if (isPolling) {
+      return;
+    }
+    isPolling = true;
+    MessagesCount.get(function (data) {
+      isPolling = false;
+
+      const newUnreadCount = (data && data.unread) ? parseInt(data.unread, 10) : 0;
+
+      if (unreadCount !== newUnreadCount) {
+        unreadCount = newUnreadCount;
+        $rootScope.$broadcast('unreadCountUpdated', newUnreadCount);
+      }
+    });
+  }
+
+  /**
+   * Return current unread count
+   */
+  function getUnreadCount() {
+    return unreadCount;
+  }
+
+  /**
+   * Set the frequency
+   */
+  function setFrequency(frequencyString) {
+    const newFrequency = (frequencyString === 'low') ? lowFrequency : highFrequency;
+
+    if (newFrequency !== frequency) {
+      frequency = newFrequency;
+      setPollingInterval();
+      // When turning to high frequency, poll on frequency change
+      if (frequencyString === 'high' && Authentication.user && Authentication.user.public) {
+        poll();
+      }
+    }
+  }
+
+}

--- a/modules/messages/client/services/messages-count.client.service.js
+++ b/modules/messages/client/services/messages-count.client.service.js
@@ -1,11 +1,9 @@
-(function () {
-  // MessagesCount service used for communicating with the messages REST endpoints
-  angular
-    .module('messages')
-    .factory('MessagesCount', MessagesCount);
+// MessagesCount service used for communicating with the messages REST endpoints
+angular
+  .module('messages')
+  .factory('MessagesCount', MessagesCount);
 
-  /* @ngInject */
-  function MessagesCount($resource) {
-    return $resource('/api/messages-count');
-  }
-}());
+/* @ngInject */
+function MessagesCount($resource) {
+  return $resource('/api/messages-count');
+}

--- a/modules/messages/client/services/messages-read.client.service.js
+++ b/modules/messages/client/services/messages-read.client.service.js
@@ -1,20 +1,18 @@
-(function () {
-  // MessagesRead service used for communicating with the messages REST endpoints
-  angular
-    .module('messages')
-    .factory('MessagesRead', MessagesRead);
+// MessagesRead service used for communicating with the messages REST endpoints
+angular
+  .module('messages')
+  .factory('MessagesRead', MessagesRead);
 
-  /* @ngInject */
-  function MessagesRead($resource) {
-    return $resource('/api/messages-read', {
-      messageIds: '@messageIds',
-    }, {
-      query: {
-        method: 'POST',
-        isArray: false,
-        cache: false,
-        ignoreLoadingBar: true,
-      },
-    });
-  }
-}());
+/* @ngInject */
+function MessagesRead($resource) {
+  return $resource('/api/messages-read', {
+    messageIds: '@messageIds',
+  }, {
+    query: {
+      method: 'POST',
+      isArray: false,
+      cache: false,
+      ignoreLoadingBar: true,
+    },
+  });
+}

--- a/modules/messages/client/services/messages.client.service.js
+++ b/modules/messages/client/services/messages.client.service.js
@@ -1,64 +1,62 @@
-(function () {
-  // Messages service used for communicating with the messages REST endpoints
-  angular
-    .module('messages')
-    .factory('Messages', Messages);
+// Messages service used for communicating with the messages REST endpoints
+angular
+  .module('messages')
+  .factory('Messages', Messages);
 
-  /* @ngInject */
-  function Messages($resource) {
+/* @ngInject */
+function Messages($resource) {
 
-    function MessageHandler() {
-      // Control flow variable; Prevents multiple identical ajax calls
-      this.paginationTimeout = false;
-      // Used in views for show/hide information
-      this.resolved = false;
-      this.nextPage = false;
-    }
-
-    MessageHandler.prototype = {
-      parseHeaders: function (header) {
-        if (header) {
-          return {
-            page: /<.*\/[^<>]*\?.*page=(\d*).*>;.*/.exec(header)[1],
-            limit: /<.*\/[^<>]*\?.*limit=(\d*).*>;.*/.exec(header)[1],
-          };
-        } else {
-          return header;
-        }
-      },
-      /**
-       * Fetches messages and sets up pagination environment
-       * Takes additional query params passed in as key , value pairs
-       */
-      fetchMessages: function (param) {
-
-        const that = this;
-        const query = (this.nextPage) ? angular.extend(this.nextPage, param) : param;
-
-        if (!this.paginationTimeout) {
-          this.paginationTimeout = true;
-
-          return this.ajaxCall.query(
-            query,
-            // Successful callback
-            function (data, headers) {
-              that.nextPage = that.parseHeaders(headers().link);
-              that.resolved = true;
-              that.paginationTimeout = false;
-            },
-            // Error callback
-            function () {
-              that.paginationTimeout = false;
-              that.resolved = false;
-            },
-          );
-        }
-      },
-      ajaxCall: $resource('/api/messages/:userId',
-        { userId: '@_id' },
-        { update: { method: 'PUT' } },
-      ),
-    };
-    return MessageHandler;
+  function MessageHandler() {
+    // Control flow variable; Prevents multiple identical ajax calls
+    this.paginationTimeout = false;
+    // Used in views for show/hide information
+    this.resolved = false;
+    this.nextPage = false;
   }
-}());
+
+  MessageHandler.prototype = {
+    parseHeaders: function (header) {
+      if (header) {
+        return {
+          page: /<.*\/[^<>]*\?.*page=(\d*).*>;.*/.exec(header)[1],
+          limit: /<.*\/[^<>]*\?.*limit=(\d*).*>;.*/.exec(header)[1],
+        };
+      } else {
+        return header;
+      }
+    },
+    /**
+     * Fetches messages and sets up pagination environment
+     * Takes additional query params passed in as key , value pairs
+     */
+    fetchMessages: function (param) {
+
+      const that = this;
+      const query = (this.nextPage) ? angular.extend(this.nextPage, param) : param;
+
+      if (!this.paginationTimeout) {
+        this.paginationTimeout = true;
+
+        return this.ajaxCall.query(
+          query,
+          // Successful callback
+          function (data, headers) {
+            that.nextPage = that.parseHeaders(headers().link);
+            that.resolved = true;
+            that.paginationTimeout = false;
+          },
+          // Error callback
+          function () {
+            that.paginationTimeout = false;
+            that.resolved = false;
+          },
+        );
+      }
+    },
+    ajaxCall: $resource('/api/messages/:userId',
+      { userId: '@_id' },
+      { update: { method: 'PUT' } },
+    ),
+  };
+  return MessageHandler;
+}

--- a/modules/offers/client/config/offers.client.routes.js
+++ b/modules/offers/client/config/offers.client.routes.js
@@ -3,128 +3,126 @@ import hostEditTemplateUrl from '@/modules/offers/client/views/offer-host-edit.c
 import meetListTemplateUrl from '@/modules/offers/client/views/offer-meet-list.client.view.html';
 import meetEditTemplateUrl from '@/modules/offers/client/views/offer-meet-edit.client.view.html';
 
-(function () {
-  angular
-    .module('offers')
-    .config(OffersRoutes);
+angular
+  .module('offers')
+  .config(OffersRoutes);
+
+/* @ngInject */
+function OffersRoutes($stateProvider, $urlRouterProvider) {
+
+  // Redirect parent states,
+  // otherwise `/offer` would throw 404 because the route is `abstract`
+  $urlRouterProvider.when('/offer', '/offer/host');
+
+  $stateProvider.
+    state('offer', {
+      url: '/offer',
+      abstract: true,
+      requiresAuth: true,
+      templateUrl: viewTemplateUrl,
+      controller: 'OfferController',
+      controllerAs: 'offer',
+      resolve: {
+        // A string value resolves to a service
+        LocationService: 'LocationService',
+
+        // Initial default location for all offer maps
+        defaultLocation: function (LocationService) {
+          // Returns `{lat: Float, lng: Float, zoom: 4}`
+          return LocationService.getDefaultLocation(4);
+        },
+      },
+    }).
+    state('offer.host', {
+      url: '/host',
+      abstract: true,
+      requiresAuth: true,
+      template: '<div ui-view></div>',
+      controller: 'OfferController',
+      controllerAs: 'offer',
+      resolve: {
+        // A string value resolves to a service
+        OffersByService: 'OffersByService',
+
+        offers: function (OffersByService, Authentication) {
+          return OffersByService.query({
+            userId: Authentication.user._id,
+            types: 'host',
+          });
+        },
+      },
+    }).
+    state('offer.host.edit', {
+      url: '?status',
+      templateUrl: hostEditTemplateUrl,
+      requiresAuth: true,
+      footerHidden: true,
+      controller: 'OfferHostEditController',
+      controllerAs: 'offerHostEdit',
+      data: {
+        pageTitle: 'Host travellers',
+      },
+    }).
+    state('offer.meet', {
+      url: '/meet',
+      abstract: true,
+      requiresAuth: true,
+      template: '<div ui-view></div>',
+      controller: 'OfferController',
+      controllerAs: 'offer',
+    }).
+    state('offer.meet.list', {
+      url: '',
+      templateUrl: meetListTemplateUrl,
+      requiresAuth: true,
+      controller: 'OfferListMeetController',
+      controllerAs: 'offerListMeet',
+      data: {
+        pageTitle: 'Meet',
+      },
+      resolve: {
+        // A string value resolves to a service
+        OffersByService: 'OffersByService',
+
+        offers: function (OffersByService, Authentication) {
+          return OffersByService.query({
+            userId: Authentication.user._id,
+            types: 'meet',
+          });
+        },
+      },
+    }).
+    state('offer.meet.add', {
+      url: '/add',
+      templateUrl: meetEditTemplateUrl,
+      requiresAuth: true,
+      footerHidden: true,
+      controller: 'OfferMeetAddController',
+      controllerAs: 'offerMeet',
+      data: {
+        pageTitle: 'Add meeting offer',
+      },
+    }).
+    state('offer.meet.edit', {
+      url: '/:offerId',
+      templateUrl: meetEditTemplateUrl,
+      requiresAuth: true,
+      footerHidden: true,
+      controller: 'OfferMeetEditController',
+      controllerAs: 'offerMeet',
+      data: {
+        pageTitle: 'Edit meeting offer',
+      },
+      resolve: {
+        offer: getOffer,
+      },
+    });
 
   /* @ngInject */
-  function OffersRoutes($stateProvider, $urlRouterProvider) {
-
-    // Redirect parent states,
-    // otherwise `/offer` would throw 404 because the route is `abstract`
-    $urlRouterProvider.when('/offer', '/offer/host');
-
-    $stateProvider.
-      state('offer', {
-        url: '/offer',
-        abstract: true,
-        requiresAuth: true,
-        templateUrl: viewTemplateUrl,
-        controller: 'OfferController',
-        controllerAs: 'offer',
-        resolve: {
-          // A string value resolves to a service
-          LocationService: 'LocationService',
-
-          // Initial default location for all offer maps
-          defaultLocation: function (LocationService) {
-            // Returns `{lat: Float, lng: Float, zoom: 4}`
-            return LocationService.getDefaultLocation(4);
-          },
-        },
-      }).
-      state('offer.host', {
-        url: '/host',
-        abstract: true,
-        requiresAuth: true,
-        template: '<div ui-view></div>',
-        controller: 'OfferController',
-        controllerAs: 'offer',
-        resolve: {
-          // A string value resolves to a service
-          OffersByService: 'OffersByService',
-
-          offers: function (OffersByService, Authentication) {
-            return OffersByService.query({
-              userId: Authentication.user._id,
-              types: 'host',
-            });
-          },
-        },
-      }).
-      state('offer.host.edit', {
-        url: '?status',
-        templateUrl: hostEditTemplateUrl,
-        requiresAuth: true,
-        footerHidden: true,
-        controller: 'OfferHostEditController',
-        controllerAs: 'offerHostEdit',
-        data: {
-          pageTitle: 'Host travellers',
-        },
-      }).
-      state('offer.meet', {
-        url: '/meet',
-        abstract: true,
-        requiresAuth: true,
-        template: '<div ui-view></div>',
-        controller: 'OfferController',
-        controllerAs: 'offer',
-      }).
-      state('offer.meet.list', {
-        url: '',
-        templateUrl: meetListTemplateUrl,
-        requiresAuth: true,
-        controller: 'OfferListMeetController',
-        controllerAs: 'offerListMeet',
-        data: {
-          pageTitle: 'Meet',
-        },
-        resolve: {
-          // A string value resolves to a service
-          OffersByService: 'OffersByService',
-
-          offers: function (OffersByService, Authentication) {
-            return OffersByService.query({
-              userId: Authentication.user._id,
-              types: 'meet',
-            });
-          },
-        },
-      }).
-      state('offer.meet.add', {
-        url: '/add',
-        templateUrl: meetEditTemplateUrl,
-        requiresAuth: true,
-        footerHidden: true,
-        controller: 'OfferMeetAddController',
-        controllerAs: 'offerMeet',
-        data: {
-          pageTitle: 'Add meeting offer',
-        },
-      }).
-      state('offer.meet.edit', {
-        url: '/:offerId',
-        templateUrl: meetEditTemplateUrl,
-        requiresAuth: true,
-        footerHidden: true,
-        controller: 'OfferMeetEditController',
-        controllerAs: 'offerMeet',
-        data: {
-          pageTitle: 'Edit meeting offer',
-        },
-        resolve: {
-          offer: getOffer,
-        },
-      });
-
-    /* @ngInject */
-    function getOffer($stateParams, OffersService) {
-      return OffersService.get({
-        offerId: $stateParams.offerId,
-      }).$promise;
-    }
-
+  function getOffer($stateParams, OffersService) {
+    return OffersService.get({
+      offerId: $stateParams.offerId,
+    }).$promise;
   }
-}());
+
+}

--- a/modules/offers/client/controllers/offer-host-edit.client.controller.js
+++ b/modules/offers/client/controllers/offer-host-edit.client.controller.js
@@ -1,154 +1,152 @@
-(function () {
-  angular
-    .module('offers')
-    .controller('OfferHostEditController', OfferHostEditController);
+angular
+  .module('offers')
+  .controller('OfferHostEditController', OfferHostEditController);
 
-  /* @ngInject */
-  function OfferHostEditController($window, $state, $stateParams, $analytics, $timeout, leafletData, OffersService, Authentication, messageCenterService, offers, defaultLocation, $scope, $filter) {
+/* @ngInject */
+function OfferHostEditController($window, $state, $stateParams, $analytics, $timeout, leafletData, OffersService, Authentication, messageCenterService, offers, defaultLocation, $scope, $filter) {
 
-    // ViewModel
-    const vm = this;
+  // ViewModel
+  const vm = this;
 
-    vm.offers = offers;
+  vm.offers = offers;
 
-    // Expoxed to the view
-    vm.leafletData = leafletData;
-    vm.editOffer = editOffer;
-    vm.mapCenter = defaultLocation;
-    vm.searchQuery = '';
-    vm.isLoading = true;
-    vm.firstTimeAround = false;
-    vm.invalidateMapSize = invalidateMapSize;
-    vm.isDescriptionTooShort = false;
+  // Expoxed to the view
+  vm.leafletData = leafletData;
+  vm.editOffer = editOffer;
+  vm.mapCenter = defaultLocation;
+  vm.searchQuery = '';
+  vm.isLoading = true;
+  vm.firstTimeAround = false;
+  vm.invalidateMapSize = invalidateMapSize;
+  vm.isDescriptionTooShort = false;
 
-    activate();
+  activate();
 
-    /**
-     * Initialize controller
-     */
-    function activate() {
+  /**
+   * Initialize controller
+   */
+  function activate() {
 
-      const defaultOfferConfig = {
-        type: 'host',
-        status: 'yes',
-        description: '',
-        noOfferDescription: '',
-        location: defaultLocation,
-        maxGuests: 1,
-      };
+    const defaultOfferConfig = {
+      type: 'host',
+      status: 'yes',
+      description: '',
+      noOfferDescription: '',
+      location: defaultLocation,
+      maxGuests: 1,
+    };
 
-      // Make sure offer is there
-      offers.$promise.then(function () {
+    // Make sure offer is there
+    offers.$promise.then(function () {
 
-        if (angular.isArray(offers) && offers.length) {
-          vm.offer = new OffersService(angular.extend(defaultOfferConfig, offers[0]));
+      if (angular.isArray(offers) && offers.length) {
+        vm.offer = new OffersService(angular.extend(defaultOfferConfig, offers[0]));
 
-          // Populate map
-          if (angular.isArray(vm.offer.location) && vm.offer.location.length === 2) {
-            vm.mapCenter.lat = parseFloat(vm.offer.location[0]);
-            vm.mapCenter.lng = parseFloat(vm.offer.location[1]);
-            vm.mapCenter.zoom = 16;
-          }
+        // Populate map
+        if (angular.isArray(vm.offer.location) && vm.offer.location.length === 2) {
+          vm.mapCenter.lat = parseFloat(vm.offer.location[0]);
+          vm.mapCenter.lng = parseFloat(vm.offer.location[1]);
+          vm.mapCenter.zoom = 16;
         }
+      }
 
 
-      },
-      function (err) {
+    },
+    function (err) {
 
-        // No previous offer, fill in defaults
-        if (err && err.status === 404) {
+      // No previous offer, fill in defaults
+      if (err && err.status === 404) {
 
-          // Creating new hosting offer, set defaults
-          vm.offer = new OffersService(defaultOfferConfig);
+        // Creating new hosting offer, set defaults
+        vm.offer = new OffersService(defaultOfferConfig);
 
-          // Show guidance
-          vm.firstTimeAround = true;
+        // Show guidance
+        vm.firstTimeAround = true;
 
-          // Locale map to user's living- or from- location, if they're set
-          if (Authentication.user.locationLiving && Authentication.user.locationLiving !== '') {
-            vm.searchQuery = Authentication.user.locationLiving;
-          } else if (Authentication.user.locationFrom && Authentication.user.locationFrom !== '') {
-            vm.searchQuery = Authentication.user.locationFrom;
-          }
-        } else {
-          vm.offer = false;
+        // Locale map to user's living- or from- location, if they're set
+        if (Authentication.user.locationLiving && Authentication.user.locationLiving !== '') {
+          vm.searchQuery = Authentication.user.locationLiving;
+        } else if (Authentication.user.locationFrom && Authentication.user.locationFrom !== '') {
+          vm.searchQuery = Authentication.user.locationFrom;
         }
+      } else {
+        vm.offer = false;
+      }
 
-      })
-      // Always execute this on both error and success
-        .finally(function () {
-          setStatusByURL();
-          vm.isLoading = false;
-        });
-
-    }
-
-    $scope.$watch('offerHostEdit.offer.description', function (newValue) {
-      vm.isDescriptionTooShort = $filter('plainTextLength')(newValue) < 5;
-    });
-
-    /**
-     * Invalidate map size on tab change
-     * Map has been hidden until this point and Leaflet couldn't calculate
-     * tile positions properly until it's visible in DOM
-     */
-    function invalidateMapSize() {
-      $timeout(function () {
-        leafletData.getMap().then(function (map) {
-          // @link http://leafletjs.com/reference-1.2.0.html#map-invalidatesize
-          map.invalidateSize(false);
-        });
+    })
+    // Always execute this on both error and success
+      .finally(function () {
+        setStatusByURL();
+        vm.isLoading = false;
       });
+
+  }
+
+  $scope.$watch('offerHostEdit.offer.description', function (newValue) {
+    vm.isDescriptionTooShort = $filter('plainTextLength')(newValue) < 5;
+  });
+
+  /**
+   * Invalidate map size on tab change
+   * Map has been hidden until this point and Leaflet couldn't calculate
+   * tile positions properly until it's visible in DOM
+   */
+  function invalidateMapSize() {
+    $timeout(function () {
+      leafletData.getMap().then(function (map) {
+        // @link http://leafletjs.com/reference-1.2.0.html#map-invalidatesize
+        map.invalidateSize(false);
+      });
+    });
+  }
+
+  /**
+   * Determine new hosting status from the URL parameter
+   * Overrides any previous status
+   */
+  function setStatusByURL() {
+    if ($stateParams.status && ['yes', 'maybe', 'no'].indexOf($stateParams.status) > -1) {
+      vm.offer.status = $stateParams.status;
+    }
+  }
+
+  /**
+   * Add offer
+   */
+  function editOffer() {
+    if (vm.isLoading) {
+      return;
     }
 
-    /**
-     * Determine new hosting status from the URL parameter
-     * Overrides any previous status
-     */
-    function setStatusByURL() {
-      if ($stateParams.status && ['yes', 'maybe', 'no'].indexOf($stateParams.status) > -1) {
-        vm.offer.status = $stateParams.status;
+    vm.isLoading = true;
+
+    // Pick location from the map
+    vm.offer.location = [parseFloat(vm.mapCenter.lat), parseFloat(vm.mapCenter.lng)];
+
+    vm.offer.createOrUpdate()
+      .then(successCallback)
+      .catch(errorCallback);
+
+    function successCallback() {
+      vm.isLoading = false;
+      $analytics.eventTrack('offer-modified', {
+        category: 'offer.edit',
+        label: 'Modified offer',
+        value: vm.offer.status,
+      });
+      if ($window.innerWidth < 768) {
+        $state.go('profile.accommodation', { username: Authentication.user.username });
+      } else {
+        $state.go('profile.about', { username: Authentication.user.username });
       }
     }
 
-    /**
-     * Add offer
-     */
-    function editOffer() {
-      if (vm.isLoading) {
-        return;
-      }
-
-      vm.isLoading = true;
-
-      // Pick location from the map
-      vm.offer.location = [parseFloat(vm.mapCenter.lat), parseFloat(vm.mapCenter.lng)];
-
-      vm.offer.createOrUpdate()
-        .then(successCallback)
-        .catch(errorCallback);
-
-      function successCallback() {
-        vm.isLoading = false;
-        $analytics.eventTrack('offer-modified', {
-          category: 'offer.edit',
-          label: 'Modified offer',
-          value: vm.offer.status,
-        });
-        if ($window.innerWidth < 768) {
-          $state.go('profile.accommodation', { username: Authentication.user.username });
-        } else {
-          $state.go('profile.about', { username: Authentication.user.username });
-        }
-      }
-
-      function errorCallback(res) {
-        vm.isLoading = false;
-        const errorMessage = (res && res.data && res.data.message) ? res.data.message : 'Snap! Something went wrong. If this keeps happening, please contact us.';
-        messageCenterService.add('danger', errorMessage);
-      }
-
+    function errorCallback(res) {
+      vm.isLoading = false;
+      const errorMessage = (res && res.data && res.data.message) ? res.data.message : 'Snap! Something went wrong. If this keeps happening, please contact us.';
+      messageCenterService.add('danger', errorMessage);
     }
 
   }
-}());
+
+}

--- a/modules/offers/client/controllers/offer-host-view.client.controller.js
+++ b/modules/offers/client/controllers/offer-host-view.client.controller.js
@@ -1,60 +1,58 @@
-(function () {
-  angular
-    .module('offers')
-    .controller('OfferHostViewController', OfferHostViewController);
+angular
+  .module('offers')
+  .controller('OfferHostViewController', OfferHostViewController);
 
-  /* @ngInject */
-  function OfferHostViewController($scope, OffersByService) {
+/* @ngInject */
+function OfferHostViewController($scope, OffersByService) {
 
-    // ViewModel
-    const vm = this;
+  // ViewModel
+  const vm = this;
 
-    // Exposed
-    vm.offer = false;
-    vm.hostingDropdown = false;
-    vm.hostingStatusLabel = hostingStatusLabel;
+  // Exposed
+  vm.offer = false;
+  vm.hostingDropdown = false;
+  vm.hostingStatusLabel = hostingStatusLabel;
 
-    activate();
+  activate();
 
-    /**
-     * Initialize controller
-     */
-    function activate() {
-
-      /**
-       * Fetch offer
-       * @todo: move to route resolve
-       * @note: profileCtrl is a reference to parent "ControllerAs" (see users module)
-       */
-      if ($scope.profileCtrl.profile && $scope.profileCtrl.profile.$resolved && $scope.profileCtrl.profile._id) {
-        OffersByService.query({
-          userId: $scope.profileCtrl.profile._id,
-          types: 'host',
-        }, function (offers) {
-          if (!offers || !offers.length) {
-            return;
-          }
-
-          vm.offer = offers[0];
-          vm.offer.$resolved = true;
-        });
-      }
-
-    }
+  /**
+   * Initialize controller
+   */
+  function activate() {
 
     /**
-     * Helper for hosting label
+     * Fetch offer
+     * @todo: move to route resolve
+     * @note: profileCtrl is a reference to parent "ControllerAs" (see users module)
      */
-    function hostingStatusLabel(status) {
-      switch (status) {
-        case 'yes':
-          return 'Can host';
-        case 'maybe':
-          return 'Might be able to host';
-        default:
-          return 'Cannot host currently';
-      }
+    if ($scope.profileCtrl.profile && $scope.profileCtrl.profile.$resolved && $scope.profileCtrl.profile._id) {
+      OffersByService.query({
+        userId: $scope.profileCtrl.profile._id,
+        types: 'host',
+      }, function (offers) {
+        if (!offers || !offers.length) {
+          return;
+        }
+
+        vm.offer = offers[0];
+        vm.offer.$resolved = true;
+      });
     }
 
   }
-}());
+
+  /**
+   * Helper for hosting label
+   */
+  function hostingStatusLabel(status) {
+    switch (status) {
+      case 'yes':
+        return 'Can host';
+      case 'maybe':
+        return 'Might be able to host';
+      default:
+        return 'Cannot host currently';
+    }
+  }
+
+}

--- a/modules/offers/client/controllers/offer-meet-add.client.controller.js
+++ b/modules/offers/client/controllers/offer-meet-add.client.controller.js
@@ -1,61 +1,59 @@
-(function () {
-  angular
-    .module('offers')
-    .controller('OfferMeetAddController', OfferMeetAddController);
+angular
+  .module('offers')
+  .controller('OfferMeetAddController', OfferMeetAddController);
 
-  /* @ngInject */
-  function OfferMeetAddController($state, $analytics, leafletData, OffersService, messageCenterService, defaultLocation) {
+/* @ngInject */
+function OfferMeetAddController($state, $analytics, leafletData, OffersService, messageCenterService, defaultLocation) {
 
-    // ViewModel
-    const vm = this;
+  // ViewModel
+  const vm = this;
 
-    // Expoxed to the view
-    vm.leafletData = leafletData;
-    vm.offer = {};
-    vm.editOffer = editOffer;
-    vm.mapCenter = defaultLocation;
-    vm.isCalendarVisible = false;
-    vm.isLoading = false;
-    vm.newOffer = false;
-    vm.minDescription = 5;
+  // Expoxed to the view
+  vm.leafletData = leafletData;
+  vm.offer = {};
+  vm.editOffer = editOffer;
+  vm.mapCenter = defaultLocation;
+  vm.isCalendarVisible = false;
+  vm.isLoading = false;
+  vm.newOffer = false;
+  vm.minDescription = 5;
 
-    activate();
+  activate();
 
-    /**
-     * Initialize controller
-     */
-    function activate() {
-      vm.newOffer = true;
-    }
+  /**
+   * Initialize controller
+   */
+  function activate() {
+    vm.newOffer = true;
+  }
 
-    /**
-     * Add offer
-     */
-    function editOffer() {
-      vm.isLoading = true;
+  /**
+   * Add offer
+   */
+  function editOffer() {
+    vm.isLoading = true;
 
-      const newOffer = new OffersService({
-        type: 'meet',
-        description: vm.offer.description,
-        location: [parseFloat(vm.mapCenter.lat), parseFloat(vm.mapCenter.lng)],
-        validUntil: vm.offer.validUntil,
+    const newOffer = new OffersService({
+      type: 'meet',
+      description: vm.offer.description,
+      location: [parseFloat(vm.mapCenter.lat), parseFloat(vm.mapCenter.lng)],
+      validUntil: vm.offer.validUntil,
+    });
+
+    newOffer.$save(function () {
+      // Done!
+      vm.isLoading = false;
+      $analytics.eventTrack('offer-modified', {
+        category: 'offer.meet.add',
+        label: 'Added meet offer',
       });
-
-      newOffer.$save(function () {
-        // Done!
-        vm.isLoading = false;
-        $analytics.eventTrack('offer-modified', {
-          category: 'offer.meet.add',
-          label: 'Added meet offer',
-        });
-        $state.go('offer.meet.list');
-      }, function (err) {
-        vm.isLoading = false;
-        const errorMessage = (err.data.message) ? err.data.message : 'Error occured. Please try again.';
-        messageCenterService.add('danger', errorMessage);
-      });
-
-    }
+      $state.go('offer.meet.list');
+    }, function (err) {
+      vm.isLoading = false;
+      const errorMessage = (err.data.message) ? err.data.message : 'Error occured. Please try again.';
+      messageCenterService.add('danger', errorMessage);
+    });
 
   }
-}());
+
+}

--- a/modules/offers/client/controllers/offer-meet-edit.client.controller.js
+++ b/modules/offers/client/controllers/offer-meet-edit.client.controller.js
@@ -1,91 +1,89 @@
-(function () {
-  angular
-    .module('offers')
-    .controller('OfferMeetEditController', OfferMeetEditController);
+angular
+  .module('offers')
+  .controller('OfferMeetEditController', OfferMeetEditController);
 
-  /* @ngInject */
-  function OfferMeetEditController($state, $analytics, moment, leafletData, messageCenterService, offer, defaultLocation) {
+/* @ngInject */
+function OfferMeetEditController($state, $analytics, moment, leafletData, messageCenterService, offer, defaultLocation) {
 
-    // ViewModel
-    const vm = this;
+  // ViewModel
+  const vm = this;
 
-    // Expoxed to the view
-    vm.leafletData = leafletData;
-    vm.offer = {};
-    vm.editOffer = editOffer;
-    vm.mapCenter = defaultLocation;
-    vm.isLoading = false;
-    vm.minDescription = 5;
+  // Expoxed to the view
+  vm.leafletData = leafletData;
+  vm.offer = {};
+  vm.editOffer = editOffer;
+  vm.mapCenter = defaultLocation;
+  vm.isLoading = false;
+  vm.minDescription = 5;
 
-    activate();
+  activate();
 
-    /**
-     * Initialize controller
-     */
-    function activate() {
+  /**
+   * Initialize controller
+   */
+  function activate() {
 
-      // Make sure offer is there
-      offer.$promise.then(function () {
+    // Make sure offer is there
+    offer.$promise.then(function () {
 
-        // Turn string date into a date object so that we can modify it
-        if (offer.validUntil) {
-          offer.validUntil = moment(offer.validUntil).toDate();
-        }
+      // Turn string date into a date object so that we can modify it
+      if (offer.validUntil) {
+        offer.validUntil = moment(offer.validUntil).toDate();
+      }
 
-        vm.offer = offer;
+      vm.offer = offer;
 
-        // Populate map
-        if (vm.offer && vm.offer.location) {
-          vm.mapCenter.lat = parseFloat(vm.offer.location[0]) || 0;
-          vm.mapCenter.lng = parseFloat(vm.offer.location[1]) || 0;
-          vm.mapCenter.zoom = 16;
-        }
+      // Populate map
+      if (vm.offer && vm.offer.location) {
+        vm.mapCenter.lat = parseFloat(vm.offer.location[0]) || 0;
+        vm.mapCenter.lng = parseFloat(vm.offer.location[1]) || 0;
+        vm.mapCenter.zoom = 16;
+      }
 
-      },
-      // Could not load offer
-      function () {
-        vm.offer = false;
-      });
-
-    }
-
-
-    /**
-     * Add offer
-     */
-    function editOffer() {
-      vm.isLoading = true;
-
-      offer.type = 'meet';
-      offer.status = 'yes';
-      offer.description = vm.offer.description;
-      offer.location = [parseFloat(vm.mapCenter.lat), parseFloat(vm.mapCenter.lng)];
-
-      const offerId = offer._id || false;
-
-      offer.$update(function () {
-        // Done!
-        $analytics.eventTrack('offer-modified', {
-          category: 'offer.meet.update',
-          label: 'Updated meet offer',
-        });
-
-        // If offer already has id, add it to URL
-        // $state will then scroll to it:
-        // that's useful if there are multiple offers on the list.
-        if (offerId) {
-          $state.go('offer.meet.list', { '#': 'offer-' + offerId });
-        } else {
-          $state.go('offer.meet.list');
-        }
-      }, function (err) {
-        const errorMessage = (err.data.message) ? err.data.message : 'Error occured. Please try again.';
-        messageCenterService.add('danger', errorMessage);
-      }).finally(function () {
-        vm.isLoading = false;
-      });
-
-    }
+    },
+    // Could not load offer
+    function () {
+      vm.offer = false;
+    });
 
   }
-}());
+
+
+  /**
+   * Add offer
+   */
+  function editOffer() {
+    vm.isLoading = true;
+
+    offer.type = 'meet';
+    offer.status = 'yes';
+    offer.description = vm.offer.description;
+    offer.location = [parseFloat(vm.mapCenter.lat), parseFloat(vm.mapCenter.lng)];
+
+    const offerId = offer._id || false;
+
+    offer.$update(function () {
+      // Done!
+      $analytics.eventTrack('offer-modified', {
+        category: 'offer.meet.update',
+        label: 'Updated meet offer',
+      });
+
+      // If offer already has id, add it to URL
+      // $state will then scroll to it:
+      // that's useful if there are multiple offers on the list.
+      if (offerId) {
+        $state.go('offer.meet.list', { '#': 'offer-' + offerId });
+      } else {
+        $state.go('offer.meet.list');
+      }
+    }, function (err) {
+      const errorMessage = (err.data.message) ? err.data.message : 'Error occured. Please try again.';
+      messageCenterService.add('danger', errorMessage);
+    }).finally(function () {
+      vm.isLoading = false;
+    });
+
+  }
+
+}

--- a/modules/offers/client/controllers/offer-meet-list.client.controller.js
+++ b/modules/offers/client/controllers/offer-meet-list.client.controller.js
@@ -1,71 +1,69 @@
-(function () {
-  angular
-    .module('offers')
-    .controller('OfferListMeetController', OfferListMeetController);
+angular
+  .module('offers')
+  .controller('OfferListMeetController', OfferListMeetController);
 
-  /* @ngInject */
-  function OfferListMeetController(offers, $timeout, $anchorScroll, $analytics, $confirm, OffersService, messageCenterService) {
+/* @ngInject */
+function OfferListMeetController(offers, $timeout, $anchorScroll, $analytics, $confirm, OffersService, messageCenterService) {
 
-    // ViewModel
-    const vm = this;
+  // ViewModel
+  const vm = this;
 
-    // Expoxed to the view
-    vm.offers = offers;
-    vm.remove = remove;
+  // Expoxed to the view
+  vm.offers = offers;
+  vm.remove = remove;
 
-    activate();
+  activate();
 
+  /**
+   * Activate controller
+   */
+  function activate() {
     /**
-     * Activate controller
+     * If URL has hash (e.g. `#offer-5994afbf2beea2a88184104f`), scroll to it
+     * @link https://docs.angularjs.org/api/ng/service/$anchorScroll
      */
-    function activate() {
-      /**
-       * If URL has hash (e.g. `#offer-5994afbf2beea2a88184104f`), scroll to it
-       * @link https://docs.angularjs.org/api/ng/service/$anchorScroll
-       */
-      $timeout(function () {
-        // Offset for scrolling position
-        $anchorScroll.yOffset = function () {
-          const $header = angular.element('#tr-header');
-          // Set y-axis offset for scrolling to element to header's height
-          return $header.length ? ($header.height() + 5) : 50;
-        };
-        $anchorScroll();
-      }, 500);
-    }
+    $timeout(function () {
+      // Offset for scrolling position
+      $anchorScroll.yOffset = function () {
+        const $header = angular.element('#tr-header');
+        // Set y-axis offset for scrolling to element to header's height
+        return $header.length ? ($header.height() + 5) : 50;
+      };
+      $anchorScroll();
+    }, 500);
+  }
 
-    /**
-     * Remove offer
-     */
-    function remove(offer) {
+  /**
+   * Remove offer
+   */
+  function remove(offer) {
 
-      // Index of this `offer` in `vm.offers` array
-      const index = vm.offers.indexOf(offer);
+    // Index of this `offer` in `vm.offers` array
+    const index = vm.offers.indexOf(offer);
 
-      // Ask for confirmation
-      $confirm({
-        // title: 'Are you sure?',
-        text: 'Are you sure you want to remove this?',
-        ok: 'Remove',
-        cancel: 'Cancel',
-      })
-      // If user pressed "continue", create another state go
-        .then(function () {
-          new OffersService(offer).$delete(function () {
-            $analytics.eventTrack('offer-delete', {
-              category: 'offer.meet.delete',
-              label: 'Removed meet offer',
-            });
-
-            // Remove `offer` from `vm.offers` array
-            vm.offers.splice(index, 1);
-          }, function (err) {
-            const errorMessage = (err.data.message) ? err.data.message : 'Error occured. Please try again.';
-            messageCenterService.add('danger', errorMessage);
+    // Ask for confirmation
+    $confirm({
+      // title: 'Are you sure?',
+      text: 'Are you sure you want to remove this?',
+      ok: 'Remove',
+      cancel: 'Cancel',
+    })
+    // If user pressed "continue", create another state go
+      .then(function () {
+        new OffersService(offer).$delete(function () {
+          $analytics.eventTrack('offer-delete', {
+            category: 'offer.meet.delete',
+            label: 'Removed meet offer',
           });
-        });
 
-    }
+          // Remove `offer` from `vm.offers` array
+          vm.offers.splice(index, 1);
+        }, function (err) {
+          const errorMessage = (err.data.message) ? err.data.message : 'Error occured. Please try again.';
+          messageCenterService.add('danger', errorMessage);
+        });
+      });
 
   }
-}());
+
+}

--- a/modules/offers/client/controllers/offer.client.controller.js
+++ b/modules/offers/client/controllers/offer.client.controller.js
@@ -1,49 +1,47 @@
-(function () {
-  angular
-    .module('offers')
-    .controller('OfferController', OfferController);
+angular
+  .module('offers')
+  .controller('OfferController', OfferController);
 
-  /* @ngInject */
-  function OfferController($timeout, MapLayersFactory) {
+/* @ngInject */
+function OfferController($timeout, MapLayersFactory) {
 
-    // ViewModel
-    const vm = this;
-    vm.invalidateMapSize = invalidateMapSize;
+  // ViewModel
+  const vm = this;
+  vm.invalidateMapSize = invalidateMapSize;
 
-    /**
-     * Activate map on tab change
-     * @param {Object} leafletData - Service for Leaflet
-     */
-    function invalidateMapSize(leafletData) {
-      $timeout(function () {
-        leafletData.getMap().then(function (map) {
-          // @link http://leafletjs.com/reference-1.2.0.html#map-invalidatesize
-          map.invalidateSize(false);
-        });
-      }, 300);
-    }
-
-    // Leaflet
-    vm.mapLayers = {
-      baselayers: MapLayersFactory.getLayers({
-        streets: true,
-        satellite: false,
-        outdoors: false,
-      }),
-    };
-    vm.mapDefaults = {
-      scrollWheelZoom: false,
-      attributionControl: true,
-      keyboard: true,
-      worldCopyJump: true,
-      controls: {
-        layers: {
-          visible: false,
-          position: 'bottomleft',
-          collapsed: false,
-        },
-      },
-    };
-
+  /**
+   * Activate map on tab change
+   * @param {Object} leafletData - Service for Leaflet
+   */
+  function invalidateMapSize(leafletData) {
+    $timeout(function () {
+      leafletData.getMap().then(function (map) {
+        // @link http://leafletjs.com/reference-1.2.0.html#map-invalidatesize
+        map.invalidateSize(false);
+      });
+    }, 300);
   }
-}());
+
+  // Leaflet
+  vm.mapLayers = {
+    baselayers: MapLayersFactory.getLayers({
+      streets: true,
+      satellite: false,
+      outdoors: false,
+    }),
+  };
+  vm.mapDefaults = {
+    scrollWheelZoom: false,
+    attributionControl: true,
+    keyboard: true,
+    worldCopyJump: true,
+    controls: {
+      layers: {
+        visible: false,
+        position: 'bottomleft',
+        collapsed: false,
+      },
+    },
+  };
+
+}

--- a/modules/offers/client/directives/tr-offer-host-view.client.directive.js
+++ b/modules/offers/client/directives/tr-offer-host-view.client.directive.js
@@ -1,100 +1,98 @@
 import templateUrl from '@/modules/offers/client/views/directives/tr-offer-host-view.client.view.html';
 
-(function () {
-  angular
-    .module('offers')
-    .directive('trOfferHostView', trOfferHostViewDirective);
+angular
+  .module('offers')
+  .directive('trOfferHostView', trOfferHostViewDirective);
+
+/* @ngInject */
+function trOfferHostViewDirective() {
+  const directive = {
+    restrict: 'A',
+    replace: true,
+    scope: {
+      profile: '=trOfferHostView', // Profile who's offer to load
+      authUser: '=trOfferHostViewAuthUser', // Currently authenticated user
+    },
+    templateUrl,
+    controller: trOfferHostViewDirectiveController,
+    controllerAs: 'trOfferHost',
+  };
+
+  return directive;
 
   /* @ngInject */
-  function trOfferHostViewDirective() {
-    const directive = {
-      restrict: 'A',
-      replace: true,
-      scope: {
-        profile: '=trOfferHostView', // Profile who's offer to load
-        authUser: '=trOfferHostViewAuthUser', // Currently authenticated user
-      },
-      templateUrl,
-      controller: trOfferHostViewDirectiveController,
-      controllerAs: 'trOfferHost',
-    };
+  function trOfferHostViewDirectiveController($scope, $window, OffersByService) {
 
-    return directive;
+    // ViewModel
+    const vm = this;
 
-    /* @ngInject */
-    function trOfferHostViewDirectiveController($scope, $window, OffersByService) {
+    // Exposed
+    vm.offer = false;
+    vm.isLoading = true;
+    vm.isOwnOffer = false;
+    vm.profile = false;
+    vm.isUserPublic = false;
+    vm.hostingDropdown = false;
+    vm.hostingStatusLabel = hostingStatusLabel;
+    vm.isMobile = $window.navigator.userAgent.toLowerCase().indexOf('mobile') >= 0 || $window.isNativeMobileApp;
+    activate();
 
-      // ViewModel
-      const vm = this;
+    /**
+     * Initialize controller
+     */
+    function activate() {
 
-      // Exposed
-      vm.offer = false;
-      vm.isLoading = true;
-      vm.isOwnOffer = false;
-      vm.profile = false;
-      vm.isUserPublic = false;
-      vm.hostingDropdown = false;
-      vm.hostingStatusLabel = hostingStatusLabel;
-      vm.isMobile = $window.navigator.userAgent.toLowerCase().indexOf('mobile') >= 0 || $window.isNativeMobileApp;
-      activate();
-
-      /**
-       * Initialize controller
-       */
-      function activate() {
-
-        if (!$scope.profile) {
-          vm.isLoading = false;
-          return;
-        }
-
-        /**
-         * Fetch offer
-         * @todo: move to route resolve
-         * @note: profileCtrl is a reference to parent "ControllerAs" (see users module)
-         */
-        $scope.profile.$promise.then(function (profile) {
-          if (profile && profile._id) {
-
-            vm.profile = profile;
-            vm.isOwnOffer = ($scope.authUser && $scope.authUser._id && $scope.authUser._id === profile._id);
-            vm.isUserPublic = ($scope.authUser && $scope.authUser.public);
-
-            OffersByService.query({
-              userId: String(profile._id),
-              types: 'host',
-            }, function (offers) {
-
-              if (!offers || !offers.length) {
-                vm.isLoading = false;
-                return;
-              }
-
-              vm.offer = offers[0];
-              vm.isLoading = false;
-            }, function () {
-              // No offer(s) found
-              vm.isLoading = false;
-            });
-          }
-        });
+      if (!$scope.profile) {
+        vm.isLoading = false;
+        return;
       }
 
       /**
-       * Helper for hosting label
+       * Fetch offer
+       * @todo: move to route resolve
+       * @note: profileCtrl is a reference to parent "ControllerAs" (see users module)
        */
-      function hostingStatusLabel(status) {
-        switch (status) {
-          case 'yes':
-            return 'Can host';
-          case 'maybe':
-            return 'Might be able to host';
-          default:
-            return 'Cannot host currently';
-        }
-      }
+      $scope.profile.$promise.then(function (profile) {
+        if (profile && profile._id) {
 
+          vm.profile = profile;
+          vm.isOwnOffer = ($scope.authUser && $scope.authUser._id && $scope.authUser._id === profile._id);
+          vm.isUserPublic = ($scope.authUser && $scope.authUser.public);
+
+          OffersByService.query({
+            userId: String(profile._id),
+            types: 'host',
+          }, function (offers) {
+
+            if (!offers || !offers.length) {
+              vm.isLoading = false;
+              return;
+            }
+
+            vm.offer = offers[0];
+            vm.isLoading = false;
+          }, function () {
+            // No offer(s) found
+            vm.isLoading = false;
+          });
+        }
+      });
+    }
+
+    /**
+     * Helper for hosting label
+     */
+    function hostingStatusLabel(status) {
+      switch (status) {
+        case 'yes':
+          return 'Can host';
+        case 'maybe':
+          return 'Might be able to host';
+        default:
+          return 'Cannot host currently';
+      }
     }
 
   }
-}());
+
+}

--- a/modules/offers/client/directives/tr-offer-valid-until.client.directive.js
+++ b/modules/offers/client/directives/tr-offer-valid-until.client.directive.js
@@ -1,104 +1,102 @@
 import templateUrl from '@/modules/offers/client/views/directives/tr-offer-valid-until.view.client.html';
 
-(function () {
-  /**
-   * A directive to modify offer's `validUntil` dates
-   */
+/**
+ * A directive to modify offer's `validUntil` dates
+ */
 
-  angular
-    .module('offers')
-    .directive('trOfferValidUntil', trOfferValidUntilDirective);
+angular
+  .module('offers')
+  .directive('trOfferValidUntil', trOfferValidUntilDirective);
+
+/* @ngInject */
+function trOfferValidUntilDirective() {
+  const directive = {
+    restrict: 'A',
+    replace: false,
+    scope: {
+      validUntil: '=trOfferValidUntil',
+    },
+    templateUrl,
+    controller: trOfferValidUntilDirectiveController,
+    controllerAs: 'trOfferValidUntil',
+  };
+
+  return directive;
 
   /* @ngInject */
-  function trOfferValidUntilDirective() {
-    const directive = {
-      restrict: 'A',
-      replace: false,
-      scope: {
-        validUntil: '=trOfferValidUntil',
-      },
-      templateUrl,
-      controller: trOfferValidUntilDirectiveController,
-      controllerAs: 'trOfferValidUntil',
+  function trOfferValidUntilDirectiveController($scope, moment, SettingsFactory) {
+
+    const appSettings = SettingsFactory.get();
+
+    // View model
+    const vm = this;
+
+    vm.isCalendarVisible = false;
+
+    // Default is one month
+    vm.offerValidityInDays = 30;
+
+    // Predefined options visible without calendar
+    vm.choices = {
+      'A week': 7,
+      'Two weeks': 14,
+      'Three weeks': 23,
+      'A month': 30,
     };
 
-    return directive;
+    // Options for Angular-UI Bootstrap datepicker
+    // https://angular-ui.github.io/bootstrap/#!#datepicker
+    vm.calendarOptions = {
+      showWeeks: false, // Hide week numbers
+      maxDate: moment().add(appSettings.limits.maxOfferValidFromNow || { days: 30 }).toDate(),
+      minDate: new Date(), // @TODO: this could be server date instead of client date
+      startingDay: 1, // Start week on Monday
+      maxMode: 'month', // Disable year selector
+    };
 
-    /* @ngInject */
-    function trOfferValidUntilDirectiveController($scope, moment, SettingsFactory) {
+    activate();
 
-      const appSettings = SettingsFactory.get();
+    /**
+     * Initialize controller
+     */
+    function activate() {
 
-      // View model
-      const vm = this;
+      // If date was prepopulated, just set directive to calendar mode
+      if ($scope.validUntil) {
+        vm.isCalendarVisible = true;
+        vm.validUntil = $scope.validUntil;
+      } else {
+        setValidUntilDays(vm.offerValidityInDays);
+      }
 
-      vm.isCalendarVisible = false;
-
-      // Default is one month
-      vm.offerValidityInDays = 30;
-
-      // Predefined options visible without calendar
-      vm.choices = {
-        'A week': 7,
-        'Two weeks': 14,
-        'Three weeks': 23,
-        'A month': 30,
-      };
-
-      // Options for Angular-UI Bootstrap datepicker
-      // https://angular-ui.github.io/bootstrap/#!#datepicker
-      vm.calendarOptions = {
-        showWeeks: false, // Hide week numbers
-        maxDate: moment().add(appSettings.limits.maxOfferValidFromNow || { days: 30 }).toDate(),
-        minDate: new Date(), // @TODO: this could be server date instead of client date
-        startingDay: 1, // Start week on Monday
-        maxMode: 'month', // Disable year selector
-      };
-
-      activate();
-
-      /**
-       * Initialize controller
-       */
-      function activate() {
-
-        // If date was prepopulated, just set directive to calendar mode
-        if ($scope.validUntil) {
-          vm.isCalendarVisible = true;
-          vm.validUntil = $scope.validUntil;
-        } else {
-          setValidUntilDays(vm.offerValidityInDays);
+      $scope.$watch('trOfferValidUntil.offerValidityInDays', function (newValue, oldValue) {
+        if (newValue !== oldValue) {
+          setValidUntilDays(newValue);
         }
+      });
 
-        $scope.$watch('trOfferValidUntil.offerValidityInDays', function (newValue, oldValue) {
-          if (newValue !== oldValue) {
-            setValidUntilDays(newValue);
-          }
-        });
+      // Update $scope when view model updates
+      $scope.$watch('trOfferValidUntil.validUntil', function (date) {
+        $scope.validUntil = date;
+      });
+    }
 
-        // Update $scope when view model updates
-        $scope.$watch('trOfferValidUntil.validUntil', function (date) {
-          $scope.validUntil = date;
-        });
-      }
+    /**
+     * Sets validity of offer to future by x days
+     *
+     * @param {Int} days Number of days to set to future
+     */
+    function setValidUntilDays(days) {
 
-      /**
-       * Sets validity of offer to future by x days
-       *
-       * @param {Int} days Number of days to set to future
-       */
-      function setValidUntilDays(days) {
+      days = parseInt(days, 10);
 
-        days = parseInt(days, 10);
+      // Defaults to max
+      // @link https://momentjs.com/docs/#/manipulating/add/
+      const add = days ? { days: days } : appSettings.limits.maxOfferValidFromNow;
 
-        // Defaults to max
-        // @link https://momentjs.com/docs/#/manipulating/add/
-        const add = days ? { days: days } : appSettings.limits.maxOfferValidFromNow;
-
-        vm.validUntil = moment().endOf('day').add(add).toDate();
-      }
-
+      vm.validUntil = moment().endOf('day').add(add).toDate();
     }
 
   }
-}());
+
+}

--- a/modules/offers/client/services/offers-by.client.service.js
+++ b/modules/offers/client/services/offers-by.client.service.js
@@ -1,20 +1,18 @@
-(function () {
-  // OffersBy service used for communicating with the offers REST endpoints
-  // Read offers by userId
-  // Accepts also `type` parameter
-  angular
-    .module('offers')
-    .factory('OffersByService', OffersByService);
+// OffersBy service used for communicating with the offers REST endpoints
+// Read offers by userId
+// Accepts also `type` parameter
+angular
+  .module('offers')
+  .factory('OffersByService', OffersByService);
 
-  /* @ngInject */
-  function OffersByService($resource) {
-    return $resource('/api/offers-by/:userId', {
-      userId: '@id',
-    }, {
-      query: {
-        method: 'GET',
-        isArray: true,
-      },
-    });
-  }
-}());
+/* @ngInject */
+function OffersByService($resource) {
+  return $resource('/api/offers-by/:userId', {
+    userId: '@id',
+  }, {
+    query: {
+      method: 'GET',
+      isArray: true,
+    },
+  });
+}

--- a/modules/offers/client/services/offers.client.service.js
+++ b/modules/offers/client/services/offers.client.service.js
@@ -1,48 +1,46 @@
-(function () {
-  // Offers service used for communicating with the offers REST endpoints
-  angular
-    .module('offers')
-    .factory('OffersService', OffersService);
+// Offers service used for communicating with the offers REST endpoints
+angular
+  .module('offers')
+  .factory('OffersService', OffersService);
 
-  /* @ngInject */
-  function OffersService($resource) {
-    const Offer = $resource('/api/offers/:offerId', {
-      offerId: '@_id',
-    }, {
-      get: {
-        method: 'GET',
-        cancellable: true,
-      },
-      update: {
-        method: 'PUT',
-      },
-      save: {
-        method: 'POST',
-      },
-      delete: {
-        method: 'DELETE',
-      },
-    });
+/* @ngInject */
+function OffersService($resource) {
+  const Offer = $resource('/api/offers/:offerId', {
+    offerId: '@_id',
+  }, {
+    get: {
+      method: 'GET',
+      cancellable: true,
+    },
+    update: {
+      method: 'PUT',
+    },
+    save: {
+      method: 'POST',
+    },
+    delete: {
+      method: 'DELETE',
+    },
+  });
 
-    angular.extend(Offer.prototype, {
-      createOrUpdate: function () {
-        const offer = this;
-        return createOrUpdate(offer);
-      },
-    });
+  angular.extend(Offer.prototype, {
+    createOrUpdate: function () {
+      const offer = this;
+      return createOrUpdate(offer);
+    },
+  });
 
-    return Offer;
+  return Offer;
 
-    /**
-     * Update if offer has `_id` and otherwise save it as new offer
-     */
-    function createOrUpdate(offer) {
-      if (offer._id) {
-        return offer.$update();
-      } else {
-        return offer.$save();
-      }
+  /**
+   * Update if offer has `_id` and otherwise save it as new offer
+   */
+  function createOrUpdate(offer) {
+    if (offer._id) {
+      return offer.$update();
+    } else {
+      return offer.$save();
     }
-
   }
-}());
+
+}

--- a/modules/pages/client/config/pages.client.routes.js
+++ b/modules/pages/client/config/pages.client.routes.js
@@ -15,163 +15,161 @@ import mediaTemplateUrl from '@/modules/pages/client/views/media.client.view.htm
 import guideTemplateUrl from '@/modules/pages/client/views/guide.client.view.html';
 import homeTemplateUrl from '@/modules/pages/client/views/home.client.view.html';
 
-(function () {
-  angular
-    .module('pages')
-    .config(PagesRoutes);
+angular
+  .module('pages')
+  .config(PagesRoutes);
 
-  /* @ngInject */
-  function PagesRoutes($stateProvider) {
+/* @ngInject */
+function PagesRoutes($stateProvider) {
 
-    // Remember to update `./public/sitemap.xml`
+  // Remember to update `./public/sitemap.xml`
 
-    $stateProvider.
-      state('navigation', {
-        url: '/navigation',
-        templateUrl: navigationTemplateUrl,
-        requiresAuth: true,
-        footerHidden: true,
-        data: {
-          pageTitle: 'Navigation',
-        },
-      }).
-      state('rules', {
-        url: '/rules',
-        templateUrl: rulesTemplateUrl,
-        data: {
-          pageTitle: 'Rules',
-        },
-      }).
-      state('team', {
-        url: '/team',
-        templateUrl: teamTemplateUrl,
-        data: {
-          pageTitle: 'Team',
-        },
-      }).
-      state('privacy', {
-        url: '/privacy',
-        templateUrl: privacyTemplateUrl,
-        data: {
-          pageTitle: 'Privacy policy',
-        },
-      }).
-      state('donate', {
-        url: '/donate',
-        templateUrl: donateTemplateUrl,
-        data: {
-          pageTitle: 'Donate',
-        },
-      }).
-      state('donate-help', {
-        url: '/donate/help',
-        templateUrl: donateHelpTemplateUrl,
-        data: {
-          pageTitle: 'Donation help',
-        },
-      }).
-      state('donate-policy', {
-        url: '/donate/policy',
-        templateUrl: donatePolicyTemplateUrl,
-        data: {
-          pageTitle: 'Donation policy',
-        },
-      }).
-      state('faq', {
-        url: '/faq',
-        templateUrl: faqTemplateUrl,
-        abstract: true,
-        controller: 'FaqController',
-        controllerAs: 'faq',
-        data: {
-          pageTitle: 'FAQ',
-        },
-      }).
-      state('faq.general', {
-        url: '',
-        templateUrl: faqGeneralTemplateUrl,
-        data: {
-          pageTitle: 'FAQ - Site & community',
-        },
-      }).
-      state('faq.tribes', {
-        url: '/tribes',
-        templateUrl: faqTribesTemplateUrl,
-        data: {
-          pageTitle: 'FAQ - Tribes',
-        },
-      }).
-      state('faq.foundation', {
-        url: '/foundation',
-        templateUrl: faqFoundationTemplateUrl,
-        data: {
-          pageTitle: 'FAQ - Foundation',
-        },
-      }).
-      state('faq.technology', {
-        url: '/technology',
-        templateUrl: faqTechnologyTemplateUrl,
-        data: {
-          pageTitle: 'FAQ - Technology',
-        },
-      }).
-      state('foundation', {
-        url: '/foundation',
-        templateUrl: foundationTemplateUrl,
-        data: {
-          pageTitle: 'Foundation',
-        },
-      }).
-      state('media', {
-        url: '/media',
-        templateUrl: mediaTemplateUrl,
-        data: {
-          pageTitle: 'Media',
-        },
-      }).
-      state('volunteering', {
-        url: '/volunteering',
-        template: '<volunteering></volunteering>',
-        data: {
-          pageTitle: 'Volunteering',
-        },
-      }).
-      state('guide', {
-        url: '/guide',
-        templateUrl: guideTemplateUrl,
-        data: {
-          pageTitle: 'Guide',
-        },
-      }).
+  $stateProvider.
+    state('navigation', {
+      url: '/navigation',
+      templateUrl: navigationTemplateUrl,
+      requiresAuth: true,
+      footerHidden: true,
+      data: {
+        pageTitle: 'Navigation',
+      },
+    }).
+    state('rules', {
+      url: '/rules',
+      templateUrl: rulesTemplateUrl,
+      data: {
+        pageTitle: 'Rules',
+      },
+    }).
+    state('team', {
+      url: '/team',
+      templateUrl: teamTemplateUrl,
+      data: {
+        pageTitle: 'Team',
+      },
+    }).
+    state('privacy', {
+      url: '/privacy',
+      templateUrl: privacyTemplateUrl,
+      data: {
+        pageTitle: 'Privacy policy',
+      },
+    }).
+    state('donate', {
+      url: '/donate',
+      templateUrl: donateTemplateUrl,
+      data: {
+        pageTitle: 'Donate',
+      },
+    }).
+    state('donate-help', {
+      url: '/donate/help',
+      templateUrl: donateHelpTemplateUrl,
+      data: {
+        pageTitle: 'Donation help',
+      },
+    }).
+    state('donate-policy', {
+      url: '/donate/policy',
+      templateUrl: donatePolicyTemplateUrl,
+      data: {
+        pageTitle: 'Donation policy',
+      },
+    }).
+    state('faq', {
+      url: '/faq',
+      templateUrl: faqTemplateUrl,
+      abstract: true,
+      controller: 'FaqController',
+      controllerAs: 'faq',
+      data: {
+        pageTitle: 'FAQ',
+      },
+    }).
+    state('faq.general', {
+      url: '',
+      templateUrl: faqGeneralTemplateUrl,
+      data: {
+        pageTitle: 'FAQ - Site & community',
+      },
+    }).
+    state('faq.tribes', {
+      url: '/tribes',
+      templateUrl: faqTribesTemplateUrl,
+      data: {
+        pageTitle: 'FAQ - Tribes',
+      },
+    }).
+    state('faq.foundation', {
+      url: '/foundation',
+      templateUrl: faqFoundationTemplateUrl,
+      data: {
+        pageTitle: 'FAQ - Foundation',
+      },
+    }).
+    state('faq.technology', {
+      url: '/technology',
+      templateUrl: faqTechnologyTemplateUrl,
+      data: {
+        pageTitle: 'FAQ - Technology',
+      },
+    }).
+    state('foundation', {
+      url: '/foundation',
+      templateUrl: foundationTemplateUrl,
+      data: {
+        pageTitle: 'Foundation',
+      },
+    }).
+    state('media', {
+      url: '/media',
+      templateUrl: mediaTemplateUrl,
+      data: {
+        pageTitle: 'Media',
+      },
+    }).
+    state('volunteering', {
+      url: '/volunteering',
+      template: '<volunteering></volunteering>',
+      data: {
+        pageTitle: 'Volunteering',
+      },
+    }).
+    state('guide', {
+      url: '/guide',
+      templateUrl: guideTemplateUrl,
+      data: {
+        pageTitle: 'Guide',
+      },
+    }).
 
-      // Redirect to home:
-      state('about', {
-        url: '/about',
-        footerHidden: true,
-        controller:
-          /* @ngInject */
-          function ($state) {
-            $state.go('home');
-          },
-        controllerAs: 'about',
-      });
+    // Redirect to home:
+    state('about', {
+      url: '/about',
+      footerHidden: true,
+      controller:
+        /* @ngInject */
+        function ($state) {
+          $state.go('home');
+        },
+      controllerAs: 'about',
+    });
 
-    /**
-     * Work around redirecting to home on SEO rendered pages
-     */
-    // Angular's `$window` service is not available for `config` blocks
-    // eslint-disable-next-line angular/window-service
-    if (window.location.search.search('_escaped_fragment_') === -1) {
-      $stateProvider.state('home', {
-        url: '/?tribe',
-        templateUrl: homeTemplateUrl,
-        controller: 'HomeController',
-        controllerAs: 'home',
-        footerHidden: true,
-      });
-    } else {
-      $stateProvider.state('home', { url: '/' });
-    }
-
+  /**
+   * Work around redirecting to home on SEO rendered pages
+   */
+  // Angular's `$window` service is not available for `config` blocks
+  // eslint-disable-next-line angular/window-service
+  if (window.location.search.search('_escaped_fragment_') === -1) {
+    $stateProvider.state('home', {
+      url: '/?tribe',
+      templateUrl: homeTemplateUrl,
+      controller: 'HomeController',
+      controllerAs: 'home',
+      footerHidden: true,
+    });
+  } else {
+    $stateProvider.state('home', { url: '/' });
   }
-}());
+
+}

--- a/modules/pages/client/controllers/faq.client.controller.js
+++ b/modules/pages/client/controllers/faq.client.controller.js
@@ -1,85 +1,83 @@
-(function () {
-  angular
-    .module('pages')
-    .controller('FaqController', FaqController);
+angular
+  .module('pages')
+  .controller('FaqController', FaqController);
 
-  /* @ngInject */
-  function FaqController($scope, $timeout, $window, $location, $state, $uiViewScroll) {
+/* @ngInject */
+function FaqController($scope, $timeout, $window, $location, $state, $uiViewScroll) {
 
-    // ViewModel
-    const vm = this;
+  // ViewModel
+  const vm = this;
 
-    // Exposed to the view
-    vm.allowStickySidebar = true;
+  // Exposed to the view
+  vm.allowStickySidebar = true;
 
-    activate();
+  activate();
 
-    /**
-     * Initialize
-     */
-    function activate() {
+  /**
+   * Initialize
+   */
+  function activate() {
 
-      // Follow on which FAQ category we are at
-      $scope.$on('$stateChangeSuccess', function () {
-        if ($state.current.name.substr(0, 4) === 'faq.') {
-          vm.category = $state.current.name.replace('faq.', '');
-          canSidebarBeSticky();
-        }
-      });
-
-      // Act when hash changes
-      $scope.$on('$locationChangeSuccess', function () {
-        if ($location.hash() !== '') {
-          highlightQuestion($location.hash());
-        }
-      });
-
-      // Determine sidebar's stickiness
-      canSidebarBeSticky();
-
-      $timeout(function () {
-
-        // If hash is present on initial page load, open it
-        if ($location.hash() !== '') {
-          // Scroll to element
-          $uiViewScroll(angular.element('#' + $location.hash()));
-          highlightQuestion($location.hash());
-        }
-
-        // Determine fixed width for the sidebar so it doesn't overflow when it gets fixed position
-        angular.element('#faq-sidebar').css({ 'width': angular.element('#faq-sidebar').width() });
-      });
-
-    }
-
-    /**
-     * Determine if sidebar should be scrolling or not
-     * If window height is smaller than sidebar's height,
-     * don't let it stick
-     */
-    function canSidebarBeSticky() {
-      $timeout(function () {
-        if ($window.innerHeight <= angular.element('#faq-sidebar').height()) {
-          vm.allowStickySidebar = false;
-        }
-      });
-    }
-
-    /**
-     * Scroll+highlight a FAQ question when clicking title at sidebar
-     */
-    function highlightQuestion(id) {
-      const $el = angular.element('#' + id);
-
-      // Performs color flash for link, see faq.less for more.
-      // Animation time at CSS is 1000ms
-      if ($el.length) {
-        $el.addClass('faq-question-flash');
-        $timeout(function () {
-          $el.removeClass('faq-question-flash');
-        }, 1010);
+    // Follow on which FAQ category we are at
+    $scope.$on('$stateChangeSuccess', function () {
+      if ($state.current.name.substr(0, 4) === 'faq.') {
+        vm.category = $state.current.name.replace('faq.', '');
+        canSidebarBeSticky();
       }
-    }
+    });
+
+    // Act when hash changes
+    $scope.$on('$locationChangeSuccess', function () {
+      if ($location.hash() !== '') {
+        highlightQuestion($location.hash());
+      }
+    });
+
+    // Determine sidebar's stickiness
+    canSidebarBeSticky();
+
+    $timeout(function () {
+
+      // If hash is present on initial page load, open it
+      if ($location.hash() !== '') {
+        // Scroll to element
+        $uiViewScroll(angular.element('#' + $location.hash()));
+        highlightQuestion($location.hash());
+      }
+
+      // Determine fixed width for the sidebar so it doesn't overflow when it gets fixed position
+      angular.element('#faq-sidebar').css({ 'width': angular.element('#faq-sidebar').width() });
+    });
 
   }
-}());
+
+  /**
+   * Determine if sidebar should be scrolling or not
+   * If window height is smaller than sidebar's height,
+   * don't let it stick
+   */
+  function canSidebarBeSticky() {
+    $timeout(function () {
+      if ($window.innerHeight <= angular.element('#faq-sidebar').height()) {
+        vm.allowStickySidebar = false;
+      }
+    });
+  }
+
+  /**
+   * Scroll+highlight a FAQ question when clicking title at sidebar
+   */
+  function highlightQuestion(id) {
+    const $el = angular.element('#' + id);
+
+    // Performs color flash for link, see faq.less for more.
+    // Animation time at CSS is 1000ms
+    if ($el.length) {
+      $el.addClass('faq-question-flash');
+      $timeout(function () {
+        $el.removeClass('faq-question-flash');
+      }, 1010);
+    }
+  }
+
+}

--- a/modules/pages/client/controllers/home.client.controller.js
+++ b/modules/pages/client/controllers/home.client.controller.js
@@ -1,91 +1,89 @@
-(function () {
-  angular
-    .module('pages')
-    .run(HomeRunBlock)
-    .controller('HomeController', HomeController);
+angular
+  .module('pages')
+  .run(HomeRunBlock)
+  .controller('HomeController', HomeController);
 
-  /* @ngInject */
-  function HomeRunBlock($location, $window, Authentication) {
-    // When landing to frontpage as authenticated user, redirect to search
-    if (Authentication.user && $location.path() === '/') {
-      $location.path('/search');
-    }
-
-    /**
-     * When the site is wrapped on mobile,
-     * we have these global variables in use:
-     *
-     * {Boolean} isMobileApp
-     * {String} mobileVersion
-     * {String} mobilePlatform
-     * {String} mobileDeviceName
-     * {String} mobileDeviceYearClass
-     */
-    if ($window.isMobileApp) {
-      $location.path('/signin');
-    }
+/* @ngInject */
+function HomeRunBlock($location, $window, Authentication) {
+  // When landing to frontpage as authenticated user, redirect to search
+  if (Authentication.user && $location.path() === '/') {
+    $location.path('/search');
   }
 
-  /* @ngInject */
-  function HomeController($stateParams, $window, TribesService, TribeService) {
+  /**
+   * When the site is wrapped on mobile,
+   * we have these global variables in use:
+   *
+   * {Boolean} isMobileApp
+   * {String} mobileVersion
+   * {String} mobilePlatform
+   * {String} mobileDeviceName
+   * {String} mobileDeviceYearClass
+   */
+  if ($window.isMobileApp) {
+    $location.path('/signin');
+  }
+}
 
-    const headerHeight = angular.element('#tr-header').height() || 0;
+/* @ngInject */
+function HomeController($stateParams, $window, TribesService, TribeService) {
 
-    // View model
-    const vm = this;
+  const headerHeight = angular.element('#tr-header').height() || 0;
 
-    // Exposed to the view
-    vm.boardHeight = $window.innerWidth <= 480 && $window.innerHeight < 700 ? 400 : $window.innerHeight - headerHeight + 14;
+  // View model
+  const vm = this;
 
-    // Load front page's landing photos
-    if ($stateParams.tribe && ['hitchhikers', 'dumpster-divers', 'punks'].indexOf($stateParams.tribe) > -1) {
-      // Photos for these 3 tribes
-      vm.boards = [
-        'rainbowpeople',
-        'hitchroad',
-        'desertgirl',
-        'hitchgirl1',
-        'hitchgirl2',
-        'hitchtruck',
-      ];
-    } else {
-      vm.boards = [
-        'woman-bridge',
-        'rainbowpeople',
-        'hitchroad',
-        'hitchgirl1',
-        'wavewatching',
-        'sahara-backpacker',
-        'hitchtruck',
-      ];
-    }
+  // Exposed to the view
+  vm.boardHeight = $window.innerWidth <= 480 && $window.innerHeight < 700 ? 400 : $window.innerHeight - headerHeight + 14;
 
-    function isTribeLoaded(tribeSlug) {
-      angular.forEach(vm.tribes, function (tribe) {
-        if (tribe.slug === tribeSlug) {
-          return true;
-        }
-      });
+  // Load front page's landing photos
+  if ($stateParams.tribe && ['hitchhikers', 'dumpster-divers', 'punks'].indexOf($stateParams.tribe) > -1) {
+    // Photos for these 3 tribes
+    vm.boards = [
+      'rainbowpeople',
+      'hitchroad',
+      'desertgirl',
+      'hitchgirl1',
+      'hitchgirl2',
+      'hitchtruck',
+    ];
+  } else {
+    vm.boards = [
+      'woman-bridge',
+      'rainbowpeople',
+      'hitchroad',
+      'hitchgirl1',
+      'wavewatching',
+      'sahara-backpacker',
+      'hitchtruck',
+    ];
+  }
 
-      return false;
-    }
-
-    // Load suggested tribes
-    vm.tribes = TribesService.query({
-      limit: 3,
-    }, function () {
-      // Got those three tribes, now fetch one more if requested
-      if ($stateParams.tribe && !isTribeLoaded($stateParams.tribe)) {
-        TribeService.get({
-          tribeSlug: $stateParams.tribe,
-        }).then(function (tribe) {
-          // If tribe was found, put it to the beginning of `vm.tribes` array
-          if (tribe && tribe._id) {
-            vm.tribes.unshift(tribe);
-          }
-        });
+  function isTribeLoaded(tribeSlug) {
+    angular.forEach(vm.tribes, function (tribe) {
+      if (tribe.slug === tribeSlug) {
+        return true;
       }
     });
 
+    return false;
   }
-}());
+
+  // Load suggested tribes
+  vm.tribes = TribesService.query({
+    limit: 3,
+  }, function () {
+    // Got those three tribes, now fetch one more if requested
+    if ($stateParams.tribe && !isTribeLoaded($stateParams.tribe)) {
+      TribeService.get({
+        tribeSlug: $stateParams.tribe,
+      }).then(function (tribe) {
+        // If tribe was found, put it to the beginning of `vm.tribes` array
+        if (tribe && tribe._id) {
+          vm.tribes.unshift(tribe);
+        }
+      });
+    }
+  });
+
+}

--- a/modules/pages/tests/client/pages.client.routes.tests.js
+++ b/modules/pages/tests/client/pages.client.routes.tests.js
@@ -1,271 +1,269 @@
 import '@/modules/pages/client/pages.client.module';
 import AppConfig from '@/modules/core/client/app/config';
 
-(function () {
-  describe('Pages Route Tests', function () {
+describe('Pages Route Tests', function () {
 
-    // We can start by loading the main application module
-    beforeEach(angular.mock.module(AppConfig.appModuleName));
+  // We can start by loading the main application module
+  beforeEach(angular.mock.module(AppConfig.appModuleName));
 
-    // Disable $urlRouterProvider transitions
-    // You should comment this out if you want to test route transitions (e.g. "adding trailing slash"-test)
-    // See http://stackoverflow.com/a/26613169/1984644 for more
-    beforeEach(angular.mock.module(function ($urlRouterProvider) {
-      $urlRouterProvider.deferIntercept();
-    }));
+  // Disable $urlRouterProvider transitions
+  // You should comment this out if you want to test route transitions (e.g. "adding trailing slash"-test)
+  // See http://stackoverflow.com/a/26613169/1984644 for more
+  beforeEach(angular.mock.module(function ($urlRouterProvider) {
+    $urlRouterProvider.deferIntercept();
+  }));
 
-    describe('Route Config', function () {
-      describe('Rules Route', function () {
-        let mainstate;
-        beforeEach(inject(function ($state) {
-          mainstate = $state.get('rules');
-        }));
+  describe('Route Config', function () {
+    describe('Rules Route', function () {
+      let mainstate;
+      beforeEach(inject(function ($state) {
+        mainstate = $state.get('rules');
+      }));
 
-        it('Should have the correct URL', function () {
-          expect(mainstate.url).toEqual('/rules');
-        });
-
-        it('Should not be abstract', function () {
-          expect(mainstate.abstract).toBe(undefined);
-        });
-
-        it('Should have templateUrl', function () {
-          expect(mainstate.templateUrl).toBe('/modules/pages/views/rules.client.view.html');
-        });
+      it('Should have the correct URL', function () {
+        expect(mainstate.url).toEqual('/rules');
       });
 
-      describe('Team Route', function () {
-        let mainstate;
-        beforeEach(inject(function ($state) {
-          mainstate = $state.get('team');
-        }));
-
-        it('Should have the correct URL', function () {
-          expect(mainstate.url).toEqual('/team');
-        });
-
-        it('Should not be abstract', function () {
-          expect(mainstate.abstract).toBe(undefined);
-        });
-
-        it('Should have templateUrl', function () {
-          expect(mainstate.templateUrl).toBe('/modules/pages/views/team.client.view.html');
-        });
+      it('Should not be abstract', function () {
+        expect(mainstate.abstract).toBe(undefined);
       });
 
-      describe('Privacy Route', function () {
-        let mainstate;
-        beforeEach(inject(function ($state) {
-          mainstate = $state.get('privacy');
-        }));
-
-        it('Should have the correct URL', function () {
-          expect(mainstate.url).toEqual('/privacy');
-        });
-
-        it('Should not be abstract', function () {
-          expect(mainstate.abstract).toBe(undefined);
-        });
-
-        it('Should have templateUrl', function () {
-          expect(mainstate.templateUrl).toBe('/modules/pages/views/privacy.client.view.html');
-        });
+      it('Should have templateUrl', function () {
+        expect(mainstate.templateUrl).toBe('/modules/pages/views/rules.client.view.html');
       });
-
-      describe('Donate Route', function () {
-        let mainstate;
-        beforeEach(inject(function ($state) {
-          mainstate = $state.get('donate');
-        }));
-
-        it('Should have the correct URL', function () {
-          expect(mainstate.url).toEqual('/donate');
-        });
-
-        it('Should not be abstract', function () {
-          expect(mainstate.abstract).toBe(undefined);
-        });
-
-        it('Should have templateUrl', function () {
-          expect(mainstate.templateUrl).toBe('/modules/pages/views/donate.client.view.html');
-        });
-      });
-
-      describe('Donation help Route', function () {
-        let mainstate;
-        beforeEach(inject(function ($state) {
-          mainstate = $state.get('donate-help');
-        }));
-
-        it('Should have the correct URL', function () {
-          expect(mainstate.url).toEqual('/donate/help');
-        });
-
-        it('Should not be abstract', function () {
-          expect(mainstate.abstract).toBe(undefined);
-        });
-
-        it('Should have templateUrl', function () {
-          expect(mainstate.templateUrl).toBe('/modules/pages/views/donate-help.client.view.html');
-        });
-      });
-
-      describe('Donation policy Route', function () {
-        let mainstate;
-        beforeEach(inject(function ($state) {
-          mainstate = $state.get('donate-policy');
-        }));
-
-        it('Should have the correct URL', function () {
-          expect(mainstate.url).toEqual('/donate/policy');
-        });
-
-        it('Should not be abstract', function () {
-          expect(mainstate.abstract).toBe(undefined);
-        });
-
-        it('Should have templateUrl', function () {
-          expect(mainstate.templateUrl).toBe('/modules/pages/views/donate-policy.client.view.html');
-        });
-      });
-
-      describe('FAQ Route', function () {
-        let mainstate;
-        beforeEach(inject(function ($state) {
-          mainstate = $state.get('faq');
-        }));
-
-        it('Should have the correct URL', function () {
-          expect(mainstate.url).toEqual('/faq');
-        });
-
-        it('Should not be abstract', function () {
-          expect(mainstate.abstract).toBe(true);
-        });
-
-        it('Should have templateUrl', function () {
-          expect(mainstate.templateUrl).toBe('/modules/pages/views/faq.client.view.html');
-        });
-      });
-
-      describe('FAQ Sub Route', function () {
-        let mainstate;
-        beforeEach(inject(function ($state) {
-          mainstate = $state.get('faq.foundation');
-        }));
-
-        it('Should have the correct URL', function () {
-          expect(mainstate.url).toEqual('/foundation');
-        });
-
-        it('Should not be abstract', function () {
-          expect(mainstate.abstract).toBe(undefined);
-        });
-
-        it('Should have templateUrl', function () {
-          expect(mainstate.templateUrl).toBe('/modules/pages/views/faq-foundation.client.view.html');
-        });
-      });
-
-      describe('Foundation Route', function () {
-        let mainstate;
-        beforeEach(inject(function ($state) {
-          mainstate = $state.get('foundation');
-        }));
-
-        it('Should have the correct URL', function () {
-          expect(mainstate.url).toEqual('/foundation');
-        });
-
-        it('Should not be abstract', function () {
-          expect(mainstate.abstract).toBe(undefined);
-        });
-
-        it('Should have templateUrl', function () {
-          expect(mainstate.templateUrl).toBe('/modules/pages/views/foundation.client.view.html');
-        });
-      });
-
-      describe('Media Route', function () {
-        let mainstate;
-        beforeEach(inject(function ($state) {
-          mainstate = $state.get('media');
-        }));
-
-        it('Should have the correct URL', function () {
-          expect(mainstate.url).toEqual('/media');
-        });
-
-        it('Should not be abstract', function () {
-          expect(mainstate.abstract).toBe(undefined);
-        });
-
-        it('Should have templateUrl', function () {
-          expect(mainstate.templateUrl).toBe('/modules/pages/views/media.client.view.html');
-        });
-      });
-
-      describe('Volunteering Route', function () {
-        let mainstate;
-        beforeEach(inject(function ($state) {
-          mainstate = $state.get('volunteering');
-        }));
-
-        it('Should have the correct URL', function () {
-          expect(mainstate.url).toEqual('/volunteering');
-        });
-
-        it('Should not be abstract', function () {
-          expect(mainstate.abstract).toBe(undefined);
-        });
-
-        it('Should have template', function () {
-          expect(mainstate.template).toBeDefined();
-        });
-      });
-
-      describe('Guide Route', function () {
-        let mainstate;
-        beforeEach(inject(function ($state) {
-          mainstate = $state.get('guide');
-        }));
-
-        it('Should have the correct URL', function () {
-          expect(mainstate.url).toEqual('/guide');
-        });
-
-        it('Should not be abstract', function () {
-          expect(mainstate.abstract).toBe(undefined);
-        });
-
-        it('Should have templateUrl', function () {
-          expect(mainstate.templateUrl).toBe('/modules/pages/views/guide.client.view.html');
-        });
-      });
-
-      describe('Mobile Navigation Route', function () {
-        let mainstate;
-        beforeEach(inject(function ($state) {
-          mainstate = $state.get('navigation');
-        }));
-
-        it('Should have the correct URL', function () {
-          expect(mainstate.url).toEqual('/navigation');
-        });
-
-        it('Should not be abstract', function () {
-          expect(mainstate.abstract).toBe(undefined);
-        });
-
-        it('Should have templateUrl', function () {
-          expect(mainstate.templateUrl).toBe('/modules/pages/views/navigation.client.view.html');
-        });
-
-        it('Should require authentication', function () {
-          expect(mainstate.requiresAuth).toBe(true);
-        });
-      });
-
     });
+
+    describe('Team Route', function () {
+      let mainstate;
+      beforeEach(inject(function ($state) {
+        mainstate = $state.get('team');
+      }));
+
+      it('Should have the correct URL', function () {
+        expect(mainstate.url).toEqual('/team');
+      });
+
+      it('Should not be abstract', function () {
+        expect(mainstate.abstract).toBe(undefined);
+      });
+
+      it('Should have templateUrl', function () {
+        expect(mainstate.templateUrl).toBe('/modules/pages/views/team.client.view.html');
+      });
+    });
+
+    describe('Privacy Route', function () {
+      let mainstate;
+      beforeEach(inject(function ($state) {
+        mainstate = $state.get('privacy');
+      }));
+
+      it('Should have the correct URL', function () {
+        expect(mainstate.url).toEqual('/privacy');
+      });
+
+      it('Should not be abstract', function () {
+        expect(mainstate.abstract).toBe(undefined);
+      });
+
+      it('Should have templateUrl', function () {
+        expect(mainstate.templateUrl).toBe('/modules/pages/views/privacy.client.view.html');
+      });
+    });
+
+    describe('Donate Route', function () {
+      let mainstate;
+      beforeEach(inject(function ($state) {
+        mainstate = $state.get('donate');
+      }));
+
+      it('Should have the correct URL', function () {
+        expect(mainstate.url).toEqual('/donate');
+      });
+
+      it('Should not be abstract', function () {
+        expect(mainstate.abstract).toBe(undefined);
+      });
+
+      it('Should have templateUrl', function () {
+        expect(mainstate.templateUrl).toBe('/modules/pages/views/donate.client.view.html');
+      });
+    });
+
+    describe('Donation help Route', function () {
+      let mainstate;
+      beforeEach(inject(function ($state) {
+        mainstate = $state.get('donate-help');
+      }));
+
+      it('Should have the correct URL', function () {
+        expect(mainstate.url).toEqual('/donate/help');
+      });
+
+      it('Should not be abstract', function () {
+        expect(mainstate.abstract).toBe(undefined);
+      });
+
+      it('Should have templateUrl', function () {
+        expect(mainstate.templateUrl).toBe('/modules/pages/views/donate-help.client.view.html');
+      });
+    });
+
+    describe('Donation policy Route', function () {
+      let mainstate;
+      beforeEach(inject(function ($state) {
+        mainstate = $state.get('donate-policy');
+      }));
+
+      it('Should have the correct URL', function () {
+        expect(mainstate.url).toEqual('/donate/policy');
+      });
+
+      it('Should not be abstract', function () {
+        expect(mainstate.abstract).toBe(undefined);
+      });
+
+      it('Should have templateUrl', function () {
+        expect(mainstate.templateUrl).toBe('/modules/pages/views/donate-policy.client.view.html');
+      });
+    });
+
+    describe('FAQ Route', function () {
+      let mainstate;
+      beforeEach(inject(function ($state) {
+        mainstate = $state.get('faq');
+      }));
+
+      it('Should have the correct URL', function () {
+        expect(mainstate.url).toEqual('/faq');
+      });
+
+      it('Should not be abstract', function () {
+        expect(mainstate.abstract).toBe(true);
+      });
+
+      it('Should have templateUrl', function () {
+        expect(mainstate.templateUrl).toBe('/modules/pages/views/faq.client.view.html');
+      });
+    });
+
+    describe('FAQ Sub Route', function () {
+      let mainstate;
+      beforeEach(inject(function ($state) {
+        mainstate = $state.get('faq.foundation');
+      }));
+
+      it('Should have the correct URL', function () {
+        expect(mainstate.url).toEqual('/foundation');
+      });
+
+      it('Should not be abstract', function () {
+        expect(mainstate.abstract).toBe(undefined);
+      });
+
+      it('Should have templateUrl', function () {
+        expect(mainstate.templateUrl).toBe('/modules/pages/views/faq-foundation.client.view.html');
+      });
+    });
+
+    describe('Foundation Route', function () {
+      let mainstate;
+      beforeEach(inject(function ($state) {
+        mainstate = $state.get('foundation');
+      }));
+
+      it('Should have the correct URL', function () {
+        expect(mainstate.url).toEqual('/foundation');
+      });
+
+      it('Should not be abstract', function () {
+        expect(mainstate.abstract).toBe(undefined);
+      });
+
+      it('Should have templateUrl', function () {
+        expect(mainstate.templateUrl).toBe('/modules/pages/views/foundation.client.view.html');
+      });
+    });
+
+    describe('Media Route', function () {
+      let mainstate;
+      beforeEach(inject(function ($state) {
+        mainstate = $state.get('media');
+      }));
+
+      it('Should have the correct URL', function () {
+        expect(mainstate.url).toEqual('/media');
+      });
+
+      it('Should not be abstract', function () {
+        expect(mainstate.abstract).toBe(undefined);
+      });
+
+      it('Should have templateUrl', function () {
+        expect(mainstate.templateUrl).toBe('/modules/pages/views/media.client.view.html');
+      });
+    });
+
+    describe('Volunteering Route', function () {
+      let mainstate;
+      beforeEach(inject(function ($state) {
+        mainstate = $state.get('volunteering');
+      }));
+
+      it('Should have the correct URL', function () {
+        expect(mainstate.url).toEqual('/volunteering');
+      });
+
+      it('Should not be abstract', function () {
+        expect(mainstate.abstract).toBe(undefined);
+      });
+
+      it('Should have template', function () {
+        expect(mainstate.template).toBeDefined();
+      });
+    });
+
+    describe('Guide Route', function () {
+      let mainstate;
+      beforeEach(inject(function ($state) {
+        mainstate = $state.get('guide');
+      }));
+
+      it('Should have the correct URL', function () {
+        expect(mainstate.url).toEqual('/guide');
+      });
+
+      it('Should not be abstract', function () {
+        expect(mainstate.abstract).toBe(undefined);
+      });
+
+      it('Should have templateUrl', function () {
+        expect(mainstate.templateUrl).toBe('/modules/pages/views/guide.client.view.html');
+      });
+    });
+
+    describe('Mobile Navigation Route', function () {
+      let mainstate;
+      beforeEach(inject(function ($state) {
+        mainstate = $state.get('navigation');
+      }));
+
+      it('Should have the correct URL', function () {
+        expect(mainstate.url).toEqual('/navigation');
+      });
+
+      it('Should not be abstract', function () {
+        expect(mainstate.abstract).toBe(undefined);
+      });
+
+      it('Should have templateUrl', function () {
+        expect(mainstate.templateUrl).toBe('/modules/pages/views/navigation.client.view.html');
+      });
+
+      it('Should require authentication', function () {
+        expect(mainstate.requiresAuth).toBe(true);
+      });
+    });
+
   });
-}());
+});

--- a/modules/references-thread/client/directives/reference-thread.client.directive.js
+++ b/modules/references-thread/client/directives/reference-thread.client.directive.js
@@ -1,97 +1,95 @@
 import templateUrl from '@/modules/references-thread/client/views/directives/tr-reference-thread.client.view.html';
 
-(function () {
+/**
+ * References-thread directive widget for asking feedback about the message thread
+ *
+ * Usage:
+ *
+ * ```
+ * <div tr-reference-thread="userToId"></div>
+ * ```
+ *
+ * userToId: feedback receiver's id
+ */
+angular
+  .module('references-thread')
+  .directive('trReferenceThread', trReferenceThreadDirective);
+
+/* @ngInject */
+function trReferenceThreadDirective() {
+  const directive = {
+    restrict: 'A',
+    replace: true,
+    templateUrl,
+    scope: {
+      trReferenceThread: '=',
+    },
+    controller: trReferenceThreadDirectiveController,
+    controllerAs: 'vm',
+    bindToController: true, // because the scope is isolated
+  };
+
+  return directive;
+}
+
+// Note: Note that the directive's controller is outside the directive's closure.
+// This style eliminates issues where the injection gets created as unreachable code after a return.
+/* @ngInject */
+function trReferenceThreadDirectiveController($scope, $analytics, messageCenterService, ReferenceThreadService) {
+
+  // View Model
+  const vm = this;
+
+  // Exposed to the view
+  vm.userTo = vm.trReferenceThread;
+  vm.createReference = createReference;
+  vm.reference = false;
+  vm.isLoading = true;
+  vm.allowCreatingReference = false;
+
+  activate();
+
   /**
-   * References-thread directive widget for asking feedback about the message thread
-   *
-   * Usage:
-   *
-   * ```
-   * <div tr-reference-thread="userToId"></div>
-   * ```
-   *
-   * userToId: feedback receiver's id
+   * Look for previous answers from the API
    */
-  angular
-    .module('references-thread')
-    .directive('trReferenceThread', trReferenceThreadDirective);
-
-  /* @ngInject */
-  function trReferenceThreadDirective() {
-    const directive = {
-      restrict: 'A',
-      replace: true,
-      templateUrl,
-      scope: {
-        trReferenceThread: '=',
-      },
-      controller: trReferenceThreadDirectiveController,
-      controllerAs: 'vm',
-      bindToController: true, // because the scope is isolated
-    };
-
-    return directive;
+  function activate() {
+    ReferenceThreadService.get({
+      userToId: vm.userTo,
+    }, function (referenceThread) {
+      vm.isLoading = false;
+      if (referenceThread) {
+        vm.allowCreatingReference = true;
+        vm.reference = referenceThread;
+      }
+    }, function (referenceThreadErr) {
+      vm.isLoading = false;
+      // In case of 404, API will tell us if we are allowed to send references to this user
+      vm.allowCreatingReference = (referenceThreadErr.data && angular.isDefined(referenceThreadErr.data.allowCreatingReference)) ? Boolean(referenceThreadErr.data.allowCreatingReference) : false;
+    });
   }
 
-  // Note: Note that the directive's controller is outside the directive's closure.
-  // This style eliminates issues where the injection gets created as unreachable code after a return.
-  /* @ngInject */
-  function trReferenceThreadDirectiveController($scope, $analytics, messageCenterService, ReferenceThreadService) {
+  /**
+   * Send answer to the API
+   */
+  function createReference(reference) {
+    const newReference = new ReferenceThreadService({
+      userTo: vm.userTo,
+      reference: String(reference),
+    });
 
-    // View Model
-    const vm = this;
+    vm.reference = newReference;
 
-    // Exposed to the view
-    vm.userTo = vm.trReferenceThread;
-    vm.createReference = createReference;
-    vm.reference = false;
-    vm.isLoading = true;
-    vm.allowCreatingReference = false;
-
-    activate();
-
-    /**
-     * Look for previous answers from the API
-     */
-    function activate() {
-      ReferenceThreadService.get({
-        userToId: vm.userTo,
-      }, function (referenceThread) {
-        vm.isLoading = false;
-        if (referenceThread) {
-          vm.allowCreatingReference = true;
-          vm.reference = referenceThread;
-        }
-      }, function (referenceThreadErr) {
-        vm.isLoading = false;
-        // In case of 404, API will tell us if we are allowed to send references to this user
-        vm.allowCreatingReference = (referenceThreadErr.data && angular.isDefined(referenceThreadErr.data.allowCreatingReference)) ? Boolean(referenceThreadErr.data.allowCreatingReference) : false;
+    newReference.$save(function (response) {
+      vm.reference = response;
+      messageCenterService.add('success', 'Thank you!');
+      $analytics.eventTrack('reference-thread-give-' + String(reference), {
+        category: 'reference.thread',
+        label: 'Give ' + String(reference) + ' thread reference',
       });
-    }
-
-    /**
-     * Send answer to the API
-     */
-    function createReference(reference) {
-      const newReference = new ReferenceThreadService({
-        userTo: vm.userTo,
-        reference: String(reference),
-      });
-
-      vm.reference = newReference;
-
-      newReference.$save(function (response) {
-        vm.reference = response;
-        messageCenterService.add('success', 'Thank you!');
-        $analytics.eventTrack('reference-thread-give-' + String(reference), {
-          category: 'reference.thread',
-          label: 'Give ' + String(reference) + ' thread reference',
-        });
-      }, function () {
-        vm.reference = false;
-        messageCenterService.add('danger', 'Something went wrong. Please try again.');
-      });
-    }
-
+    }, function () {
+      vm.reference = false;
+      messageCenterService.add('danger', 'Something went wrong. Please try again.');
+    });
   }
-}());
+
+}

--- a/modules/references-thread/client/services/reference-thread.client.service.js
+++ b/modules/references-thread/client/services/reference-thread.client.service.js
@@ -1,18 +1,16 @@
-(function () {
-  // Reference thread service used for communicating with the REST endpoints
-  // Read reference by userToId
-  angular
-    .module('references-thread')
-    .factory('ReferenceThreadService', ReferenceThreadService);
+// Reference thread service used for communicating with the REST endpoints
+// Read reference by userToId
+angular
+  .module('references-thread')
+  .factory('ReferenceThreadService', ReferenceThreadService);
 
-  /* @ngInject */
-  function ReferenceThreadService($resource) {
-    return $resource('/api/references-thread/:userToId', {
-      userToId: '@_id',
-    }, {
-      get: {
-        method: 'GET',
-      },
-    });
-  }
-}());
+/* @ngInject */
+function ReferenceThreadService($resource) {
+  return $resource('/api/references-thread/:userToId', {
+    userToId: '@_id',
+  }, {
+    get: {
+      method: 'GET',
+    },
+  });
+}

--- a/modules/search/client/config/search.client.routes.js
+++ b/modules/search/client/config/search.client.routes.js
@@ -3,94 +3,92 @@ import searchMapTemplateUrl from '@/modules/search/client/views/search-map.clien
 import searchSidebarTemplateUrl from '@/modules/search/client/views/search-sidebar.client.view.html';
 import searchSigninTemplateUrl from '@/modules/search/client/views/search-signin.client.view.html';
 
-(function () {
-  angular
-    .module('search')
-    .config(SearchRoutes);
-  /* @ngInject */
-  function SearchRoutes($stateProvider) {
+angular
+  .module('search')
+  .config(SearchRoutes);
+/* @ngInject */
+function SearchRoutes($stateProvider) {
 
-    $stateProvider.
-      state('search', {
-        url: '/search?' + [
-          'location',
-          'offer',
-          'tribe',
-        ].join('?'),
-        templateUrl: searchTemplateUrl,
-        abstract: true,
-        requiresAuth: true,
-        footerHidden: true,
-        controller: 'SearchController',
-        controllerAs: 'search',
-        resolve: {
+  $stateProvider.
+    state('search', {
+      url: '/search?' + [
+        'location',
+        'offer',
+        'tribe',
+      ].join('?'),
+      templateUrl: searchTemplateUrl,
+      abstract: true,
+      requiresAuth: true,
+      footerHidden: true,
+      controller: 'SearchController',
+      controllerAs: 'search',
+      resolve: {
 
-          // A string value resolves to a service
-          OffersService: 'OffersService',
-          offer: function ($stateParams, OffersService) {
-            if ($stateParams.offer && $stateParams.offer.length === 24) {
-              return OffersService.get({
-                offerId: $stateParams.offer,
-              });
-            } else {
-              return false;
-            }
-          },
+        // A string value resolves to a service
+        OffersService: 'OffersService',
+        offer: function ($stateParams, OffersService) {
+          if ($stateParams.offer && $stateParams.offer.length === 24) {
+            return OffersService.get({
+              offerId: $stateParams.offer,
+            });
+          } else {
+            return false;
+          }
+        },
 
-          // A string value resolves to a service
-          TribeService: 'TribeService',
-          tribe: function (TribeService, $stateParams) {
-            if ($stateParams.tribe && $stateParams.tribe.length) {
-              return TribeService.get({
-                tribeSlug: $stateParams.tribe,
-              });
-            } else {
-              return false;
-            }
-          },
+        // A string value resolves to a service
+        TribeService: 'TribeService',
+        tribe: function (TribeService, $stateParams) {
+          if ($stateParams.tribe && $stateParams.tribe.length) {
+            return TribeService.get({
+              tribeSlug: $stateParams.tribe,
+            });
+          } else {
+            return false;
+          }
+        },
 
+      },
+      data: {
+        pageTitle: 'Search',
+      },
+    }).
+    state('search.map', {
+      url: '',
+      requiresAuth: true,
+      footerHidden: true,
+      data: {
+        pageTitle: 'Search',
+      },
+      views: {
+        'map': {
+          templateUrl: searchMapTemplateUrl,
+          controller: 'SearchMapController',
+          controllerAs: 'searchMap',
         },
-        data: {
-          pageTitle: 'Search',
+        'sidebar': {
+          templateUrl: searchSidebarTemplateUrl,
         },
-      }).
-      state('search.map', {
-        url: '',
-        requiresAuth: true,
-        footerHidden: true,
-        data: {
-          pageTitle: 'Search',
-        },
-        views: {
-          'map': {
-            templateUrl: searchMapTemplateUrl,
-            controller: 'SearchMapController',
-            controllerAs: 'searchMap',
-          },
-          'sidebar': {
-            templateUrl: searchSidebarTemplateUrl,
-          },
-        },
-      }).
-      state('search-signin', {
-        url: '/search?location?offer?tribe',
-        templateUrl: searchSigninTemplateUrl,
-        requiresAuth: false,
-        footerHidden: true,
-        controller: 'SearchSignupController',
-        controllerAs: 'searchSignup',
-        data: {
-          pageTitle: 'Search',
-        },
-      }).
-      state('search-users', {
-        url: '/search/members',
-        template: '<search-users />',
-        requiresAuth: true,
-        footerHidden: true,
-        data: {
-          pageTitle: 'Search members',
-        },
-      });
-  }
-}());
+      },
+    }).
+    state('search-signin', {
+      url: '/search?location?offer?tribe',
+      templateUrl: searchSigninTemplateUrl,
+      requiresAuth: false,
+      footerHidden: true,
+      controller: 'SearchSignupController',
+      controllerAs: 'searchSignup',
+      data: {
+        pageTitle: 'Search',
+      },
+    }).
+    state('search-users', {
+      url: '/search/members',
+      template: '<search-users />',
+      requiresAuth: true,
+      footerHidden: true,
+      data: {
+        pageTitle: 'Search members',
+      },
+    });
+}

--- a/modules/search/client/controllers/search-map.client.controller.js
+++ b/modules/search/client/controllers/search-map.client.controller.js
@@ -1,390 +1,388 @@
-(function () {
-  angular
-    .module('search')
-    .controller('SearchMapController', SearchMapController);
+angular
+  .module('search')
+  .controller('SearchMapController', SearchMapController);
 
-  /* @ngInject */
-  function SearchMapController($scope, $state, $stateParams, $timeout, $analytics, OffersService, Authentication, leafletData, messageCenterService, MapLayersFactory, MapMarkersFactory, SearchMapService, FiltersService) {
+/* @ngInject */
+function SearchMapController($scope, $state, $stateParams, $timeout, $analytics, OffersService, Authentication, leafletData, messageCenterService, MapLayersFactory, MapMarkersFactory, SearchMapService, FiltersService) {
 
-    // `search-map-canvas` is id of <leaflet> element
-    const mapId = 'search-map-canvas';
+  // `search-map-canvas` is id of <leaflet> element
+  const mapId = 'search-map-canvas';
 
-    // Prefix for Leaflet events
-    // @link https://github.com/angular-ui/ui-leaflet/commit/d22b3f0
-    const listenerPrefix = 'leafletDirectiveMap.' + mapId;
+  // Prefix for Leaflet events
+  // @link https://github.com/angular-ui/ui-leaflet/commit/d22b3f0
+  const listenerPrefix = 'leafletDirectiveMap.' + mapId;
 
-    // ViewModel
-    const vm = this;
+  // ViewModel
+  const vm = this;
 
-    // Exposed to the view
-    vm.pruneCluster = new PruneClusterForLeaflet(60, 60);
-    vm.mapLayerstyle = 'street';
-    vm.notFound = false;
-    vm.mapCenter = false;
-    vm.currentSelection = MapMarkersFactory.getOfferCircle({
-      layer: 'selectedOffers',
+  // Exposed to the view
+  vm.pruneCluster = new PruneClusterForLeaflet(60, 60);
+  vm.mapLayerstyle = 'street';
+  vm.notFound = false;
+  vm.mapCenter = false;
+  vm.currentSelection = MapMarkersFactory.getOfferCircle({
+    layer: 'selectedOffers',
+  });
+
+  vm.mapMinimumZoom = 4;
+  vm.mapBounds = {};
+  vm.mapLayers = {
+    baselayers: MapLayersFactory.getLayers({ streets: true, satellite: true, outdoors: true }),
+    overlays: {
+      selectedOffers: {
+        name: 'Selected hosts',
+        type: 'group',
+        visible: false,
+      },
+    },
+  };
+  vm.mapDefaults = {
+    attributionControl: false, // Adding this manually below
+    zoomControl: false, // Adding this manually below
+    keyboard: true,
+    worldCopyJump: true,
+    controls: {
+      layers: {
+        visible: true,
+        position: 'bottomleft',
+        collapsed: true,
+      },
+    },
+  };
+  vm.mapPaths = {
+    selected: vm.currentSelection,
+  };
+  /**
+   * Catch map events:
+   * click, dblclick, mousedown, mouseup, mouseover, mouseout, mousemove, contextmenu, focus, blur,
+   * preclick, load, unload, viewreset, movestart, move, moveend, dragstart, drag, dragend, zoomstart,
+   * zoomend, zoomlevelschange, resize, autopanstart, layeradd, layerremove, baselayerchange, overlayadd,
+   * overlayremove, locationfound, locationerror, popupopen, popupclose
+   */
+  vm.mapEvents = {
+    map: {
+      enable: ['click', 'moveend', 'load', 'baselayerchange'],
+      logic: 'emit',
+    },
+  };
+  vm.mapLastBounds = {
+    northEastLng: 0,
+    northEastLat: 0,
+    southWestLng: 0,
+    southWestLat: 0,
+  };
+
+  // Init
+  activate();
+
+  /**
+   * Initialize controller
+   */
+  function activate() {
+
+    // Set map's initial location
+    SearchMapService.getMapCenter().then(function (mapCenter) {
+      vm.mapCenter = mapCenter;
     });
 
-    vm.mapMinimumZoom = 4;
-    vm.mapBounds = {};
-    vm.mapLayers = {
-      baselayers: MapLayersFactory.getLayers({ streets: true, satellite: true, outdoors: true }),
-      overlays: {
-        selectedOffers: {
-          name: 'Selected hosts',
-          type: 'group',
-          visible: false,
-        },
-      },
-    };
-    vm.mapDefaults = {
-      attributionControl: false, // Adding this manually below
-      zoomControl: false, // Adding this manually below
-      keyboard: true,
-      worldCopyJump: true,
-      controls: {
-        layers: {
-          visible: true,
-          position: 'bottomleft',
-          collapsed: true,
-        },
-      },
-    };
-    vm.mapPaths = {
-      selected: vm.currentSelection,
-    };
-    /**
-     * Catch map events:
-     * click, dblclick, mousedown, mouseup, mouseover, mouseout, mousemove, contextmenu, focus, blur,
-     * preclick, load, unload, viewreset, movestart, move, moveend, dragstart, drag, dragend, zoomstart,
-     * zoomend, zoomlevelschange, resize, autopanstart, layeradd, layerremove, baselayerchange, overlayadd,
-     * overlayremove, locationfound, locationerror, popupopen, popupclose
-     */
-    vm.mapEvents = {
-      map: {
-        enable: ['click', 'moveend', 'load', 'baselayerchange'],
-        logic: 'emit',
-      },
-    };
-    vm.mapLastBounds = {
-      northEastLng: 0,
-      northEastLat: 0,
-      southWestLng: 0,
-      southWestLat: 0,
-    };
+    // Wait for Leaflet object
+    leafletData.getMap(mapId).then(function (map) {
 
-    // Init
-    activate();
+      // Add map scale
+      map.addControl(L.control.scale({
+        position: 'bottomright',
+      }));
 
-    /**
-     * Initialize controller
-     */
-    function activate() {
+      // Add map zoom control (+/- buttons)
+      map.addControl(L.control.zoom({
+        position: 'bottomright',
+      }));
 
-      // Set map's initial location
-      SearchMapService.getMapCenter().then(function (mapCenter) {
-        vm.mapCenter = mapCenter;
-      });
+      // Add map attribution
+      map.addControl(L.control.attribution({
+        position: 'bottomright',
+        prefix: '',
+      }));
 
-      // Wait for Leaflet object
-      leafletData.getMap(mapId).then(function (map) {
+      // Set active area to accommodate sidebar
+      // @link https://github.com/Mappy/Leaflet-active-area
+      map.setActiveArea('search-map-active-area');
+    });
 
-        // Add map scale
-        map.addControl(L.control.scale({
-          position: 'bottomright',
-        }));
+    // Set Leaflet listeners
+    $scope.$on(listenerPrefix + '.baselayerchange', onBaseLayerChange);
+    $scope.$on(listenerPrefix + '.load', onLeafletLoad);
+    $scope.$on(listenerPrefix + '.moveend', onLeafletMoveEnd);
+    $scope.$on(listenerPrefix + '.click', closeOffer);
 
-        // Add map zoom control (+/- buttons)
-        map.addControl(L.control.zoom({
-          position: 'bottomright',
-        }));
-
-        // Add map attribution
-        map.addControl(L.control.attribution({
-          position: 'bottomright',
-          prefix: '',
-        }));
-
-        // Set active area to accommodate sidebar
-        // @link https://github.com/Mappy/Leaflet-active-area
-        map.setActiveArea('search-map-active-area');
-      });
-
-      // Set Leaflet listeners
-      $scope.$on(listenerPrefix + '.baselayerchange', onBaseLayerChange);
-      $scope.$on(listenerPrefix + '.load', onLeafletLoad);
-      $scope.$on(listenerPrefix + '.moveend', onLeafletMoveEnd);
-      $scope.$on(listenerPrefix + '.click', closeOffer);
-
-      // If offer gets closed elsewhere
-      $scope.$on('search.closeOffer', function () {
-        vm.mapLayers.overlays.selectedOffers.visible = false;
-
-        // Set history state + URL without reloading the view
-        setOfferUrl('');
-      });
-
-      // Listen to new map location values from other controllers
-      $scope.$on('search.mapCenter', function (event, mapCenter) {
-        vm.mapCenter = mapCenter;
-      });
-      $scope.$on('search.mapBounds', function (event, mapBounds) {
-        vm.mapBounds = mapBounds;
-      });
-
-      // Listen to other controllers
-      $scope.$on('search.resetMarkers', resetMarkers);
-
-      // Setting up the marker and click event
-      vm.pruneCluster.PrepareLeafletMarker = function (leafletMarker, data) {
-
-        // Set offer icon if not set yet
-        if (!leafletMarker.options.iconSet) {
-          leafletMarker.setIcon(data.icon);
-          leafletMarker.options.iconSet = true;
-        }
-
-        // Handle click events
-        if (!leafletMarker.listens('click')) {
-          leafletMarker.on('click', function ($event) {
-
-            $scope.$emit('search.loadingOffer');
-
-            // Load offer details
-            OffersService
-              .get({ offerId: data.offerId })
-              .$promise
-              .then(function (offer) {
-                previewOffer(offer, false, $event);
-              })
-              .catch(function () {
-                closeOffer();
-                messageCenterService.add('danger', 'Something went wrong. Make sure you are connected to internet and try again. ');
-              });
-          });
-        }
-      };
-
-      // Initializing either location search or offer
-      // Center map to the offer, if there is one
-      if ($stateParams.offer && $scope.$parent.search.offer) {
-        $scope.$parent.search.offer
-          .$promise
-          .then(function (offer) {
-            previewOffer(offer, true);
-          });
-      }
-
-    }
-
-    /**
-     * Open hosting offer
-     */
-    function previewOffer(offer, reCenterMap, $event) {
-      if (offer.location) {
-        // Let parent controller handle setting this to scope
-        $scope.$emit('search.previewOffer', offer);
-
-        // Set history state + URL without reloading the view
-        setOfferUrl(offer._id);
-
-        // Position circle
-        // If (click) event was passed to us, use coordinates from that.
-        // This is because on map the dot is always at `fuzzyLocation`, but for
-        // `offer` we have real location when user is owner of that `offer`.
-        // Otherwise circle would be off for user's own markers.
-        vm.currentSelection.latlngs = $event && $event.latlng ? $event.latlng : offer.location;
-
-        // Make circle visible
-        vm.mapLayers.overlays.selectedOffers.visible = true;
-
-        // Re-position map
-        if (reCenterMap) {
-          vm.mapCenter = {
-            // See above explanation for using `$event` coordinates
-            lat: $event && $event.latlng ? $event.latlng.lat : offer.location[0],
-            lng: $event && $event.latlng ? $event.latlng.lng : offer.location[1],
-            zoom: 13,
-          };
-        }
-        $analytics.eventTrack('offer.preview', {
-          category: 'search.map',
-          label: 'Preview offer',
-        });
-      }
-    }
-
-
-    /**
-     * Close hosting offer
-     */
-    function closeOffer() {
+    // If offer gets closed elsewhere
+    $scope.$on('search.closeOffer', function () {
       vm.mapLayers.overlays.selectedOffers.visible = false;
-      $scope.$emit('search.closeOffer');
-    }
 
-    /**
-     * Set URL history state without reloading the page
-     */
-    function setOfferUrl(offerId) {
-      $state.go(
-        'search.map',
-        { offer: offerId || '' },
-        {
-          location: true, // will update the url in the location bar,
-          inherit: true, // will inherit url parameters from current url.
-          notify: false, // will not broadcast $stateChangeStart and $stateChangeSuccess events.
-          reload: false, // will not force transition even if no state or params have changed
-        },
-      );
-    }
+      // Set history state + URL without reloading the view
+      setOfferUrl('');
+    });
 
-    /**
-     * Force refresh markers on map
-     */
-    function resetMarkers() {
-      getMarkers(true);
-    }
+    // Listen to new map location values from other controllers
+    $scope.$on('search.mapCenter', function (event, mapCenter) {
+      vm.mapCenter = mapCenter;
+    });
+    $scope.$on('search.mapBounds', function (event, mapBounds) {
+      vm.mapBounds = mapBounds;
+    });
 
-    /**
-     * Load markers to the current bounding box
-     */
-    function getMarkers(forcedRefresh) {
+    // Listen to other controllers
+    $scope.$on('search.resetMarkers', resetMarkers);
 
-      // Don't proceed if:
-      // - Map does not have bounds set (typically at map init these might be missing for some milliseconds)
-      // - If user isn't public(confirmed) yet - no need to hit API just to get 401
-      if (!vm.mapBounds.northEast || !Authentication.user.public) return;
+    // Setting up the marker and click event
+    vm.pruneCluster.PrepareLeafletMarker = function (leafletMarker, data) {
 
-      // Don't do anything on too big zoom levels
-      if (vm.mapCenter.zoom <= vm.mapMinimumZoom) {
-        return;
+      // Set offer icon if not set yet
+      if (!leafletMarker.options.iconSet) {
+        leafletMarker.setIcon(data.icon);
+        leafletMarker.options.iconSet = true;
       }
 
-      // If we get out of the boundig box of the last api query we have to call the API for the new markers
-      // Note also `forcedRefresh`, in which case previous bounding box is ignored
-      if (forcedRefresh ||
-          vm.mapBounds.northEast.lng > vm.mapLastBounds.northEastLng ||
-          vm.mapBounds.northEast.lat > vm.mapLastBounds.northEastLat ||
-          vm.mapBounds.southWest.lng < vm.mapLastBounds.southWestLng ||
-          vm.mapBounds.southWest.lat < vm.mapLastBounds.southWestLat) {
+      // Handle click events
+      if (!leafletMarker.listens('click')) {
+        leafletMarker.on('click', function ($event) {
 
-        // We add a margin to the boundings depending on the zoom level
-        const boundingDelta = 10 / vm.mapCenter.zoom;
+          $scope.$emit('search.loadingOffer');
 
-        // Saving the current bounding box amd zoom
-        vm.mapLastBounds = {
-          northEastLng: vm.mapBounds.northEast.lng + boundingDelta,
-          northEastLat: vm.mapBounds.northEast.lat + boundingDelta,
-          southWestLng: vm.mapBounds.southWest.lng - boundingDelta,
-          southWestLat: vm.mapBounds.southWest.lat - boundingDelta,
-        };
-
-        vm.lastZoom = vm.mapCenter.zoom;
-
-        // API Call
-        // @TODO: cancel any pending queries:
-        // @link https://code.angularjs.org/1.5.11/docs/api/ngResource/service/$resource#cancelling-requests
-        OffersService.query({
-          northEastLng: vm.mapLastBounds.northEastLng,
-          northEastLat: vm.mapLastBounds.northEastLat,
-          southWestLng: vm.mapLastBounds.southWestLng,
-          southWestLat: vm.mapLastBounds.southWestLat,
-          filters: FiltersService.get(),
-        }, function (offers) {
-
-          // Remove last markers
-          // eslint-disable-next-line new-cap
-          vm.pruneCluster.RemoveMarkers();
-
-          // Let's go through those markers
-          // This loop might look weird but it's actually speed optimized :P
-          for (let i = -1, len = offers.length; ++i < len;) {
-            const marker = new PruneCluster.Marker(
-              offers[i].location[0],
-              offers[i].location[1],
-            );
-
-            marker.data.icon = MapMarkersFactory.getIcon(offers[i]);
-            marker.data.offerId = offers[i]._id;
-
-            // Register markers
-            // eslint-disable-next-line new-cap
-            vm.pruneCluster.RegisterMarker(marker);
-          }
-
-          // Update markers
-          // eslint-disable-next-line new-cap
-          vm.pruneCluster.ProcessView();
-        }, function () {
-          messageCenterService.add('danger', 'Sorry, something went wrong. Please try again.');
+          // Load offer details
+          OffersService
+            .get({ offerId: data.offerId })
+            .$promise
+            .then(function (offer) {
+              previewOffer(offer, false, $event);
+            })
+            .catch(function () {
+              closeOffer();
+              messageCenterService.add('danger', 'Something went wrong. Make sure you are connected to internet and try again. ');
+            });
         });
       }
-    }
+    };
 
-    /**
-     * When Leaflet map has loaded
-     */
-    function onLeafletLoad() {
-      leafletData.getMap(mapId).then(function (map) {
-        map.addLayer(vm.pruneCluster);
-      });
-
-      // If the zoom is big enough we wait for the map to be loaded with timeout and we get the markers
-      if (vm.mapCenter.zoom > vm.mapMinimumZoom) {
-        const loadMarkers = function () {
-          if (angular.isDefined(vm.mapBounds.northEast)) {
-            getMarkers();
-          } else {
-            // $timeout does $apply for us
-            $timeout(loadMarkers, 10);
-          }
-        };
-        // $timeout does $apply for us
-        $timeout(loadMarkers, 10);
-      }
-    }
-
-    /**
-     * When moving the map has ended. Fires also on zoom changes.
-     */
-    function onLeafletMoveEnd() {
-      if (vm.mapCenter.zoom > vm.mapMinimumZoom) {
-        getMarkers();
-      } else {
-        // Otherwise hide the markers...
-
-        /* eslint-disable new-cap */
-        vm.pruneCluster.RemoveMarkers();
-        vm.pruneCluster.ProcessView();
-        /* eslint-enable new-cap */
-
-        vm.mapLastBounds = {
-          northEastLng: 0,
-          northEastLat: 0,
-          southWestLng: 0,
-          southWestLat: 0,
-        };
-      }
-
-      SearchMapService.cacheMapCenter(vm.mapCenter);
-    }
-
-    /**
-     * When Leaflet base layer changes
-     */
-    function onBaseLayerChange(event, layer) {
-      $analytics.eventTrack('baselayerchange', {
-        category: 'search.map',
-        label: layer.leafletEvent.name,
-      });
-      // Determine currently selected baselayer style 'TRStyle' has to be
-      // set when defining layers. Possible values are: street, satellite
-      // Defaults to street
-      $timeout(function () {
-        vm.mapLayerstyle = (layer.leafletEvent.layer.options.TRStyle) ? layer.leafletEvent.layer.options.TRStyle : 'streets';
-      });
+    // Initializing either location search or offer
+    // Center map to the offer, if there is one
+    if ($stateParams.offer && $scope.$parent.search.offer) {
+      $scope.$parent.search.offer
+        .$promise
+        .then(function (offer) {
+          previewOffer(offer, true);
+        });
     }
 
   }
-}());
+
+  /**
+   * Open hosting offer
+   */
+  function previewOffer(offer, reCenterMap, $event) {
+    if (offer.location) {
+      // Let parent controller handle setting this to scope
+      $scope.$emit('search.previewOffer', offer);
+
+      // Set history state + URL without reloading the view
+      setOfferUrl(offer._id);
+
+      // Position circle
+      // If (click) event was passed to us, use coordinates from that.
+      // This is because on map the dot is always at `fuzzyLocation`, but for
+      // `offer` we have real location when user is owner of that `offer`.
+      // Otherwise circle would be off for user's own markers.
+      vm.currentSelection.latlngs = $event && $event.latlng ? $event.latlng : offer.location;
+
+      // Make circle visible
+      vm.mapLayers.overlays.selectedOffers.visible = true;
+
+      // Re-position map
+      if (reCenterMap) {
+        vm.mapCenter = {
+          // See above explanation for using `$event` coordinates
+          lat: $event && $event.latlng ? $event.latlng.lat : offer.location[0],
+          lng: $event && $event.latlng ? $event.latlng.lng : offer.location[1],
+          zoom: 13,
+        };
+      }
+      $analytics.eventTrack('offer.preview', {
+        category: 'search.map',
+        label: 'Preview offer',
+      });
+    }
+  }
+
+
+  /**
+   * Close hosting offer
+   */
+  function closeOffer() {
+    vm.mapLayers.overlays.selectedOffers.visible = false;
+    $scope.$emit('search.closeOffer');
+  }
+
+  /**
+   * Set URL history state without reloading the page
+   */
+  function setOfferUrl(offerId) {
+    $state.go(
+      'search.map',
+      { offer: offerId || '' },
+      {
+        location: true, // will update the url in the location bar,
+        inherit: true, // will inherit url parameters from current url.
+        notify: false, // will not broadcast $stateChangeStart and $stateChangeSuccess events.
+        reload: false, // will not force transition even if no state or params have changed
+      },
+    );
+  }
+
+  /**
+   * Force refresh markers on map
+   */
+  function resetMarkers() {
+    getMarkers(true);
+  }
+
+  /**
+   * Load markers to the current bounding box
+   */
+  function getMarkers(forcedRefresh) {
+
+    // Don't proceed if:
+    // - Map does not have bounds set (typically at map init these might be missing for some milliseconds)
+    // - If user isn't public(confirmed) yet - no need to hit API just to get 401
+    if (!vm.mapBounds.northEast || !Authentication.user.public) return;
+
+    // Don't do anything on too big zoom levels
+    if (vm.mapCenter.zoom <= vm.mapMinimumZoom) {
+      return;
+    }
+
+    // If we get out of the boundig box of the last api query we have to call the API for the new markers
+    // Note also `forcedRefresh`, in which case previous bounding box is ignored
+    if (forcedRefresh ||
+        vm.mapBounds.northEast.lng > vm.mapLastBounds.northEastLng ||
+        vm.mapBounds.northEast.lat > vm.mapLastBounds.northEastLat ||
+        vm.mapBounds.southWest.lng < vm.mapLastBounds.southWestLng ||
+        vm.mapBounds.southWest.lat < vm.mapLastBounds.southWestLat) {
+
+      // We add a margin to the boundings depending on the zoom level
+      const boundingDelta = 10 / vm.mapCenter.zoom;
+
+      // Saving the current bounding box amd zoom
+      vm.mapLastBounds = {
+        northEastLng: vm.mapBounds.northEast.lng + boundingDelta,
+        northEastLat: vm.mapBounds.northEast.lat + boundingDelta,
+        southWestLng: vm.mapBounds.southWest.lng - boundingDelta,
+        southWestLat: vm.mapBounds.southWest.lat - boundingDelta,
+      };
+
+      vm.lastZoom = vm.mapCenter.zoom;
+
+      // API Call
+      // @TODO: cancel any pending queries:
+      // @link https://code.angularjs.org/1.5.11/docs/api/ngResource/service/$resource#cancelling-requests
+      OffersService.query({
+        northEastLng: vm.mapLastBounds.northEastLng,
+        northEastLat: vm.mapLastBounds.northEastLat,
+        southWestLng: vm.mapLastBounds.southWestLng,
+        southWestLat: vm.mapLastBounds.southWestLat,
+        filters: FiltersService.get(),
+      }, function (offers) {
+
+        // Remove last markers
+        // eslint-disable-next-line new-cap
+        vm.pruneCluster.RemoveMarkers();
+
+        // Let's go through those markers
+        // This loop might look weird but it's actually speed optimized :P
+        for (let i = -1, len = offers.length; ++i < len;) {
+          const marker = new PruneCluster.Marker(
+            offers[i].location[0],
+            offers[i].location[1],
+          );
+
+          marker.data.icon = MapMarkersFactory.getIcon(offers[i]);
+          marker.data.offerId = offers[i]._id;
+
+          // Register markers
+          // eslint-disable-next-line new-cap
+          vm.pruneCluster.RegisterMarker(marker);
+        }
+
+        // Update markers
+        // eslint-disable-next-line new-cap
+        vm.pruneCluster.ProcessView();
+      }, function () {
+        messageCenterService.add('danger', 'Sorry, something went wrong. Please try again.');
+      });
+    }
+  }
+
+  /**
+   * When Leaflet map has loaded
+   */
+  function onLeafletLoad() {
+    leafletData.getMap(mapId).then(function (map) {
+      map.addLayer(vm.pruneCluster);
+    });
+
+    // If the zoom is big enough we wait for the map to be loaded with timeout and we get the markers
+    if (vm.mapCenter.zoom > vm.mapMinimumZoom) {
+      const loadMarkers = function () {
+        if (angular.isDefined(vm.mapBounds.northEast)) {
+          getMarkers();
+        } else {
+          // $timeout does $apply for us
+          $timeout(loadMarkers, 10);
+        }
+      };
+      // $timeout does $apply for us
+      $timeout(loadMarkers, 10);
+    }
+  }
+
+  /**
+   * When moving the map has ended. Fires also on zoom changes.
+   */
+  function onLeafletMoveEnd() {
+    if (vm.mapCenter.zoom > vm.mapMinimumZoom) {
+      getMarkers();
+    } else {
+      // Otherwise hide the markers...
+
+      /* eslint-disable new-cap */
+      vm.pruneCluster.RemoveMarkers();
+      vm.pruneCluster.ProcessView();
+      /* eslint-enable new-cap */
+
+      vm.mapLastBounds = {
+        northEastLng: 0,
+        northEastLat: 0,
+        southWestLng: 0,
+        southWestLat: 0,
+      };
+    }
+
+    SearchMapService.cacheMapCenter(vm.mapCenter);
+  }
+
+  /**
+   * When Leaflet base layer changes
+   */
+  function onBaseLayerChange(event, layer) {
+    $analytics.eventTrack('baselayerchange', {
+      category: 'search.map',
+      label: layer.leafletEvent.name,
+    });
+    // Determine currently selected baselayer style 'TRStyle' has to be
+    // set when defining layers. Possible values are: street, satellite
+    // Defaults to street
+    $timeout(function () {
+      vm.mapLayerstyle = (layer.leafletEvent.layer.options.TRStyle) ? layer.leafletEvent.layer.options.TRStyle : 'streets';
+    });
+  }
+
+}

--- a/modules/search/client/controllers/search-signup.client.controller.js
+++ b/modules/search/client/controllers/search-signup.client.controller.js
@@ -1,37 +1,35 @@
-(function () {
-  angular
-    .module('search')
-    .controller('SearchSignupController', SearchSignupController);
+angular
+  .module('search')
+  .controller('SearchSignupController', SearchSignupController);
 
-  /* @ngInject */
-  function SearchSignupController($stateParams, MapLayersFactory, LocationService) {
+/* @ngInject */
+function SearchSignupController($stateParams, MapLayersFactory, LocationService) {
 
-    // ViewModel
-    const vm = this;
+  // ViewModel
+  const vm = this;
 
-    // Variables passed to leaflet directive at init
-    vm.mapCenter = LocationService.getDefaultLocation(3);
-    vm.mapLayers = {
-      baselayers: MapLayersFactory.getLayers({ streets: false, satellite: true, outdoors: false }),
-    };
-    vm.mapDefaults = {
-      attributionControl: false,
-      keyboard: false,
-      worldCopyJump: true,
-      zoomControl: false,
-      controls: {
-        layers: {
-          visible: false,
-        },
+  // Variables passed to leaflet directive at init
+  vm.mapCenter = LocationService.getDefaultLocation(3);
+  vm.mapLayers = {
+    baselayers: MapLayersFactory.getLayers({ streets: false, satellite: true, outdoors: false }),
+  };
+  vm.mapDefaults = {
+    attributionControl: false,
+    keyboard: false,
+    worldCopyJump: true,
+    zoomControl: false,
+    controls: {
+      layers: {
+        visible: false,
       },
-    };
+    },
+  };
 
-    /**
-     * Pass search query to the view
-     */
-    if ($stateParams.location && $stateParams.location !== '') {
-      vm.searchQuery = $stateParams.location.replace('_', ' ', 'g');
-    }
-
+  /**
+   * Pass search query to the view
+   */
+  if ($stateParams.location && $stateParams.location !== '') {
+    vm.searchQuery = $stateParams.location.replace('_', ' ', 'g');
   }
-}());
+
+}

--- a/modules/search/client/controllers/search.client.controller.js
+++ b/modules/search/client/controllers/search.client.controller.js
@@ -1,218 +1,216 @@
-(function () {
-  angular
-    .module('search')
-    .controller('SearchController', SearchController);
+angular
+  .module('search')
+  .controller('SearchController', SearchController);
 
-  /* @ngInject */
-  function SearchController($scope, $window, $analytics, $stateParams, $timeout, offer, tribe, Authentication, FiltersService, messageCenterService, LocationService) {
-    // ViewModel
-    const vm = this;
+/* @ngInject */
+function SearchController($scope, $window, $analytics, $stateParams, $timeout, offer, tribe, Authentication, FiltersService, messageCenterService, LocationService) {
+  // ViewModel
+  const vm = this;
 
-    // Exposed to the view
-    // Sidebar visible: registered users on bigger screens
-    // Sidebar hidden: on small screens and un-registered users
-    vm.isSidebarOpen = ($stateParams.offer && offer) || (Authentication.user && Authentication.user.public && $window.innerWidth >= 768);
-    vm.screenWidth = $window.innerWidth;
-    vm.offer = offer || false;
-    vm.filters = FiltersService.get();
-    vm.toggleSidebar = toggleSidebar;
-    vm.closeSidebar = closeSidebar;
-    vm.openSidebar = openSidebar;
-    vm.onPlaceSearch = onPlaceSearch;
-    vm.openSearchPlaceInput = openSearchPlaceInput;
-    vm.onLanguageFiltersChange = onLanguageFiltersChange;
-    vm.onSeenFilterChange = onSeenFilterChange;
-    vm.onlineInPast6Months = vm.filters.seen && vm.filters.seen.months === 6;
-    vm.sidebarTab = 'filters';
+  // Exposed to the view
+  // Sidebar visible: registered users on bigger screens
+  // Sidebar hidden: on small screens and un-registered users
+  vm.isSidebarOpen = ($stateParams.offer && offer) || (Authentication.user && Authentication.user.public && $window.innerWidth >= 768);
+  vm.screenWidth = $window.innerWidth;
+  vm.offer = offer || false;
+  vm.filters = FiltersService.get();
+  vm.toggleSidebar = toggleSidebar;
+  vm.closeSidebar = closeSidebar;
+  vm.openSidebar = openSidebar;
+  vm.onPlaceSearch = onPlaceSearch;
+  vm.openSearchPlaceInput = openSearchPlaceInput;
+  vm.onLanguageFiltersChange = onLanguageFiltersChange;
+  vm.onSeenFilterChange = onSeenFilterChange;
+  vm.onlineInPast6Months = vm.filters.seen && vm.filters.seen.months === 6;
+  vm.sidebarTab = 'filters';
 
-    // Visibility toggle for search place input on small screens
-    vm.isPlaceSearchVisible = false;
+  // Visibility toggle for search place input on small screens
+  vm.isPlaceSearchVisible = false;
 
-    // Init search from the URL, `tr-location` directive attached
-    // to search input will take care of the rest.
-    // `Replacing underscore with space is to make search queries
-    // coming from Hitchwiki/Nomadwiki/Trashwiki work
-    // @link https://github.com/Hitchwiki/hitchwiki/issues/61
-    // @link https://github.com/Trustroots/trustroots/issues/113
-    vm.searchQuery = ($stateParams.location) ? $stateParams.location.replace('_', ' ', 'g').replace('+', ' ', 'g') : '';
+  // Init search from the URL, `tr-location` directive attached
+  // to search input will take care of the rest.
+  // `Replacing underscore with space is to make search queries
+  // coming from Hitchwiki/Nomadwiki/Trashwiki work
+  // @link https://github.com/Hitchwiki/hitchwiki/issues/61
+  // @link https://github.com/Trustroots/trustroots/issues/113
+  vm.searchQuery = ($stateParams.location) ? $stateParams.location.replace('_', ' ', 'g').replace('+', ' ', 'g') : '';
 
-    activate();
+  activate();
 
-    /**
-     * Initialize controller
-     */
-    function activate() {
-      // If tribe was requested from URL, set it active
-      if (tribe && tribe._id) {
-        vm.filters.tribes = [tribe._id];
-        FiltersService.set('tribes', [tribe._id]);
-      }
+  /**
+   * Initialize controller
+   */
+  function activate() {
+    // If tribe was requested from URL, set it active
+    if (tribe && tribe._id) {
+      vm.filters.tribes = [tribe._id];
+      FiltersService.set('tribes', [tribe._id]);
+    }
 
-      if (angular.isDefined(vm.searchQuery) && angular.isString(vm.searchQuery) && vm.searchQuery) {
-        LocationService.suggestions(vm.searchQuery).then(function (suggestions) {
-          if (suggestions.length) {
-            const bounds = LocationService.getBounds(suggestions[0]);
-            onPlaceSearch(bounds, 'bounds');
-            vm.searchQuery = suggestions[0].trTitle;
-          }
-        });
-      }
-
-      // Watch for changes at types filters
-      $scope.$watchCollection('search.filters.types', function (newTypesFilters, oldTypesFilters) {
-        if (!angular.equals(newTypesFilters, oldTypesFilters)) {
-          // Save new value to cache
-          FiltersService.set('types', newTypesFilters);
-          onFiltersUpdated();
+    if (angular.isDefined(vm.searchQuery) && angular.isString(vm.searchQuery) && vm.searchQuery) {
+      LocationService.suggestions(vm.searchQuery).then(function (suggestions) {
+        if (suggestions.length) {
+          const bounds = LocationService.getBounds(suggestions[0]);
+          onPlaceSearch(bounds, 'bounds');
+          vm.searchQuery = suggestions[0].trTitle;
         }
       });
-
-      // Watch for changes at tribes filters
-      $scope.$watchCollection('search.filters.tribes', function (newTribeFilters, oldTribeFilters) {
-        if (!angular.equals(newTribeFilters, oldTribeFilters)) {
-          // Save new value to cache
-          FiltersService.set('tribes', newTribeFilters);
-          onFiltersUpdated();
-        }
-      });
-
-      // `SearchMap` controller sends these signals down to this controller
-      $scope.$on('search.loadingOffer', function () {
-        vm.offer = false;
-        vm.loadingOffer = true;
-      });
-      $scope.$on('search.previewOffer', function (event, offer) {
-        vm.offer = offer;
-        vm.loadingOffer = false;
-        openSidebar('results');
-      });
-      $scope.$on('search.closeOffer', function () {
-        vm.offer = false;
-        vm.loadingOffer = false;
-      });
-
-      // Initializing either location search or offer
-      if ($stateParams.offer && !vm.offer) {
-        // Offer not found or other error
-        messageCenterService.add('danger', 'Sorry, we did not find what you are looking for.');
-        $analytics.eventTrack('offer-not-found', {
-          category: 'search.map',
-          label: 'Offer not found',
-        });
-      }
-
     }
 
-    /**
-     * Fired for changes at languages filters
-     */
-    function onLanguageFiltersChange() {
-      // `vm.filters.languages` is still out of sync at this point,
-      // but in next cycle after `$timeout` we have updated version.
-      $timeout(function () {
+    // Watch for changes at types filters
+    $scope.$watchCollection('search.filters.types', function (newTypesFilters, oldTypesFilters) {
+      if (!angular.equals(newTypesFilters, oldTypesFilters)) {
         // Save new value to cache
-        FiltersService.set('languages', vm.filters.languages || []);
-
+        FiltersService.set('types', newTypesFilters);
         onFiltersUpdated();
-      });
-    }
+      }
+    });
 
-    /**
-     * Fired for changes at seen filter
-     */
-    function onSeenFilterChange() {
-      vm.filters.seen.months = vm.onlineInPast6Months ? 6 : 24;
-
-      // `vm.filters.seen` is still out of sync at this point,
-      // but in next cycle after `$timeout` we have updated version.
-      $timeout(function () {
+    // Watch for changes at tribes filters
+    $scope.$watchCollection('search.filters.tribes', function (newTribeFilters, oldTribeFilters) {
+      if (!angular.equals(newTribeFilters, oldTribeFilters)) {
         // Save new value to cache
-        FiltersService.set('seen', vm.filters.seen);
-
+        FiltersService.set('tribes', newTribeFilters);
         onFiltersUpdated();
+      }
+    });
+
+    // `SearchMap` controller sends these signals down to this controller
+    $scope.$on('search.loadingOffer', function () {
+      vm.offer = false;
+      vm.loadingOffer = true;
+    });
+    $scope.$on('search.previewOffer', function (event, offer) {
+      vm.offer = offer;
+      vm.loadingOffer = false;
+      openSidebar('results');
+    });
+    $scope.$on('search.closeOffer', function () {
+      vm.offer = false;
+      vm.loadingOffer = false;
+    });
+
+    // Initializing either location search or offer
+    if ($stateParams.offer && !vm.offer) {
+      // Offer not found or other error
+      messageCenterService.add('danger', 'Sorry, we did not find what you are looking for.');
+      $analytics.eventTrack('offer-not-found', {
+        category: 'search.map',
+        label: 'Offer not found',
       });
     }
-
-    /**
-     * Closes offer when filters are changed and updates the map
-     */
-    function onFiltersUpdated() {
-      // Close possible open offers
-      if (vm.offer) {
-        vm.offer = false;
-        // Tells `SearchMapController` and `SearchSidebarController`
-        // to close anything offer related
-        $scope.$broadcast('search.closeOffer');
-      }
-      // Tells map controller to reset markers
-      $scope.$broadcast('search.resetMarkers');
-    }
-
-    /**
-     * Open search place input on small screens
-     */
-    function openSearchPlaceInput() {
-      vm.isPlaceSearchVisible = true;
-
-      closeSidebar();
-
-      $timeout(function () {
-        // Focus to search input
-        angular.element('#search-query').focus();
-      });
-    }
-
-    /**
-     * Broadcast information about changed search location
-     */
-    function onPlaceSearch(data, type) {
-      vm.isPlaceSearchVisible = false;
-
-      if (data && type === 'center') {
-        $scope.$broadcast('search.mapCenter', data);
-      } else if (data && type === 'bounds') {
-        $scope.$broadcast('search.mapBounds', data);
-      }
-    }
-
-    /**
-     * Toggles search results / filters sidebar
-     */
-    function toggleSidebar(activeTab) {
-      if (vm.isSidebarOpen) {
-        closeSidebar(activeTab);
-      } else {
-        openSidebar(activeTab);
-      }
-    }
-
-    /**
-     * Close search results / filters sidebar
-     */
-    function closeSidebar(activeTab) {
-      vm.isSidebarOpen = false;
-
-      // Close offer(s)
-      $scope.$broadcast('search.closeOffer');
-
-      // Activate specific tab
-      if (activeTab) {
-        vm.sidebarTab = activeTab;
-      }
-    }
-
-    /**
-     * Open search results / filters sidebar
-     */
-    function openSidebar(activeTab) {
-      vm.isSidebarOpen = true;
-
-      // Activate specific tab
-      if (activeTab) {
-        vm.sidebarTab = activeTab;
-      }
-    }
-
 
   }
-}());
+
+  /**
+   * Fired for changes at languages filters
+   */
+  function onLanguageFiltersChange() {
+    // `vm.filters.languages` is still out of sync at this point,
+    // but in next cycle after `$timeout` we have updated version.
+    $timeout(function () {
+      // Save new value to cache
+      FiltersService.set('languages', vm.filters.languages || []);
+
+      onFiltersUpdated();
+    });
+  }
+
+  /**
+   * Fired for changes at seen filter
+   */
+  function onSeenFilterChange() {
+    vm.filters.seen.months = vm.onlineInPast6Months ? 6 : 24;
+
+    // `vm.filters.seen` is still out of sync at this point,
+    // but in next cycle after `$timeout` we have updated version.
+    $timeout(function () {
+      // Save new value to cache
+      FiltersService.set('seen', vm.filters.seen);
+
+      onFiltersUpdated();
+    });
+  }
+
+  /**
+   * Closes offer when filters are changed and updates the map
+   */
+  function onFiltersUpdated() {
+    // Close possible open offers
+    if (vm.offer) {
+      vm.offer = false;
+      // Tells `SearchMapController` and `SearchSidebarController`
+      // to close anything offer related
+      $scope.$broadcast('search.closeOffer');
+    }
+    // Tells map controller to reset markers
+    $scope.$broadcast('search.resetMarkers');
+  }
+
+  /**
+   * Open search place input on small screens
+   */
+  function openSearchPlaceInput() {
+    vm.isPlaceSearchVisible = true;
+
+    closeSidebar();
+
+    $timeout(function () {
+      // Focus to search input
+      angular.element('#search-query').focus();
+    });
+  }
+
+  /**
+   * Broadcast information about changed search location
+   */
+  function onPlaceSearch(data, type) {
+    vm.isPlaceSearchVisible = false;
+
+    if (data && type === 'center') {
+      $scope.$broadcast('search.mapCenter', data);
+    } else if (data && type === 'bounds') {
+      $scope.$broadcast('search.mapBounds', data);
+    }
+  }
+
+  /**
+   * Toggles search results / filters sidebar
+   */
+  function toggleSidebar(activeTab) {
+    if (vm.isSidebarOpen) {
+      closeSidebar(activeTab);
+    } else {
+      openSidebar(activeTab);
+    }
+  }
+
+  /**
+   * Close search results / filters sidebar
+   */
+  function closeSidebar(activeTab) {
+    vm.isSidebarOpen = false;
+
+    // Close offer(s)
+    $scope.$broadcast('search.closeOffer');
+
+    // Activate specific tab
+    if (activeTab) {
+      vm.sidebarTab = activeTab;
+    }
+  }
+
+  /**
+   * Open search results / filters sidebar
+   */
+  function openSidebar(activeTab) {
+    vm.isSidebarOpen = true;
+
+    // Activate specific tab
+    if (activeTab) {
+      vm.sidebarTab = activeTab;
+    }
+  }
+
+
+}

--- a/modules/search/client/directives/tr-my-tribes-toggle.client.directive.js
+++ b/modules/search/client/directives/tr-my-tribes-toggle.client.directive.js
@@ -1,106 +1,104 @@
 import templateUrl from '@/modules/search/client/views/directives/tr-my-tribes-toggle.client.view.html';
 
-(function () {
-  /**
-   * Directive to
-   *
-   * Usage:
-   * `<div tr-my-tribes-toggle="tribeIds"></div>`
-   */
-  angular
-    .module('search')
-    .directive('trMyTribesToggle', trMyTribesToggleDirective);
+/**
+ * Directive to
+ *
+ * Usage:
+ * `<div tr-my-tribes-toggle="tribeIds"></div>`
+ */
+angular
+  .module('search')
+  .directive('trMyTribesToggle', trMyTribesToggleDirective);
+
+/* @ngInject */
+function trMyTribesToggleDirective(UserMembershipsService) {
+
+  const directive = {
+    restrict: 'A',
+    replace: true,
+    scope: {
+      tribeIds: '=trMyTribesToggle',
+    },
+    templateUrl,
+    controller: trMyTribesToggleController,
+    controllerAs: 'myTribesToggle',
+  };
+
+  return directive;
 
   /* @ngInject */
-  function trMyTribesToggleDirective(UserMembershipsService) {
+  function trMyTribesToggleController($scope) {
 
-    const directive = {
-      restrict: 'A',
-      replace: true,
-      scope: {
-        tribeIds: '=trMyTribesToggle',
-      },
-      templateUrl,
-      controller: trMyTribesToggleController,
-      controllerAs: 'myTribesToggle',
-    };
+    // Flag used to detect if toggle was touched
+    let toggled = false;
 
-    return directive;
+    // View Model
+    const vm = this;
 
-    /* @ngInject */
-    function trMyTribesToggleController($scope) {
+    vm.onChange = onChange;
+    vm.toggle = false;
+    vm.initialized = false;
+    vm.userTribes = [];
 
-      // Flag used to detect if toggle was touched
-      let toggled = false;
+    // Fill `vm.userTribes`
+    collectUserTribeIds();
 
-      // View Model
-      const vm = this;
-
-      vm.onChange = onChange;
-      vm.toggle = false;
-      vm.initialized = false;
-      vm.userTribes = [];
-
-      // Fill `vm.userTribes`
-      collectUserTribeIds();
-
-      /**
-       * Receives an array of tribes id's from outside the directive
-       * and switches this toggle off
-       */
-      $scope.$watchCollection('tribeIds', function () {
-        if (toggled) {
-          toggled = false;
-          return;
-        }
+    /**
+     * Receives an array of tribes id's from outside the directive
+     * and switches this toggle off
+     */
+    $scope.$watchCollection('tribeIds', function () {
+      if (toggled) {
         toggled = false;
-        vm.toggle = false;
-      });
+        return;
+      }
+      toggled = false;
+      vm.toggle = false;
+    });
 
-      /**
-       * Initialize memberships array
-       * Collects ids of tribes
-       * from user's `member` collection.
-       */
-      function collectUserTribeIds() {
-        UserMembershipsService.query()
-          .$promise
-          .then(function (userMemberships) {
+    /**
+     * Initialize memberships array
+     * Collects ids of tribes
+     * from user's `member` collection.
+     */
+    function collectUserTribeIds() {
+      UserMembershipsService.query()
+        .$promise
+        .then(function (userMemberships) {
 
-            if (!angular.isArray(userMemberships) || !userMemberships.length) {
-              return;
-            }
+          if (!angular.isArray(userMemberships) || !userMemberships.length) {
+            return;
+          }
 
-            // Fill `vm.userTribes` array with ids of tribes
-            const tribeIds = [];
-            angular.forEach(userMemberships, function (membership) {
-              tribeIds.push(membership.tribe._id);
-            });
-            vm.userTribes = tribeIds;
-          })
-          .finally(function () {
-            vm.initialized = true;
+          // Fill `vm.userTribes` array with ids of tribes
+          const tribeIds = [];
+          angular.forEach(userMemberships, function (membership) {
+            tribeIds.push(membership.tribe._id);
           });
-
-      }
-
-      /**
-       * Get an array of tribe objects from an array of user membersip objects
-       * Returns a promise
-       */
-      function onChange() {
-        toggled = true;
-
-        // Toggle was set `false`, no need to react
-        if (vm.toggle === false) {
-          return;
-        }
-
-        // If toggle was set `true`, wipe out old tribe ids
-        // and replace them with user's tribe ids
-        $scope.tribeIds = vm.userTribes;
-      }
+          vm.userTribes = tribeIds;
+        })
+        .finally(function () {
+          vm.initialized = true;
+        });
 
     }
+
+    /**
+     * Get an array of tribe objects from an array of user membersip objects
+     * Returns a promise
+     */
+    function onChange() {
+      toggled = true;
+
+      // Toggle was set `false`, no need to react
+      if (vm.toggle === false) {
+        return;
+      }
+
+      // If toggle was set `true`, wipe out old tribe ids
+      // and replace them with user's tribe ids
+      $scope.tribeIds = vm.userTribes;
+    }
+
   }
-}());
+}

--- a/modules/search/client/directives/tr-tribes-toggle.client.directive.js
+++ b/modules/search/client/directives/tr-tribes-toggle.client.directive.js
@@ -1,104 +1,102 @@
 import templateUrl from '@/modules/search/client/views/directives/tr-tribes-toggle.client.view.html';
 
-(function () {
-  /**
-   * Directive to show tribe selector filter
-   * Keeps a list of tribe ids up to date in scope variable
-   * Also if scope variable is updated from the controller,
-   * toggles in directive will be updated.
-   *
-   * Usage:
-   * `<div tr-tribes-toggle="tribeIds"></div>`
-   */
-  angular
-    .module('search')
-    .directive('trTribesToggle', trTribesToggleDirective);
+/**
+ * Directive to show tribe selector filter
+ * Keeps a list of tribe ids up to date in scope variable
+ * Also if scope variable is updated from the controller,
+ * toggles in directive will be updated.
+ *
+ * Usage:
+ * `<div tr-tribes-toggle="tribeIds"></div>`
+ */
+angular
+  .module('search')
+  .directive('trTribesToggle', trTribesToggleDirective);
+
+/* @ngInject */
+function trTribesToggleDirective(TribesService) {
+
+  let ignoreToggles = false;
+
+  const directive = {
+    restrict: 'A',
+    replace: true,
+    scope: {
+      tribeIds: '=trTribesToggle',
+    },
+    templateUrl,
+    controller: trTribesToggleDirectiveController,
+    controllerAs: 'trTribesToggle',
+  };
+
+  return directive;
 
   /* @ngInject */
-  function trTribesToggleDirective(TribesService) {
+  function trTribesToggleDirectiveController($scope) {
 
-    let ignoreToggles = false;
+    // View Model
+    const vm = this;
 
-    const directive = {
-      restrict: 'A',
-      replace: true,
-      scope: {
-        tribeIds: '=trTribesToggle',
-      },
-      templateUrl,
-      controller: trTribesToggleDirectiveController,
-      controllerAs: 'trTribesToggle',
-    };
+    // Get all the tribes
+    vm.tribes = TribesService.query();
 
-    return directive;
+    // States of toggle switches inside this directive
+    // `{ tribeId: true|false, ... }`
+    vm.toggles = {};
+    vm.onToggleChange = onToggleChange;
 
-    /* @ngInject */
-    function trTribesToggleDirectiveController($scope) {
+    // Init
+    activate();
 
-      // View Model
-      const vm = this;
+    /**
+     * Initialize directive controller
+     */
+    function activate() {
+      if ($scope.tribeIds && $scope.tribeIds.length) {
+        angular.forEach($scope.tribeIds, function (tribeId) {
+          vm.toggles[tribeId] = true;
+        });
+      }
+    }
 
-      // Get all the tribes
-      vm.tribes = TribesService.query();
+    /**
+     * State of a toggle switch has changed. Map toggles which are on
+     * into an array of tribe ids: `[id1, id2, ...]`
+     */
+    function onToggleChange() {
+      const TribeIds = [];
+      angular.forEach(vm.toggles, function (active, tribeId) {
+        if (active) TribeIds.push(tribeId);
+      });
+      // Tell tribeIds $watch that we changed `$scope.TribeIds`
+      // from inside the directive
+      ignoreToggles = true;
+      $scope.tribeIds = TribeIds;
+    }
 
-      // States of toggle switches inside this directive
-      // `{ tribeId: true|false, ... }`
-      vm.toggles = {};
-      vm.onToggleChange = onToggleChange;
+    /**
+     * Receives an array of tribes id's from outside the directive
+     * and toggles them active within this directive
+     */
+    $scope.$watchCollection('tribeIds', function tribeIdsWatch(newTribeIds, oldTribeIds) {
+      if (!angular.equals(newTribeIds, oldTribeIds)) {
+        // `$scope.tribeIds` was changed by onToggleChange function
+        // thus don't go trough toggle switches as they're already correct
+        if (ignoreToggles) {
+          ignoreToggles = false;
+          return;
+        }
 
-      // Init
-      activate();
-
-      /**
-       * Initialize directive controller
-       */
-      function activate() {
-        if ($scope.tribeIds && $scope.tribeIds.length) {
-          angular.forEach($scope.tribeIds, function (tribeId) {
+        // Clear all previous toggles
+        vm.toggles = {};
+        if (newTribeIds && newTribeIds.length) {
+          // Loop trough new values and set toggles on for requested tribes
+          angular.forEach(newTribeIds, function (tribeId) {
             vm.toggles[tribeId] = true;
           });
         }
       }
+    });
 
-      /**
-       * State of a toggle switch has changed. Map toggles which are on
-       * into an array of tribe ids: `[id1, id2, ...]`
-       */
-      function onToggleChange() {
-        const TribeIds = [];
-        angular.forEach(vm.toggles, function (active, tribeId) {
-          if (active) TribeIds.push(tribeId);
-        });
-        // Tell tribeIds $watch that we changed `$scope.TribeIds`
-        // from inside the directive
-        ignoreToggles = true;
-        $scope.tribeIds = TribeIds;
-      }
-
-      /**
-       * Receives an array of tribes id's from outside the directive
-       * and toggles them active within this directive
-       */
-      $scope.$watchCollection('tribeIds', function tribeIdsWatch(newTribeIds, oldTribeIds) {
-        if (!angular.equals(newTribeIds, oldTribeIds)) {
-          // `$scope.tribeIds` was changed by onToggleChange function
-          // thus don't go trough toggle switches as they're already correct
-          if (ignoreToggles) {
-            ignoreToggles = false;
-            return;
-          }
-
-          // Clear all previous toggles
-          vm.toggles = {};
-          if (newTribeIds && newTribeIds.length) {
-            // Loop trough new values and set toggles on for requested tribes
-            angular.forEach(newTribeIds, function (tribeId) {
-              vm.toggles[tribeId] = true;
-            });
-          }
-        }
-      });
-
-    }
   }
-}());
+}

--- a/modules/search/client/directives/tr-types-toggle.client.directive.js
+++ b/modules/search/client/directives/tr-types-toggle.client.directive.js
@@ -1,115 +1,113 @@
 import templateUrl from '@/modules/search/client/views/directives/tr-types-toggle.client.view.html';
 
-(function () {
-  /**
-   * Directive to show offer type selector filter
-   * Keeps a list of types up to date in scope variable
-   * Also if scope variable is updated from the controller,
-   * toggles in directive will be updated.
-   *
-   * Usage:
-   * `<div tr-types-toggle="types"></div>`
-   */
-  angular
-    .module('search')
-    .directive('trTypesToggle', trTypesToggleDirective);
+/**
+ * Directive to show offer type selector filter
+ * Keeps a list of types up to date in scope variable
+ * Also if scope variable is updated from the controller,
+ * toggles in directive will be updated.
+ *
+ * Usage:
+ * `<div tr-types-toggle="types"></div>`
+ */
+angular
+  .module('search')
+  .directive('trTypesToggle', trTypesToggleDirective);
+
+/* @ngInject */
+function trTypesToggleDirective() {
+
+  let ignoreToggles = false;
+
+  const directive = {
+    restrict: 'A',
+    replace: true,
+    scope: {
+      types: '=trTypesToggle',
+    },
+    templateUrl,
+    controller: trTypesToggleDirectiveController,
+    controllerAs: 'trTypesToggle',
+  };
+
+  return directive;
 
   /* @ngInject */
-  function trTypesToggleDirective() {
+  function trTypesToggleDirectiveController($scope) {
 
-    let ignoreToggles = false;
+    // View Model
+    const vm = this;
 
-    const directive = {
-      restrict: 'A',
-      replace: true,
-      scope: {
-        types: '=trTypesToggle',
+    // Offer types and their labels
+    vm.types = [
+      {
+        id: 'host',
+        label: 'Hosts',
       },
-      templateUrl,
-      controller: trTypesToggleDirectiveController,
-      controllerAs: 'trTypesToggle',
-    };
+      {
+        id: 'meet',
+        label: 'Meetups',
+      },
+    ];
 
-    return directive;
+    // States of toggle switches inside this directive
+    // `{ id: true|false, ... }`
+    vm.toggles = {};
+    vm.onToggleChange = onToggleChange;
 
-    /* @ngInject */
-    function trTypesToggleDirectiveController($scope) {
+    // Init
+    activate();
 
-      // View Model
-      const vm = this;
+    /**
+     * Initialize directive controller
+     */
+    function activate() {
+      if ($scope.types && $scope.types.length) {
+        angular.forEach($scope.types, function (type) {
+          vm.toggles[type] = true;
+        });
+      }
+    }
 
-      // Offer types and their labels
-      vm.types = [
-        {
-          id: 'host',
-          label: 'Hosts',
-        },
-        {
-          id: 'meet',
-          label: 'Meetups',
-        },
-      ];
+    /**
+     * State of a toggle switch has changed. Map toggles which are on
+     * into an array of tribe ids: `[id1, id2, ...]`
+     */
+    function onToggleChange() {
+      const types = [];
+      angular.forEach(vm.toggles, function (active, type) {
+        if (active) {
+          types.push(type);
+        }
+      });
+      // Tell tribeIds $watch that we changed `$scope.types`
+      // from inside the directive
+      ignoreToggles = true;
+      $scope.types = types;
+    }
 
-      // States of toggle switches inside this directive
-      // `{ id: true|false, ... }`
-      vm.toggles = {};
-      vm.onToggleChange = onToggleChange;
+    /**
+     * Receives an array of types id's from outside the directive
+     * and toggles them active within this directive
+     */
+    $scope.$watchCollection('types', function typesWatch(newTypes, oldTypes) {
+      if (!angular.equals(newTypes, oldTypes)) {
+        // `$scope.types` was changed by onToggleChange function
+        // thus don't go trough toggle switches as they're already correct
+        if (ignoreToggles) {
+          ignoreToggles = false;
+          return;
+        }
 
-      // Init
-      activate();
-
-      /**
-       * Initialize directive controller
-       */
-      function activate() {
-        if ($scope.types && $scope.types.length) {
-          angular.forEach($scope.types, function (type) {
-            vm.toggles[type] = true;
+        // Clear all previous toggles
+        vm.toggles = {};
+        if (newTypes && newTypes.length) {
+          // Loop trough new values and set toggles on for requested types
+          angular.forEach(newTypes, function (type) {
+            vm.toggles[type.id] = true;
           });
         }
       }
+    });
 
-      /**
-       * State of a toggle switch has changed. Map toggles which are on
-       * into an array of tribe ids: `[id1, id2, ...]`
-       */
-      function onToggleChange() {
-        const types = [];
-        angular.forEach(vm.toggles, function (active, type) {
-          if (active) {
-            types.push(type);
-          }
-        });
-        // Tell tribeIds $watch that we changed `$scope.types`
-        // from inside the directive
-        ignoreToggles = true;
-        $scope.types = types;
-      }
-
-      /**
-       * Receives an array of types id's from outside the directive
-       * and toggles them active within this directive
-       */
-      $scope.$watchCollection('types', function typesWatch(newTypes, oldTypes) {
-        if (!angular.equals(newTypes, oldTypes)) {
-          // `$scope.types` was changed by onToggleChange function
-          // thus don't go trough toggle switches as they're already correct
-          if (ignoreToggles) {
-            ignoreToggles = false;
-            return;
-          }
-
-          // Clear all previous toggles
-          vm.toggles = {};
-          if (newTypes && newTypes.length) {
-            // Loop trough new values and set toggles on for requested types
-            angular.forEach(newTypes, function (type) {
-              vm.toggles[type.id] = true;
-            });
-          }
-        }
-      });
-
-    }
   }
-}());
+}

--- a/modules/search/client/services/filters.client.service.js
+++ b/modules/search/client/services/filters.client.service.js
@@ -1,77 +1,75 @@
-(function () {
+/**
+ * Service for handing filters
+ */
+angular
+  .module('core')
+  .factory('FiltersService', FiltersService);
+
+/* @ngInject */
+function FiltersService($log, Authentication, locker) {
+
+  // Default structure for filters object
+  const defaultFilters = {
+    tribes: [],
+    types: [
+      'host',
+      'meet',
+    ],
+    languages: [],
+    seen: {
+      months: 24,
+    },
+  };
+
+  // Make cache id unique for this user
+  const cachePrefix = (Authentication.user) ? 'search.filters.' + Authentication.user._id : 'search.filters';
+
+  // Look up for filters from cache.
+  // Returns `defaultFilters` if nothing is found.
+  let filters = locker.supported() ? locker.get(cachePrefix, defaultFilters) : defaultFilters;
+
+  // If cached filters were found, their structure might've been incomplete
+  // `angular.extend` extends `filters` by copying own enumerable
+  // properties from `defaultFilters` to `filters`.
+  filters = angular.extend(defaultFilters, filters);
+
+  const service = {
+    set: set,
+    get: get,
+  };
+
+  return service;
+
   /**
-   * Service for handing filters
+   * Get filter(s)
+   *
+   * @param filter String Filter name to receive. If undefined, will return all filters.
    */
-  angular
-    .module('core')
-    .factory('FiltersService', FiltersService);
-
-  /* @ngInject */
-  function FiltersService($log, Authentication, locker) {
-
-    // Default structure for filters object
-    const defaultFilters = {
-      tribes: [],
-      types: [
-        'host',
-        'meet',
-      ],
-      languages: [],
-      seen: {
-        months: 24,
-      },
-    };
-
-    // Make cache id unique for this user
-    const cachePrefix = (Authentication.user) ? 'search.filters.' + Authentication.user._id : 'search.filters';
-
-    // Look up for filters from cache.
-    // Returns `defaultFilters` if nothing is found.
-    let filters = locker.supported() ? locker.get(cachePrefix, defaultFilters) : defaultFilters;
-
-    // If cached filters were found, their structure might've been incomplete
-    // `angular.extend` extends `filters` by copying own enumerable
-    // properties from `defaultFilters` to `filters`.
-    filters = angular.extend(defaultFilters, filters);
-
-    const service = {
-      set: set,
-      get: get,
-    };
-
-    return service;
-
-    /**
-     * Get filter(s)
-     *
-     * @param filter String Filter name to receive. If undefined, will return all filters.
-     */
-    function get(filter) {
-      // Single filter
-      if (filter && angular.isString(filter)) {
-        if (angular.isDefined(filters[filter])) {
-          return filters[filter];
-        } else {
-          $log.warn('Requested filter does not exist.');
-          return;
-        }
+  function get(filter) {
+    // Single filter
+    if (filter && angular.isString(filter)) {
+      if (angular.isDefined(filters[filter])) {
+        return filters[filter];
       } else {
-        // All filters
-        return filters;
+        $log.warn('Requested filter does not exist.');
+        return;
       }
+    } else {
+      // All filters
+      return filters;
     }
-
-    /**
-     * Set filter
-     */
-    function set(filter, content) {
-      filters[filter] = content;
-
-      // Cache whole filters object
-      if (locker.supported()) {
-        locker.put(cachePrefix, filters);
-      }
-    }
-
   }
-}());
+
+  /**
+   * Set filter
+   */
+  function set(filter, content) {
+    filters[filter] = content;
+
+    // Cache whole filters object
+    if (locker.supported()) {
+      locker.put(cachePrefix, filters);
+    }
+  }
+
+}

--- a/modules/search/client/services/search-map.client.service.js
+++ b/modules/search/client/services/search-map.client.service.js
@@ -1,91 +1,89 @@
-(function () {
+/**
+ * Service for handing filters
+ */
+angular
+  .module('core')
+  .factory('SearchMapService', SearchMapService);
+
+/* @ngInject */
+function SearchMapService($q, $log, Authentication, LocationService, locker) {
+
+  // Default location for all TR maps
+  // Returns `{lat: Float, lng: Float, zoom: 6}`
+  const defaultLocation = LocationService.getDefaultLocation(6);
+
+  // Make cache id unique for this user
+  const cachePrefix = Authentication.user ? 'search.mapCenter.' + Authentication.user._id : 'search.mapCenter';
+
+  const service = {
+    getMapCenter: getMapCenter,
+    cacheMapCenter: cacheMapCenter,
+  };
+
+  return service;
+
   /**
-   * Service for handing filters
+   * Return map location from cache or fallback to default location
    */
-  angular
-    .module('core')
-    .factory('SearchMapService', SearchMapService);
+  function getMapCenter() {
+    return $q(function (resolve) {
 
-  /* @ngInject */
-  function SearchMapService($q, $log, Authentication, LocationService, locker) {
+      // Is local/sessionStorage supported? This might fail in browser's incognito mode
+      if (locker.supported()) {
+        // Get location from cache, return `false` if it doesn't exist in locker
+        const cachedLocation = locker.get(cachePrefix, false);
 
-    // Default location for all TR maps
-    // Returns `{lat: Float, lng: Float, zoom: 6}`
-    const defaultLocation = LocationService.getDefaultLocation(6);
-
-    // Make cache id unique for this user
-    const cachePrefix = Authentication.user ? 'search.mapCenter.' + Authentication.user._id : 'search.mapCenter';
-
-    const service = {
-      getMapCenter: getMapCenter,
-      cacheMapCenter: cacheMapCenter,
-    };
-
-    return service;
-
-    /**
-     * Return map location from cache or fallback to default location
-     */
-    function getMapCenter() {
-      return $q(function (resolve) {
-
-        // Is local/sessionStorage supported? This might fail in browser's incognito mode
-        if (locker.supported()) {
-          // Get location from cache, return `false` if it doesn't exist in locker
-          const cachedLocation = locker.get(cachePrefix, false);
-
-          // Validate cached location or fall back to default
-          // If it's older than two days, we won't use it.
-          if (cachedLocation &&
-             cachedLocation.lat &&
-             cachedLocation.lng &&
-             cachedLocation.zoom &&
-             isFinite(cachedLocation.lat) &&
-             isFinite(cachedLocation.lng) &&
-             isFinite(cachedLocation.zoom) &&
-             cachedLocation.date &&
-             moment().diff(moment(cachedLocation.date), 'days') < 2) {
-            resolve(cachedLocation);
-          } else {
-            // No cached location found, it was invalid or it was outdated
-            resolve(defaultLocation);
-          }
-
-          // Make sure there's something in locker for the next time
-          // If the key already exists in locker, then no action will
-          // be taken and false will be returned
-          // Conditionally adding an item if it doesn't already exist
-          locker.add(cachePrefix, defaultLocation);
+        // Validate cached location or fall back to default
+        // If it's older than two days, we won't use it.
+        if (cachedLocation &&
+           cachedLocation.lat &&
+           cachedLocation.lng &&
+           cachedLocation.zoom &&
+           isFinite(cachedLocation.lat) &&
+           isFinite(cachedLocation.lng) &&
+           isFinite(cachedLocation.zoom) &&
+           cachedLocation.date &&
+           moment().diff(moment(cachedLocation.date), 'days') < 2) {
+          resolve(cachedLocation);
         } else {
-          // When local/sessionStorage is not supported, use default location:
+          // No cached location found, it was invalid or it was outdated
           resolve(defaultLocation);
         }
 
+        // Make sure there's something in locker for the next time
+        // If the key already exists in locker, then no action will
+        // be taken and false will be returned
+        // Conditionally adding an item if it doesn't already exist
+        locker.add(cachePrefix, defaultLocation);
+      } else {
+        // When local/sessionStorage is not supported, use default location:
+        resolve(defaultLocation);
+      }
+
+    });
+  }
+
+  /**
+   * Save map state to the cache
+   */
+  function cacheMapCenter(location) {
+    // Validate location
+    if (angular.isUndefined(location.lat) ||
+        angular.isUndefined(location.lng) ||
+        angular.isUndefined(location.zoom)) {
+      $log.warn('Cannot cache location: missing coordinates or zoom.');
+      return;
+    }
+
+    // Store in cache
+    if (locker.supported()) {
+      locker.put(cachePrefix, {
+        'lat': location.lat,
+        'lng': location.lng,
+        'zoom': location.zoom,
+        'date': new Date(),
       });
     }
-
-    /**
-     * Save map state to the cache
-     */
-    function cacheMapCenter(location) {
-      // Validate location
-      if (angular.isUndefined(location.lat) ||
-          angular.isUndefined(location.lng) ||
-          angular.isUndefined(location.zoom)) {
-        $log.warn('Cannot cache location: missing coordinates or zoom.');
-        return;
-      }
-
-      // Store in cache
-      if (locker.supported()) {
-        locker.put(cachePrefix, {
-          'lat': location.lat,
-          'lng': location.lng,
-          'zoom': location.zoom,
-          'date': new Date(),
-        });
-      }
-    }
-
   }
-}());
+
+}

--- a/modules/search/tests/client/search.client.routes.tests.js
+++ b/modules/search/tests/client/search.client.routes.tests.js
@@ -4,94 +4,92 @@ import '@/modules/tribes/client/tribes.client.module';
 
 import AppConfig from '@/modules/core/client/app/config';
 
-(function () {
-  describe('Search Route Tests', function () {
+describe('Search Route Tests', function () {
 
-    // We can start by loading the main application module
-    beforeEach(angular.mock.module(AppConfig.appModuleName));
+  // We can start by loading the main application module
+  beforeEach(angular.mock.module(AppConfig.appModuleName));
 
-    describe('Route Config', function () {
-      describe('Main Route', function () {
-        let mainstate;
-        beforeEach(inject(function ($state) {
-          mainstate = $state.get('search');
-        }));
+  describe('Route Config', function () {
+    describe('Main Route', function () {
+      let mainstate;
+      beforeEach(inject(function ($state) {
+        mainstate = $state.get('search');
+      }));
 
-        it('Should have the correct URL', function () {
-          expect(mainstate.url).toEqual('/search?location?offer?tribe');
-        });
-
-        it('Should be abstract', function () {
-          expect(mainstate.abstract).toBe(true);
-        });
-
-        it('Should have templateUrl', function () {
-          expect(mainstate.templateUrl).toBe('/modules/search/views/search.client.view.html');
-        });
+      it('Should have the correct URL', function () {
+        expect(mainstate.url).toEqual('/search?location?offer?tribe');
       });
 
-      describe('Map Route', function () {
-        let mainstate;
-        beforeEach(inject(function ($state) {
-          mainstate = $state.get('search.map');
-        }));
-
-        it('Should have the correct URL', function () {
-          expect(mainstate.url).toEqual('');
-        });
-
-        it('Should not be abstract', function () {
-          expect(mainstate.abstract).toBe(undefined);
-        });
-
-        it('Should have map and sidebar views', function () {
-          expect(mainstate.views.map).toBeDefined();
-          expect(mainstate.views.sidebar).toBeDefined();
-        });
-
-        it('Should have map templateUrl', function () {
-          expect(mainstate.views.map.templateUrl).toBe('/modules/search/views/search-map.client.view.html');
-        });
-
-        it('Should have sidebar templateUrl', function () {
-          expect(mainstate.views.sidebar.templateUrl).toBe('/modules/search/views/search-sidebar.client.view.html');
-        });
+      it('Should be abstract', function () {
+        expect(mainstate.abstract).toBe(true);
       });
 
-      describe('Search non-authenticated Route', function () {
-        let mainstate;
-        beforeEach(inject(function ($state) {
-          mainstate = $state.get('search-signin');
-        }));
-
-        it('Should have the correct URL', function () {
-          expect(mainstate.url).toEqual('/search?location?offer?tribe');
-        });
-
-        it('Should not be abstract', function () {
-          expect(mainstate.abstract).toBe(undefined);
-        });
-
-        it('Should have templateUrl', function () {
-          expect(mainstate.templateUrl).toBe('/modules/search/views/search-signin.client.view.html');
-        });
+      it('Should have templateUrl', function () {
+        expect(mainstate.templateUrl).toBe('/modules/search/views/search.client.view.html');
       });
-
-      describe('Handle Trailing Slash', function () {
-        beforeEach(inject(function ($state, $rootScope, $location) {
-          $state.go('search.map');
-          $rootScope.$digest();
-          expect($location.path()).toBe('/search');
-        }));
-
-        it('Should remove trailing slash', inject(function ($state, $location, $rootScope) {
-          $location.path('search/');
-          $rootScope.$digest();
-
-          expect($location.path()).toBe('/search');
-        }));
-      });
-
     });
+
+    describe('Map Route', function () {
+      let mainstate;
+      beforeEach(inject(function ($state) {
+        mainstate = $state.get('search.map');
+      }));
+
+      it('Should have the correct URL', function () {
+        expect(mainstate.url).toEqual('');
+      });
+
+      it('Should not be abstract', function () {
+        expect(mainstate.abstract).toBe(undefined);
+      });
+
+      it('Should have map and sidebar views', function () {
+        expect(mainstate.views.map).toBeDefined();
+        expect(mainstate.views.sidebar).toBeDefined();
+      });
+
+      it('Should have map templateUrl', function () {
+        expect(mainstate.views.map.templateUrl).toBe('/modules/search/views/search-map.client.view.html');
+      });
+
+      it('Should have sidebar templateUrl', function () {
+        expect(mainstate.views.sidebar.templateUrl).toBe('/modules/search/views/search-sidebar.client.view.html');
+      });
+    });
+
+    describe('Search non-authenticated Route', function () {
+      let mainstate;
+      beforeEach(inject(function ($state) {
+        mainstate = $state.get('search-signin');
+      }));
+
+      it('Should have the correct URL', function () {
+        expect(mainstate.url).toEqual('/search?location?offer?tribe');
+      });
+
+      it('Should not be abstract', function () {
+        expect(mainstate.abstract).toBe(undefined);
+      });
+
+      it('Should have templateUrl', function () {
+        expect(mainstate.templateUrl).toBe('/modules/search/views/search-signin.client.view.html');
+      });
+    });
+
+    describe('Handle Trailing Slash', function () {
+      beforeEach(inject(function ($state, $rootScope, $location) {
+        $state.go('search.map');
+        $rootScope.$digest();
+        expect($location.path()).toBe('/search');
+      }));
+
+      it('Should remove trailing slash', inject(function ($state, $location, $rootScope) {
+        $location.path('search/');
+        $rootScope.$digest();
+
+        expect($location.path()).toBe('/search');
+      }));
+    });
+
   });
-}());
+});

--- a/modules/statistics/client/config/statistics.client.routes.js
+++ b/modules/statistics/client/config/statistics.client.routes.js
@@ -1,31 +1,29 @@
 import templateUrl from '@/modules/statistics/client/views/statistics.client.view.html';
 
-(function () {
-  angular
-    .module('statistics')
-    .config(StatisticsRoutes);
+angular
+  .module('statistics')
+  .config(StatisticsRoutes);
 
-  /* @ngInject */
-  function StatisticsRoutes($stateProvider) {
+/* @ngInject */
+function StatisticsRoutes($stateProvider) {
 
-    $stateProvider.
-      state('statistics', {
-        url: '/statistics',
-        templateUrl,
-        controller: 'StatisticsController',
-        controllerAs: 'stats',
-        footerHidden: false,
-        resolve: {
-          // A string value resolves to a service
-          SettingsService: 'Statistics',
-          statisticsData: function (Statistics) {
-            return Statistics.get();
-          },
+  $stateProvider.
+    state('statistics', {
+      url: '/statistics',
+      templateUrl,
+      controller: 'StatisticsController',
+      controllerAs: 'stats',
+      footerHidden: false,
+      resolve: {
+        // A string value resolves to a service
+        SettingsService: 'Statistics',
+        statisticsData: function (Statistics) {
+          return Statistics.get();
         },
-        data: {
-          pageTitle: 'Statistics',
-        },
-      });
+      },
+      data: {
+        pageTitle: 'Statistics',
+      },
+    });
 
-  }
-}());
+}

--- a/modules/statistics/client/controllers/statistics.client.controller.js
+++ b/modules/statistics/client/controllers/statistics.client.controller.js
@@ -1,56 +1,54 @@
-(function () {
-  angular
-    .module('statistics')
-    .controller('StatisticsController', StatisticsController);
+angular
+  .module('statistics')
+  .controller('StatisticsController', StatisticsController);
 
-  /* @ngInject */
-  function StatisticsController($scope, $interval, Statistics, statisticsData) {
+/* @ngInject */
+function StatisticsController($scope, $interval, Statistics, statisticsData) {
 
-    // ViewModel
-    const vm = this;
+  // ViewModel
+  const vm = this;
 
-    vm.statisticsData = statisticsData;
-    vm.launchDate = new Date(2014, 11, 23); // Dec 23, 2014
+  vm.statisticsData = statisticsData;
+  vm.launchDate = new Date(2014, 11, 23); // Dec 23, 2014
 
-    // Process statistics data at init
-    statisticsData.$promise.then(function () {
+  // Process statistics data at init
+  statisticsData.$promise.then(function () {
+    processStats(statisticsData);
+  });
+
+  // Update page every now and then while it's open
+  const statsInterval = $interval(function () {
+    Statistics.get({}, function (statisticsData) {
       processStats(statisticsData);
     });
+  }, (10 * 60000)); // every 10 mins
 
-    // Update page every now and then while it's open
-    const statsInterval = $interval(function () {
-      Statistics.get({}, function (statisticsData) {
-        processStats(statisticsData);
+  // Clean interval when leaving the page
+  $scope.$on('$destroy', function () {
+    if (statsInterval) {
+      $interval.cancel(statsInterval);
+    }
+  });
+
+  function processStats(data) {
+
+    angular.extend(vm, data);
+
+    vm.hostingTotal = data.hosting.yes + data.hosting.maybe;
+    vm.hostingPercentage = (vm.hostingTotal / data.total) * 100;
+    vm.hostingYesPercentage = (data.hosting.yes / vm.hostingTotal) * 100;
+    vm.hostingMaybePercentage = (data.hosting.maybe / vm.hostingTotal) * 100;
+
+    vm.newsletterPercentage = (data.newsletter / data.total) * 100;
+
+    vm.connections = [];
+    angular.forEach(data.connected, function (count, network) {
+      vm.connections.push({
+        network: network,
+        count: count,
       });
-    }, (10 * 60000)); // every 10 mins
-
-    // Clean interval when leaving the page
-    $scope.$on('$destroy', function () {
-      if (statsInterval) {
-        $interval.cancel(statsInterval);
-      }
     });
 
-    function processStats(data) {
-
-      angular.extend(vm, data);
-
-      vm.hostingTotal = data.hosting.yes + data.hosting.maybe;
-      vm.hostingPercentage = (vm.hostingTotal / data.total) * 100;
-      vm.hostingYesPercentage = (data.hosting.yes / vm.hostingTotal) * 100;
-      vm.hostingMaybePercentage = (data.hosting.maybe / vm.hostingTotal) * 100;
-
-      vm.newsletterPercentage = (data.newsletter / data.total) * 100;
-
-      vm.connections = [];
-      angular.forEach(data.connected, function (count, network) {
-        vm.connections.push({
-          network: network,
-          count: count,
-        });
-      });
-
-    }
-
   }
-}());
+
+}

--- a/modules/statistics/client/services/statistics.client.service.js
+++ b/modules/statistics/client/services/statistics.client.service.js
@@ -1,12 +1,10 @@
-(function () {
-  // Statistics service used for communicating with the statistics REST endpoints
+// Statistics service used for communicating with the statistics REST endpoints
 
-  angular
-    .module('statistics')
-    .factory('Statistics', StatisticsService);
+angular
+  .module('statistics')
+  .factory('Statistics', StatisticsService);
 
-  /* @ngInject */
-  function StatisticsService($resource) {
-    return $resource('/api/statistics');
-  }
-}());
+/* @ngInject */
+function StatisticsService($resource) {
+  return $resource('/api/statistics');
+}

--- a/modules/statistics/tests/client/statistics.client.routes.tests.js
+++ b/modules/statistics/tests/client/statistics.client.routes.tests.js
@@ -1,65 +1,63 @@
 import '@/modules/statistics/client/statistics.client.module';
 import AppConfig from '@/modules/core/client/app/config';
 
-(function () {
-  describe('Statistics Route Tests', function () {
-    // Initialize global variables
-    let $httpBackend;
+describe('Statistics Route Tests', function () {
+  // Initialize global variables
+  let $httpBackend;
 
-    // We can start by loading the main application module
-    beforeEach(angular.mock.module(AppConfig.appModuleName));
+  // We can start by loading the main application module
+  beforeEach(angular.mock.module(AppConfig.appModuleName));
 
-    // The injector ignores leading and trailing underscores here (i.e. _$httpBackend_).
-    // This allows us to inject a service but then attach it to a variable
-    // with the same name as the service.
-    beforeEach(inject(function ($rootScope, _$httpBackend_) {
-      $httpBackend = _$httpBackend_;
-    }));
+  // The injector ignores leading and trailing underscores here (i.e. _$httpBackend_).
+  // This allows us to inject a service but then attach it to a variable
+  // with the same name as the service.
+  beforeEach(inject(function ($rootScope, _$httpBackend_) {
+    $httpBackend = _$httpBackend_;
+  }));
 
-    describe('Route Config', function () {
-      describe('Main Route', function () {
-        let mainstate;
-        beforeEach(inject(function ($state) {
-          // Test expected GET request
-          $httpBackend.when('GET', '/modules/pages/views/home.client.view.html').respond(200, '');
-          $httpBackend.when('GET', '/modules/statistics/views/statistics.client.view.html').respond(200, '');
-          $httpBackend.when('GET', '/api/statistics').respond(200, '');
+  describe('Route Config', function () {
+    describe('Main Route', function () {
+      let mainstate;
+      beforeEach(inject(function ($state) {
+        // Test expected GET request
+        $httpBackend.when('GET', '/modules/pages/views/home.client.view.html').respond(200, '');
+        $httpBackend.when('GET', '/modules/statistics/views/statistics.client.view.html').respond(200, '');
+        $httpBackend.when('GET', '/api/statistics').respond(200, '');
 
-          mainstate = $state.get('statistics');
-        }));
+        mainstate = $state.get('statistics');
+      }));
 
-        it('Should have the correct URL', function () {
-          expect(mainstate.url).toEqual('/statistics');
-        });
-
-        it('Should not be abstract', function () {
-          expect(mainstate.abstract).toBe(undefined);
-        });
-
-        it('Should have templateUrl', function () {
-          expect(mainstate.templateUrl).toBe('/modules/statistics/views/statistics.client.view.html');
-        });
+      it('Should have the correct URL', function () {
+        expect(mainstate.url).toEqual('/statistics');
       });
 
-      describe('Handle Trailing Slash', function () {
-        beforeEach(inject(function ($state, $rootScope) {
-          // Test expected GET request
-          $httpBackend.when('GET', '/modules/pages/views/home.client.view.html').respond(200, '');
-          $httpBackend.when('GET', '/modules/statistics/views/statistics.client.view.html').respond(200, '');
-          $httpBackend.when('GET', '/api/statistics').respond(200, '');
-
-          $state.go('statistics');
-          $rootScope.$digest();
-        }));
-
-        it('Should remove trailing slash', inject(function ($state, $location, $rootScope) {
-          $location.path('statistics/');
-          $rootScope.$digest();
-
-          expect($location.path()).toBe('/statistics');
-        }));
+      it('Should not be abstract', function () {
+        expect(mainstate.abstract).toBe(undefined);
       });
 
+      it('Should have templateUrl', function () {
+        expect(mainstate.templateUrl).toBe('/modules/statistics/views/statistics.client.view.html');
+      });
     });
+
+    describe('Handle Trailing Slash', function () {
+      beforeEach(inject(function ($state, $rootScope) {
+        // Test expected GET request
+        $httpBackend.when('GET', '/modules/pages/views/home.client.view.html').respond(200, '');
+        $httpBackend.when('GET', '/modules/statistics/views/statistics.client.view.html').respond(200, '');
+        $httpBackend.when('GET', '/api/statistics').respond(200, '');
+
+        $state.go('statistics');
+        $rootScope.$digest();
+      }));
+
+      it('Should remove trailing slash', inject(function ($state, $location, $rootScope) {
+        $location.path('statistics/');
+        $rootScope.$digest();
+
+        expect($location.path()).toBe('/statistics');
+      }));
+    });
+
   });
-}());
+});

--- a/modules/support/client/config/support.client.routes.js
+++ b/modules/support/client/config/support.client.routes.js
@@ -1,35 +1,33 @@
 import supportTemplateUrl from '@/modules/support/client/views/support.client.view.html';
 import contactTemplateUrl from '@/modules/support/client/views/support.client.view.html';
 
-(function () {
-  angular
-    .module('support')
-    .config(SupportRoutes);
+angular
+  .module('support')
+  .config(SupportRoutes);
 
-  /* @ngInject */
-  function SupportRoutes($stateProvider) {
+/* @ngInject */
+function SupportRoutes($stateProvider) {
 
-    $stateProvider.
-      state('support', {
-        url: '/support?report=',
-        templateUrl: supportTemplateUrl,
-        requiresAuth: false,
-        controller: 'SupportController',
-        controllerAs: 'support',
-        data: {
-          pageTitle: 'Support',
-        },
-      }).
-      // Deprecated (02-2016):
-      state('contact', {
-        url: '/contact',
-        templateUrl: contactTemplateUrl,
-        requiresAuth: false,
-        controller: 'SupportController',
-        controllerAs: 'support',
-        data: {
-          pageTitle: 'Contact us',
-        },
-      });
-  }
-}());
+  $stateProvider.
+    state('support', {
+      url: '/support?report=',
+      templateUrl: supportTemplateUrl,
+      requiresAuth: false,
+      controller: 'SupportController',
+      controllerAs: 'support',
+      data: {
+        pageTitle: 'Support',
+      },
+    }).
+    // Deprecated (02-2016):
+    state('contact', {
+      url: '/contact',
+      templateUrl: contactTemplateUrl,
+      requiresAuth: false,
+      controller: 'SupportController',
+      controllerAs: 'support',
+      data: {
+        pageTitle: 'Contact us',
+      },
+    });
+}

--- a/modules/support/client/controllers/support.client.controller.js
+++ b/modules/support/client/controllers/support.client.controller.js
@@ -1,64 +1,62 @@
-(function () {
-  angular
-    .module('support')
-    .controller('SupportController', SupportController);
+angular
+  .module('support')
+  .controller('SupportController', SupportController);
 
-  /* @ngInject */
-  function SupportController(SupportService, messageCenterService, $stateParams) {
+/* @ngInject */
+function SupportController(SupportService, messageCenterService, $stateParams) {
 
-    // ViewModel
-    const vm = this;
+  // ViewModel
+  const vm = this;
 
-    // Exposed to the view
-    vm.sendSupportRequest = sendSupportRequest;
+  // Exposed to the view
+  vm.sendSupportRequest = sendSupportRequest;
+  vm.success = false;
+  vm.isLoading = false;
+  vm.request = {
+    username: '',
+    email: '',
+    message: '',
+  };
+
+  activate();
+
+  /**
+   * Initialize controller
+   */
+  function activate() {
+    if ($stateParams.report && $stateParams.report !== '') {
+      vm.request.reportMember = $stateParams.report;
+    }
+  }
+
+  /**
+   * Send support request
+   */
+  function sendSupportRequest(isValid) {
     vm.success = false;
-    vm.isLoading = false;
-    vm.request = {
-      username: '',
-      email: '',
-      message: '',
-    };
+    vm.isLoading = true;
 
-    activate();
-
-    /**
-     * Initialize controller
-     */
-    function activate() {
-      if ($stateParams.report && $stateParams.report !== '') {
-        vm.request.reportMember = $stateParams.report;
-      }
+    if (!isValid) {
+      vm.isLoading = false;
+      return false;
     }
 
-    /**
-     * Send support request
-     */
-    function sendSupportRequest(isValid) {
-      vm.success = false;
-      vm.isLoading = true;
-
-      if (!isValid) {
-        vm.isLoading = false;
-        return false;
-      }
-
-      if (vm.request.message === '') {
-        messageCenterService.add('danger', 'Please write a message first.', { timeout: 20000 });
-        vm.isLoading = false;
-        return false;
-      }
-
-      const supportRequest = new SupportService(vm.request);
-
-      supportRequest.$save(function () {
-        vm.success = true;
-        vm.isLoading = false;
-      }, function (err) {
-        vm.isLoading = false;
-        messageCenterService.add('danger', err.message || 'Something went wrong. Please try again.', { timeout: 20000 });
-      });
-
+    if (vm.request.message === '') {
+      messageCenterService.add('danger', 'Please write a message first.', { timeout: 20000 });
+      vm.isLoading = false;
+      return false;
     }
+
+    const supportRequest = new SupportService(vm.request);
+
+    supportRequest.$save(function () {
+      vm.success = true;
+      vm.isLoading = false;
+    }, function (err) {
+      vm.isLoading = false;
+      messageCenterService.add('danger', err.message || 'Something went wrong. Please try again.', { timeout: 20000 });
+    });
 
   }
-}());
+
+}

--- a/modules/support/client/services/support.client.service.js
+++ b/modules/support/client/services/support.client.service.js
@@ -1,12 +1,10 @@
-(function () {
-  // Support service used for communicating with the support REST endpoints
+// Support service used for communicating with the support REST endpoints
 
-  angular
-    .module('support')
-    .factory('SupportService', SupportService);
+angular
+  .module('support')
+  .factory('SupportService', SupportService);
 
-  /* @ngInject */
-  function SupportService($resource) {
-    return $resource('/api/support');
-  }
-}());
+/* @ngInject */
+function SupportService($resource) {
+  return $resource('/api/support');
+}

--- a/modules/support/tests/client/support.client.routes.tests.js
+++ b/modules/support/tests/client/support.client.routes.tests.js
@@ -1,65 +1,63 @@
 import '@/modules/support/client/support.client.module';
 import AppConfig from '@/modules/core/client/app/config';
 
-(function () {
-  describe('Support Route Tests', function () {
+describe('Support Route Tests', function () {
 
-    // We can start by loading the main application module
-    beforeEach(angular.mock.module(AppConfig.appModuleName));
+  // We can start by loading the main application module
+  beforeEach(angular.mock.module(AppConfig.appModuleName));
 
-    describe('Route Config', function () {
-      describe('Main Route (support)', function () {
-        let mainstate;
-        beforeEach(inject(function ($state) {
-          mainstate = $state.get('support');
-        }));
+  describe('Route Config', function () {
+    describe('Main Route (support)', function () {
+      let mainstate;
+      beforeEach(inject(function ($state) {
+        mainstate = $state.get('support');
+      }));
 
-        it('Should have the correct URL', function () {
-          expect(mainstate.url).toEqual('/support?report=');
-        });
-
-        it('Should not be abstract', function () {
-          expect(mainstate.abstract).toBe(undefined);
-        });
-
-        it('Should have templateUrl', function () {
-          expect(mainstate.templateUrl).toBe('/modules/support/views/support.client.view.html');
-        });
+      it('Should have the correct URL', function () {
+        expect(mainstate.url).toEqual('/support?report=');
       });
 
-      describe('Alternative Route (contact)', function () {
-        let mainstate;
-        beforeEach(inject(function ($state) {
-          mainstate = $state.get('contact');
-        }));
-
-        it('Should have the correct URL (contact)', function () {
-          expect(mainstate.url).toEqual('/contact');
-        });
-
-        it('Should not be abstract', function () {
-          expect(mainstate.abstract).toBe(undefined);
-        });
-
-        it('Should have templateUrl', function () {
-          expect(mainstate.templateUrl).toBe('/modules/support/views/support.client.view.html');
-        });
+      it('Should not be abstract', function () {
+        expect(mainstate.abstract).toBe(undefined);
       });
 
-      describe('Handle Trailing Slash', function () {
-        beforeEach(inject(function ($state, $rootScope) {
-          $state.go('support');
-          $rootScope.$digest();
-        }));
-
-        it('Should remove trailing slash', inject(function ($state, $location, $rootScope) {
-          $location.path('support/');
-          $rootScope.$digest();
-
-          expect($location.path()).toBe('/support');
-        }));
+      it('Should have templateUrl', function () {
+        expect(mainstate.templateUrl).toBe('/modules/support/views/support.client.view.html');
       });
-
     });
+
+    describe('Alternative Route (contact)', function () {
+      let mainstate;
+      beforeEach(inject(function ($state) {
+        mainstate = $state.get('contact');
+      }));
+
+      it('Should have the correct URL (contact)', function () {
+        expect(mainstate.url).toEqual('/contact');
+      });
+
+      it('Should not be abstract', function () {
+        expect(mainstate.abstract).toBe(undefined);
+      });
+
+      it('Should have templateUrl', function () {
+        expect(mainstate.templateUrl).toBe('/modules/support/views/support.client.view.html');
+      });
+    });
+
+    describe('Handle Trailing Slash', function () {
+      beforeEach(inject(function ($state, $rootScope) {
+        $state.go('support');
+        $rootScope.$digest();
+      }));
+
+      it('Should remove trailing slash', inject(function ($state, $location, $rootScope) {
+        $location.path('support/');
+        $rootScope.$digest();
+
+        expect($location.path()).toBe('/support');
+      }));
+    });
+
   });
-}());
+});

--- a/modules/tribes/client/config/tribes.client.config.js
+++ b/modules/tribes/client/config/tribes.client.config.js
@@ -1,55 +1,53 @@
 import listTemplateUrl from '@/modules/tribes/client/views/tribes-list.client.view.html';
 import showTemplateUrl from '@/modules/tribes/client/views/tribe.client.view.html';
 
-(function () {
-  angular
-    .module('tribes')
-    .config(TribesRoutes);
+angular
+  .module('tribes')
+  .config(TribesRoutes);
 
-  /* @ngInject */
-  function TribesRoutes($stateProvider) {
+/* @ngInject */
+function TribesRoutes($stateProvider) {
 
-    $stateProvider.
-      state('tribes', {
-        url: '/tribes',
-        abstract: true,
-        template: '<ui-view/>',
-      }).
-      state('tribes.list', {
-        url: '',
-        templateUrl: listTemplateUrl,
-        controller: 'TribesListController',
-        controllerAs: 'tribesList',
-        resolve: {
-          // A string value resolves to a service
-          TribesService: 'TribesService',
-          tribes: function (TribesService) {
-            return TribesService.query();
-          },
+  $stateProvider.
+    state('tribes', {
+      url: '/tribes',
+      abstract: true,
+      template: '<ui-view/>',
+    }).
+    state('tribes.list', {
+      url: '',
+      templateUrl: listTemplateUrl,
+      controller: 'TribesListController',
+      controllerAs: 'tribesList',
+      resolve: {
+        // A string value resolves to a service
+        TribesService: 'TribesService',
+        tribes: function (TribesService) {
+          return TribesService.query();
         },
-        data: {
-          pageTitle: 'Tribes',
+      },
+      data: {
+        pageTitle: 'Tribes',
+      },
+    }).
+    state('tribes.tribe', {
+      url: '/:tribe',
+      footerHidden: true,
+      templateUrl: showTemplateUrl,
+      controller: 'TribeController',
+      controllerAs: 'tribeCtrl',
+      resolve: {
+        // A string value resolves to a service
+        TribeService: 'TribeService',
+        tribe: function (TribeService, $stateParams) {
+          return TribeService.get({
+            tribeSlug: $stateParams.tribe,
+          });
         },
-      }).
-      state('tribes.tribe', {
-        url: '/:tribe',
-        footerHidden: true,
-        templateUrl: showTemplateUrl,
-        controller: 'TribeController',
-        controllerAs: 'tribeCtrl',
-        resolve: {
-          // A string value resolves to a service
-          TribeService: 'TribeService',
-          tribe: function (TribeService, $stateParams) {
-            return TribeService.get({
-              tribeSlug: $stateParams.tribe,
-            });
-          },
-        },
-        data: {
-          pageTitle: 'Tribe',
-        },
-      });
+      },
+      data: {
+        pageTitle: 'Tribe',
+      },
+    });
 
-  }
-}());
+}

--- a/modules/tribes/client/controllers/tribe.client.controller.js
+++ b/modules/tribes/client/controllers/tribe.client.controller.js
@@ -1,33 +1,31 @@
-(function () {
-  angular
-    .module('tribes')
-    .controller('TribeController', TribeController);
+angular
+  .module('tribes')
+  .controller('TribeController', TribeController);
 
-  /* @ngInject */
-  function TribeController($scope, $state, tribe, Facebook) {
+/* @ngInject */
+function TribeController($scope, $state, tribe, Facebook) {
 
-    const headerHeight = angular.element('#tr-header').height() || 0;
+  const headerHeight = angular.element('#tr-header').height() || 0;
 
-    // ViewModel
-    const vm = this;
+  // ViewModel
+  const vm = this;
 
-    // Exposed to the view
+  // Exposed to the view
+  vm.tribe = tribe;
+  vm.windowHeight = angular.element('html').height() - headerHeight;
+  vm.goBack = goBack;
+  vm.facebookIsActibe = Facebook.isActive;
+
+  // Ensure tribe in view updates when directives modify it
+  $scope.$on('tribeUpdated', function (event, tribe) {
     vm.tribe = tribe;
-    vm.windowHeight = angular.element('html').height() - headerHeight;
-    vm.goBack = goBack;
-    vm.facebookIsActibe = Facebook.isActive;
+  });
 
-    // Ensure tribe in view updates when directives modify it
-    $scope.$on('tribeUpdated', function (event, tribe) {
-      vm.tribe = tribe;
-    });
-
-    /**
-     * Go to tribe grid
-     */
-    function goBack() {
-      $state.go('tribes.list');
-    }
-
+  /**
+   * Go to tribe grid
+   */
+  function goBack() {
+    $state.go('tribes.list');
   }
-}());
+
+}

--- a/modules/tribes/client/controllers/tribes-list.client.controller.js
+++ b/modules/tribes/client/controllers/tribes-list.client.controller.js
@@ -1,27 +1,25 @@
-(function () {
-  angular
-    .module('tribes')
-    .controller('TribesListController', TribesListController);
+angular
+  .module('tribes')
+  .controller('TribesListController', TribesListController);
 
-  /* @ngInject */
-  function TribesListController(tribes, $state, Authentication, TribeService) {
+/* @ngInject */
+function TribesListController(tribes, $state, Authentication, TribeService) {
 
-    // ViewModel
-    const vm = this;
+  // ViewModel
+  const vm = this;
 
-    // Exposed to the view
-    vm.tribes = tribes;
-    vm.user = Authentication.user;
-    vm.openTribe = openTribe;
+  // Exposed to the view
+  vm.tribes = tribes;
+  vm.user = Authentication.user;
+  vm.openTribe = openTribe;
 
-    /**
-     * Open tribe
-     */
-    function openTribe(tribe) {
-      // Put tribe object to cache to be used after page transition has
-      // finished, thus no need to reload tribe from the API
-      TribeService.fillCache(angular.copy(tribe));
-      $state.go('tribes.tribe', { 'tribe': tribe.slug });
-    }
+  /**
+   * Open tribe
+   */
+  function openTribe(tribe) {
+    // Put tribe object to cache to be used after page transition has
+    // finished, thus no need to reload tribe from the API
+    TribeService.fillCache(angular.copy(tribe));
+    $state.go('tribes.tribe', { 'tribe': tribe.slug });
   }
-}());
+}

--- a/modules/tribes/client/directives/tr-tribe-badge.client.directive.js
+++ b/modules/tribes/client/directives/tr-tribe-badge.client.directive.js
@@ -1,46 +1,44 @@
 import templateUrl from '@/modules/tribes/client/views/directives/tr-tribe-badge.client.view.html';
 
-(function () {
-  /**
-   * List tribes in common between two lists of tribes
-   */
-  angular
-    .module('tribes')
-    .directive('trTribeBadge', trTribeBadgeDirective);
+/**
+ * List tribes in common between two lists of tribes
+ */
+angular
+  .module('tribes')
+  .directive('trTribeBadge', trTribeBadgeDirective);
+
+/* @ngInject */
+function trTribeBadgeDirective(TribeService) {
+  return {
+    templateUrl,
+    restrict: 'AE',
+    replace: true,
+    scope: {
+      tribe: '=trTribeBadge',
+    },
+    controller: trTribeBadgeController,
+    controllerAs: 'tribeBadge',
+  };
 
   /* @ngInject */
-  function trTribeBadgeDirective(TribeService) {
-    return {
-      templateUrl,
-      restrict: 'AE',
-      replace: true,
-      scope: {
-        tribe: '=trTribeBadge',
-      },
-      controller: trTribeBadgeController,
-      controllerAs: 'tribeBadge',
-    };
+  function trTribeBadgeController($scope, $state) {
 
-    /* @ngInject */
-    function trTribeBadgeController($scope, $state) {
+    // View Model
+    const vm = this;
 
-      // View Model
-      const vm = this;
+    // Exposed to the view
+    vm.openTribe = openTribe;
+    vm.tribe = $scope.tribe;
 
-      // Exposed to the view
-      vm.openTribe = openTribe;
-      vm.tribe = $scope.tribe;
-
-      /**
-       * Open tribe
-       */
-      function openTribe() {
-        // Put tribe object to cache to be used after page transition has
-        // finished, thus no need to reload tribe from the API
-        TribeService.fillCache(angular.copy(vm.tribe));
-        $state.go('tribes.tribe', { 'tribe': vm.tribe.slug });
-      }
-
+    /**
+     * Open tribe
+     */
+    function openTribe() {
+      // Put tribe object to cache to be used after page transition has
+      // finished, thus no need to reload tribe from the API
+      TribeService.fillCache(angular.copy(vm.tribe));
+      $state.go('tribes.tribe', { 'tribe': vm.tribe.slug });
     }
+
   }
-}());
+}

--- a/modules/tribes/client/directives/tr-tribe-join-button.client.directive.js
+++ b/modules/tribes/client/directives/tr-tribe-join-button.client.directive.js
@@ -1,220 +1,218 @@
 import templateUrl from '@/modules/tribes/client/views/directives/tr-tribe-join-button.client.view.html';
 
-(function () {
-  /**
-   * Join tribe button
-   */
-  angular
-    .module('tribes')
-    .directive('trTribeJoinButton', trTribeJoinButtonDirective);
+/**
+ * Join tribe button
+ */
+angular
+  .module('tribes')
+  .directive('trTribeJoinButton', trTribeJoinButtonDirective);
+
+/* @ngInject */
+function trTribeJoinButtonDirective() {
+  return {
+    restrict: 'AE',
+    replace: true,
+    transclude: true,
+    scope: {
+      tribe: '=',
+      joinLabel: '=',
+      joinedLabel: '=',
+      icon: '=',
+    },
+    templateUrl,
+    controller: trTribeJoinButtonDirectiveController,
+    controllerAs: 'tribeJoinButton',
+  };
 
   /* @ngInject */
-  function trTribeJoinButtonDirective() {
-    return {
-      restrict: 'AE',
-      replace: true,
-      transclude: true,
-      scope: {
-        tribe: '=',
-        joinLabel: '=',
-        joinedLabel: '=',
-        icon: '=',
-      },
-      templateUrl,
-      controller: trTribeJoinButtonDirectiveController,
-      controllerAs: 'tribeJoinButton',
-    };
+  function trTribeJoinButtonDirectiveController(
+    $q,
+    $confirm,
+    $scope,
+    $state,
+    $rootScope,
+    $analytics,
+    Authentication,
+    TribeService,
+    UserMembershipsService,
+    messageCenterService,
+  ) {
 
-    /* @ngInject */
-    function trTribeJoinButtonDirectiveController(
-      $q,
-      $confirm,
-      $scope,
-      $state,
-      $rootScope,
-      $analytics,
-      Authentication,
-      TribeService,
-      UserMembershipsService,
-      messageCenterService,
-    ) {
+    const vm = this;
 
-      const vm = this;
+    vm.tribe = $scope.tribe;
+    vm.isMember = false;
+    vm.isLoading = false;
+    vm.joinLabel = $scope.joinLabel || 'Join';
+    vm.joinedLabel = $scope.joinedLabel || 'Joined';
+    vm.icon = Boolean($scope.icon);
 
-      vm.tribe = $scope.tribe;
-      vm.isMember = false;
-      vm.isLoading = false;
-      vm.joinLabel = $scope.joinLabel || 'Join';
-      vm.joinedLabel = $scope.joinedLabel || 'Joined';
-      vm.icon = Boolean($scope.icon);
+    vm.toggleMembership = toggleMembership;
 
-      vm.toggleMembership = toggleMembership;
+    activate();
 
-      activate();
+    /**
+     * Initialize directive
+     */
+    function activate() {
+      // Check if authenticated user is already a member
+      if (Authentication.user) {
+        vm.isMember = Authentication.user
+          && Authentication.user.memberIds
+          && Authentication.user.memberIds.indexOf(vm.tribe._id) > -1;
+      }
+    }
 
-      /**
-       * Initialize directive
-       */
-      function activate() {
-        // Check if authenticated user is already a member
-        if (Authentication.user) {
-          vm.isMember = Authentication.user
-            && Authentication.user.memberIds
-            && Authentication.user.memberIds.indexOf(vm.tribe._id) > -1;
-        }
+    /**
+     * Go to signup page and refer to this tribe
+     */
+    function tribeSignup() {
+      TribeService.fillCache(angular.copy(vm.tribe));
+      $state.go('signup', { 'tribe': vm.tribe.slug });
+    }
+
+    /**
+     * Toggle membership (join or leave)
+     */
+    function toggleMembership() {
+      if (vm.isLoading) {
+        return;
       }
 
-      /**
-       * Go to signup page and refer to this tribe
-       */
-      function tribeSignup() {
-        TribeService.fillCache(angular.copy(vm.tribe));
-        $state.go('signup', { 'tribe': vm.tribe.slug });
+      vm.isLoading = true;
+
+      // If user is not authenticated, redirect them to signup page
+      if (!Authentication.user) {
+        return tribeSignup();
       }
 
-      /**
-       * Toggle membership (join or leave)
-       */
-      function toggleMembership() {
-        if (vm.isLoading) {
-          return;
-        }
-
-        vm.isLoading = true;
-
-        // If user is not authenticated, redirect them to signup page
-        if (!Authentication.user) {
-          return tribeSignup();
-        }
-
-        // Join tribe
-        if (!vm.isMember) {
-          return join()
-            .then(function (data) {
-              vm.isMember = true;
-
-              applyChangedData(data);
-
-              $analytics.eventTrack('join-tribe', {
-                category: 'tribes.membership',
-                label: 'Join tribe',
-                value: $scope.tribe.slug,
-              });
-            })
-            .catch(function () {
-              messageCenterService.add('danger', 'Failed to join the tribe. Try again!');
-            })
-            .finally(function () {
-              vm.isLoading = false;
-            });
-        }
-
-        // Leave tribe
-        leave()
+      // Join tribe
+      if (!vm.isMember) {
+        return join()
           .then(function (data) {
-            vm.isMember = false;
+            vm.isMember = true;
 
             applyChangedData(data);
 
-            $analytics.eventTrack('leave-tribe', {
+            $analytics.eventTrack('join-tribe', {
               category: 'tribes.membership',
-              label: 'Leave tribe',
+              label: 'Join tribe',
               value: $scope.tribe.slug,
             });
           })
-          .catch(function (err) {
-            if (err === 'cancelled') {
-              $analytics.eventTrack('leave-tribe-cancelled', {
-                category: 'tribes.membership',
-                label: 'Leaving tribe cancelled',
-                value: $scope.tribe.slug,
-              });
-              return;
-            }
-
-            const errorMessage = err && err.data && err.data.message ? err.data.message : 'Failed to leave the tribe. Try again!';
-            messageCenterService.add('danger', errorMessage);
+          .catch(function () {
+            messageCenterService.add('danger', 'Failed to join the tribe. Try again!');
           })
           .finally(function () {
             vm.isLoading = false;
           });
       }
 
-      /**
-       * Join Tribe
-       */
-      function join() {
-        return $q(function (resolve, reject) {
-          UserMembershipsService.post({
-            tribeId: $scope.tribe._id,
-          },
-          function (data) {
-            if (data.tribe && data.user) {
-              data.tribe.$resolved = true;
+      // Leave tribe
+      leave()
+        .then(function (data) {
+          vm.isMember = false;
 
-              resolve(data);
-            } else {
-              reject();
-            }
-          }, function (err) {
-            reject(err);
+          applyChangedData(data);
+
+          $analytics.eventTrack('leave-tribe', {
+            category: 'tribes.membership',
+            label: 'Leave tribe',
+            value: $scope.tribe.slug,
           });
-        });
-      }
-
-      /**
-       * Leave tribe
-       */
-      function leave() {
-        return $q(function (resolve, reject) {
-          // Ask user for confirmation
-          $confirm({
-            title: 'Leave this Tribe?',
-            text: 'Do you want to leave "' + $scope.tribe.label + '"?',
-            ok: 'Leave Tribe',
-            cancel: 'Cancel',
-          })
-            .then(function () {
-              UserMembershipsService.delete({
-                tribeId: $scope.tribe._id,
-              },
-              function (data) {
-                if (data.tribe && data.user) {
-                  // API success
-                  data.tribe.$resolved = true;
-
-                  resolve(data);
-                } else {
-                // API returned error
-                  reject();
-                }
-              }, function (err) {
-              // API returned error
-                reject(err);
-              });
-            },
-            // `Cancel` button from confirm dialog
-            function () {
-              reject('cancelled');
+        })
+        .catch(function (err) {
+          if (err === 'cancelled') {
+            $analytics.eventTrack('leave-tribe-cancelled', {
+              category: 'tribes.membership',
+              label: 'Leaving tribe cancelled',
+              value: $scope.tribe.slug,
             });
+            return;
+          }
 
+          const errorMessage = err && err.data && err.data.message ? err.data.message : 'Failed to leave the tribe. Try again!';
+          messageCenterService.add('danger', errorMessage);
+        })
+        .finally(function () {
+          vm.isLoading = false;
         });
-      }
-
-      function applyChangedData(data) {
-        // Update tribe with new count
-        if (data.tribe) {
-          $scope.tribe = data.tribe;
-          $rootScope.$broadcast('tribeUpdated', data.tribe);
-        }
-
-        // User model is updated with new tribe data
-        if (data.user) {
-          Authentication.user = data.user;
-          $rootScope.$broadcast('userUpdated');
-        }
-      }
-
     }
+
+    /**
+     * Join Tribe
+     */
+    function join() {
+      return $q(function (resolve, reject) {
+        UserMembershipsService.post({
+          tribeId: $scope.tribe._id,
+        },
+        function (data) {
+          if (data.tribe && data.user) {
+            data.tribe.$resolved = true;
+
+            resolve(data);
+          } else {
+            reject();
+          }
+        }, function (err) {
+          reject(err);
+        });
+      });
+    }
+
+    /**
+     * Leave tribe
+     */
+    function leave() {
+      return $q(function (resolve, reject) {
+        // Ask user for confirmation
+        $confirm({
+          title: 'Leave this Tribe?',
+          text: 'Do you want to leave "' + $scope.tribe.label + '"?',
+          ok: 'Leave Tribe',
+          cancel: 'Cancel',
+        })
+          .then(function () {
+            UserMembershipsService.delete({
+              tribeId: $scope.tribe._id,
+            },
+            function (data) {
+              if (data.tribe && data.user) {
+                // API success
+                data.tribe.$resolved = true;
+
+                resolve(data);
+              } else {
+              // API returned error
+                reject();
+              }
+            }, function (err) {
+            // API returned error
+              reject(err);
+            });
+          },
+          // `Cancel` button from confirm dialog
+          function () {
+            reject('cancelled');
+          });
+
+      });
+    }
+
+    function applyChangedData(data) {
+      // Update tribe with new count
+      if (data.tribe) {
+        $scope.tribe = data.tribe;
+        $rootScope.$broadcast('tribeUpdated', data.tribe);
+      }
+
+      // User model is updated with new tribe data
+      if (data.user) {
+        Authentication.user = data.user;
+        $rootScope.$broadcast('userUpdated');
+      }
+    }
+
   }
-}());
+}

--- a/modules/tribes/client/directives/tr-tribe-styles.client.directive.js
+++ b/modules/tribes/client/directives/tr-tribe-styles.client.directive.js
@@ -1,62 +1,60 @@
-(function () {
-  /**
-   * Directive to apply tribe color + image styles to an element
-   *
-   * Set background image dimensions (width x height): <div tr-tribe-dimensions="600x400"></div>
-   * See https://uploadcare.com/documentation/cdn/#operation-scale-crop
-   *
-   * Set background image quality: <div tr-tribe-quality="normal"></div>
-   * Options: normal, better, best, lighter (default), lightest
-   * See https://uploadcare.com/documentation/cdn/#operation-quality
-   *
-   * Set progressive image loading: <div tr-tribe-progressive="yes"></div>
-   * Options: yes (default), no
-   * See https://uploadcare.com/documentation/cdn/#operation-progressive
-   */
-  angular
-    .module('tribes')
-    .directive('trTribeStyles', trTribeStylesDirective);
+/**
+ * Directive to apply tribe color + image styles to an element
+ *
+ * Set background image dimensions (width x height): <div tr-tribe-dimensions="600x400"></div>
+ * See https://uploadcare.com/documentation/cdn/#operation-scale-crop
+ *
+ * Set background image quality: <div tr-tribe-quality="normal"></div>
+ * Options: normal, better, best, lighter (default), lightest
+ * See https://uploadcare.com/documentation/cdn/#operation-quality
+ *
+ * Set progressive image loading: <div tr-tribe-progressive="yes"></div>
+ * Options: yes (default), no
+ * See https://uploadcare.com/documentation/cdn/#operation-progressive
+ */
+angular
+  .module('tribes')
+  .directive('trTribeStyles', trTribeStylesDirective);
 
-  /* @ngInject */
-  function trTribeStylesDirective() {
-    return {
-      restrict: 'A',
-      replace: false,
-      scope: false,
-      link: function (scope, elem, attrs) {
+/* @ngInject */
+function trTribeStylesDirective() {
+  return {
+    restrict: 'A',
+    replace: false,
+    scope: false,
+    link: function (scope, elem, attrs) {
 
-        if (angular.isDefined(attrs.trTribeStyles) && attrs.trTribeStyles !== '') {
-          let style = '';
-          const tribe = angular.fromJson(attrs.trTribeStyles);
+      if (angular.isDefined(attrs.trTribeStyles) && attrs.trTribeStyles !== '') {
+        let style = '';
+        const tribe = angular.fromJson(attrs.trTribeStyles);
 
-          // Set background image
-          // Uses Uploadcare.com to resize and deliver images
-          if (tribe.image_UUID) {
-            const dimensions = (angular.isDefined(attrs.trTribeStylesDimensions) && attrs.trTribeStylesDimensions !== '') ? attrs.trTribeStylesDimensions : '1024x768';
-            const quality = (angular.isDefined(attrs.trTribeStylesQuality) && attrs.trTribeStylesQuality !== '') ? attrs.trTribeStylesQuality : 'lighter';
-            const progressive = (angular.isDefined(attrs.trTribeStylesProgressive) && (attrs.trTribeStylesProgressive === 'yes' || attrs.trTribeStylesProgressive === 'no')) ? attrs.trTribeStylesProgressive : 'no';
+        // Set background image
+        // Uses Uploadcare.com to resize and deliver images
+        if (tribe.image_UUID) {
+          const dimensions = (angular.isDefined(attrs.trTribeStylesDimensions) && attrs.trTribeStylesDimensions !== '') ? attrs.trTribeStylesDimensions : '1024x768';
+          const quality = (angular.isDefined(attrs.trTribeStylesQuality) && attrs.trTribeStylesQuality !== '') ? attrs.trTribeStylesQuality : 'lighter';
+          const progressive = (angular.isDefined(attrs.trTribeStylesProgressive) && (attrs.trTribeStylesProgressive === 'yes' || attrs.trTribeStylesProgressive === 'no')) ? attrs.trTribeStylesProgressive : 'no';
 
-            // Available CDN parameters: https://uploadcare.com/documentation/cdn/
-            const img_params = [
-              'progressive/' + progressive,
-              'scale_crop/' + dimensions + '/center',
-              'quality/' + quality,
-              'format/jpeg',
-            ];
+          // Available CDN parameters: https://uploadcare.com/documentation/cdn/
+          const img_params = [
+            'progressive/' + progressive,
+            'scale_crop/' + dimensions + '/center',
+            'quality/' + quality,
+            'format/jpeg',
+          ];
 
-            style += 'background-image: url(https://ucarecdn.com/' + tribe.image_UUID + '/-/' + img_params.join('/-/') + '/);';
-          }
-
-          if (tribe.color) {
-            style += 'background-color: #' + tribe.color + ';';
-          }
-
-          if (style !== '') {
-            attrs.$set('style', style);
-          }
+          style += 'background-image: url(https://ucarecdn.com/' + tribe.image_UUID + '/-/' + img_params.join('/-/') + '/);';
         }
 
-      },
-    };
-  }
-}());
+        if (tribe.color) {
+          style += 'background-color: #' + tribe.color + ';';
+        }
+
+        if (style !== '') {
+          attrs.$set('style', style);
+        }
+      }
+
+    },
+  };
+}

--- a/modules/tribes/client/directives/tr-tribes-in-common.client.directive.js
+++ b/modules/tribes/client/directives/tr-tribes-in-common.client.directive.js
@@ -1,70 +1,68 @@
 import templateUrl from '@/modules/tribes/client/views/directives/tr-tribes-in-common.client.view.html';
 
-(function () {
-  /**
-   * List tribes in common between two lists of tribes
-   */
-  angular
-    .module('tribes')
-    .directive('trTribesInCommon', trTribesInCommonDirective);
+/**
+ * List tribes in common between two lists of tribes
+ */
+angular
+  .module('tribes')
+  .directive('trTribesInCommon', trTribesInCommonDirective);
+
+/* @ngInject */
+function trTribesInCommonDirective(Authentication, TribeService) {
+  return {
+    templateUrl,
+    restrict: 'A',
+    replace: true,
+    scope: {
+      trTribesInCommon: '=',
+    },
+    controller: trTribesInCommonController,
+    controllerAs: 'tribesInCommon',
+  };
 
   /* @ngInject */
-  function trTribesInCommonDirective(Authentication, TribeService) {
-    return {
-      templateUrl,
-      restrict: 'A',
-      replace: true,
-      scope: {
-        trTribesInCommon: '=',
-      },
-      controller: trTribesInCommonController,
-      controllerAs: 'tribesInCommon',
-    };
+  function trTribesInCommonController($scope, $state) {
 
-    /* @ngInject */
-    function trTribesInCommonController($scope, $state) {
+    // View Model
+    const vm = this;
 
-      // View Model
-      const vm = this;
+    // Exposed to the view
+    vm.openTribe = openTribe;
+    vm.memberships = [];
 
-      // Exposed to the view
-      vm.openTribe = openTribe;
-      vm.memberships = [];
+    activate();
 
-      activate();
+    /**
+     * Initialize directive controller
+     */
+    function activate() {
+      const tribesInCommon = [];
 
-      /**
-       * Initialize directive controller
-       */
-      function activate() {
-        const tribesInCommon = [];
-
-        // Loop all tribes memberships
-        if (angular.isDefined($scope.trTribesInCommon) &&
-            angular.isArray($scope.trTribesInCommon) &&
-            Authentication.user.memberIds &&
-            Authentication.user.memberIds.length > 0) {
-          angular.forEach($scope.trTribesInCommon, function (membership) {
-            // If authenticated user has it as well, add to list
-            if (membership.tribe && Authentication.user.memberIds.indexOf(membership.tribe._id) > -1) {
-              tribesInCommon.push(membership);
-            }
-          });
-        }
-
-        vm.memberships = tribesInCommon;
+      // Loop all tribes memberships
+      if (angular.isDefined($scope.trTribesInCommon) &&
+          angular.isArray($scope.trTribesInCommon) &&
+          Authentication.user.memberIds &&
+          Authentication.user.memberIds.length > 0) {
+        angular.forEach($scope.trTribesInCommon, function (membership) {
+          // If authenticated user has it as well, add to list
+          if (membership.tribe && Authentication.user.memberIds.indexOf(membership.tribe._id) > -1) {
+            tribesInCommon.push(membership);
+          }
+        });
       }
 
-      /**
-       * Open tribe
-       */
-      function openTribe(tribe) {
-        // Put tribe object to cache to be used after page transition has
-        // finished, thus no need to reload tribe from the API
-        TribeService.fillCache(angular.copy(tribe));
-        $state.go('tribes.tribe', { 'tribe': tribe.slug });
-      }
-
+      vm.memberships = tribesInCommon;
     }
+
+    /**
+     * Open tribe
+     */
+    function openTribe(tribe) {
+      // Put tribe object to cache to be used after page transition has
+      // finished, thus no need to reload tribe from the API
+      TribeService.fillCache(angular.copy(tribe));
+      $state.go('tribes.tribe', { 'tribe': tribe.slug });
+    }
+
   }
-}());
+}

--- a/modules/tribes/client/services/tribe.client.service.js
+++ b/modules/tribes/client/services/tribe.client.service.js
@@ -1,79 +1,77 @@
-(function () {
-  angular
-    .module('tribes')
-    .factory('TribeService', TribeService);
+angular
+  .module('tribes')
+  .factory('TribeService', TribeService);
 
-  /* @ngInject */
-  function TribeService($resource, $q, $log) {
+/* @ngInject */
+function TribeService($resource, $q, $log) {
 
-    // `$resource` to communicate with tribes REST API
-    const Tribe = $resource('/api/tribes/:tribeSlug', {
-      tribeSlug: '@slug',
-    }, {
-      get: {
-        method: 'GET',
-      },
-    });
+  // `$resource` to communicate with tribes REST API
+  const Tribe = $resource('/api/tribes/:tribeSlug', {
+    tribeSlug: '@slug',
+  }, {
+    get: {
+      method: 'GET',
+    },
+  });
 
-    let cachedTribe;
+  let cachedTribe;
 
-    const service = {
-      fillCache: fillCache,
-      clearCache: clearCache,
-      get: get,
-    };
+  const service = {
+    fillCache: fillCache,
+    clearCache: clearCache,
+    get: get,
+  };
 
-    return service;
+  return service;
 
-    /**
-     * Service to store single tribe object for caching
-     * Automatically clears cache on `get()`.
-     */
-    function fillCache(tribe) {
-      if (angular.isUndefined(tribe) || angular.isUndefined(tribe.slug)) {
-        $log.error('Missing tribe to cache.');
-        return;
-      } else {
-        cachedTribe = tribe;
-        cachedTribe.$resolved = true;
-      }
+  /**
+   * Service to store single tribe object for caching
+   * Automatically clears cache on `get()`.
+   */
+  function fillCache(tribe) {
+    if (angular.isUndefined(tribe) || angular.isUndefined(tribe.slug)) {
+      $log.error('Missing tribe to cache.');
+      return;
+    } else {
+      cachedTribe = tribe;
+      cachedTribe.$resolved = true;
     }
-
-    /**
-     * Empty cache
-     */
-    function clearCache() {
-      cachedTribe = undefined;
-    }
-
-    /**
-     * Get tribe
-     * First checks if tribe exists in cache and if not, returns API `$resource` promise
-     * Automatically clears cache after retreiving object from cache
-     */
-    function get(options) {
-      return $q(function (resolve, reject) {
-        if (angular.isUndefined(options) || angular.isUndefined(options.tribeSlug) || !angular.isString(options.tribeSlug)) {
-          $log.error('Missing tribeSlug');
-          reject();
-        } else if (cachedTribe && cachedTribe.slug === options.tribeSlug) {
-          // Found from cache
-          resolve(cachedTribe);
-          clearCache();
-        } else {
-          // Not found from cache, return $resource
-          Tribe.get({
-            tribeSlug: options.tribeSlug,
-          }).$promise
-            .then(function (tribe) {
-              resolve(tribe);
-            })
-            .catch(function () {
-              reject();
-            });
-        }
-      });
-    }
-
   }
-}());
+
+  /**
+   * Empty cache
+   */
+  function clearCache() {
+    cachedTribe = undefined;
+  }
+
+  /**
+   * Get tribe
+   * First checks if tribe exists in cache and if not, returns API `$resource` promise
+   * Automatically clears cache after retreiving object from cache
+   */
+  function get(options) {
+    return $q(function (resolve, reject) {
+      if (angular.isUndefined(options) || angular.isUndefined(options.tribeSlug) || !angular.isString(options.tribeSlug)) {
+        $log.error('Missing tribeSlug');
+        reject();
+      } else if (cachedTribe && cachedTribe.slug === options.tribeSlug) {
+        // Found from cache
+        resolve(cachedTribe);
+        clearCache();
+      } else {
+        // Not found from cache, return $resource
+        Tribe.get({
+          tribeSlug: options.tribeSlug,
+        }).$promise
+          .then(function (tribe) {
+            resolve(tribe);
+          })
+          .catch(function () {
+            reject();
+          });
+      }
+    });
+  }
+
+}

--- a/modules/tribes/client/services/tribes.client.service.js
+++ b/modules/tribes/client/services/tribes.client.service.js
@@ -1,17 +1,15 @@
-(function () {
-  angular
-    .module('tribes')
-    .factory('TribesService', TribesService);
+angular
+  .module('tribes')
+  .factory('TribesService', TribesService);
 
-  /* @ngInject */
-  function TribesService($resource) {
-    return $resource('/api/tribes', {
-      limit: 50,
-    }, {
-      'query': {
-        method: 'GET',
-        isArray: true,
-      },
-    });
-  }
-}());
+/* @ngInject */
+function TribesService($resource) {
+  return $resource('/api/tribes', {
+    limit: 50,
+  }, {
+    'query': {
+      method: 'GET',
+      isArray: true,
+    },
+  });
+}

--- a/modules/users/client/config/users.client.config.js
+++ b/modules/users/client/config/users.client.config.js
@@ -1,35 +1,33 @@
-(function () {
-  angular
-    .module('users')
-    .config(UsersConfig);
+angular
+  .module('users')
+  .config(UsersConfig);
 
-  /* @ngInject */
-  function UsersConfig($httpProvider) {
+/* @ngInject */
+function UsersConfig($httpProvider) {
 
-    // Config HTTP Error Handling
-    // Set the httpProvider "not authorized" interceptor
-    $httpProvider.interceptors.push(['$q', '$location', 'Authentication',
-      function ($q, $location, Authentication) {
-        return {
-          responseError: function (rejection) {
-            if (rejection.config.url.startsWith('/api/')) {
-              switch (rejection.status) {
-                case 401:
-                  // Deauthenticate the global user
-                  Authentication.user = null;
+  // Config HTTP Error Handling
+  // Set the httpProvider "not authorized" interceptor
+  $httpProvider.interceptors.push(['$q', '$location', 'Authentication',
+    function ($q, $location, Authentication) {
+      return {
+        responseError: function (rejection) {
+          if (rejection.config.url.startsWith('/api/')) {
+            switch (rejection.status) {
+              case 401:
+                // Deauthenticate the global user
+                Authentication.user = null;
 
-                  // Redirect to signin page
-                  $location.path('/signin');
-                  break;
-                case 403:
-                  // Add unauthorized behaviour
-                  break;
-              }
+                // Redirect to signin page
+                $location.path('/signin');
+                break;
+              case 403:
+                // Add unauthorized behaviour
+                break;
             }
-            return $q.reject(rejection);
-          },
-        };
-      },
-    ]);
-  }
-}());
+          }
+          return $q.reject(rejection);
+        },
+      };
+    },
+  ]);
+}

--- a/modules/users/client/config/users.client.routes.js
+++ b/modules/users/client/config/users.client.routes.js
@@ -24,389 +24,387 @@ import profileReferencesTemplateUrl from '@/modules/users/client/views/profile/p
 
 import AppConfig from '@/modules/core/client/app/config';
 
-(function () {
-  angular
-    .module('users')
-    .config(UsersRoutes);
+angular
+  .module('users')
+  .config(UsersRoutes);
 
-  /* @ngInject */
-  function UsersRoutes($stateProvider) {
+/* @ngInject */
+function UsersRoutes($stateProvider) {
 
-    $stateProvider.
-      // Invite route deprecated in 11-2018
-      state('invite', {
-        url: '/invite',
-        controller:
-          /* @ngInject */
-          function ($state) {
-            $state.go('signup');
-          },
-        controllerAs: 'invite',
-        requiresAuth: false,
-        data: {
-          pageTitle: 'Signup',
+  $stateProvider.
+    // Invite route deprecated in 11-2018
+    state('invite', {
+      url: '/invite',
+      controller:
+        /* @ngInject */
+        function ($state) {
+          $state.go('signup');
         },
-      }).
-      // Users state routing
-      state('welcome', {
-        url: '/welcome',
-        templateUrl: welcomeTemplateUrl,
-        requiresAuth: true,
-        footerHidden: true,
-        data: {
-          pageTitle: 'Welcome',
-        },
-      }).
+      controllerAs: 'invite',
+      requiresAuth: false,
+      data: {
+        pageTitle: 'Signup',
+      },
+    }).
+    // Users state routing
+    state('welcome', {
+      url: '/welcome',
+      templateUrl: welcomeTemplateUrl,
+      requiresAuth: true,
+      footerHidden: true,
+      data: {
+        pageTitle: 'Welcome',
+      },
+    }).
 
-      state('profile-edit', {
-        url: '/profile/edit',
-        templateUrl: profileEditTemplateUrl,
-        abstract: true,
-        controller: 'ProfileEditController',
-        controllerAs: 'profileEdit',
-      }).
-      state('profile-edit.about', {
-        url: '',
-        templateUrl: profileEditAboutTemplateUrl,
-        controller: 'ProfileEditAboutController',
-        controllerAs: 'profileEditAbout',
-        requiresAuth: true,
-        data: {
-          pageTitle: 'Edit profile',
+    state('profile-edit', {
+      url: '/profile/edit',
+      templateUrl: profileEditTemplateUrl,
+      abstract: true,
+      controller: 'ProfileEditController',
+      controllerAs: 'profileEdit',
+    }).
+    state('profile-edit.about', {
+      url: '',
+      templateUrl: profileEditAboutTemplateUrl,
+      controller: 'ProfileEditAboutController',
+      controllerAs: 'profileEditAbout',
+      requiresAuth: true,
+      data: {
+        pageTitle: 'Edit profile',
+      },
+    }).
+    state('profile-edit.locations', {
+      url: '/locations',
+      templateUrl: profileEditLocationsTemplateUrl,
+      controller: 'ProfileEditLocationsController',
+      controllerAs: 'profileEditLocations',
+      requiresAuth: true,
+      resolve: {
+        // A string value resolves to a service
+        SettingsService: 'SettingsService',
+        appSettings: function (SettingsService) {
+          return SettingsService.get();
         },
-      }).
-      state('profile-edit.locations', {
-        url: '/locations',
-        templateUrl: profileEditLocationsTemplateUrl,
-        controller: 'ProfileEditLocationsController',
-        controllerAs: 'profileEditLocations',
-        requiresAuth: true,
-        resolve: {
-          // A string value resolves to a service
-          SettingsService: 'SettingsService',
-          appSettings: function (SettingsService) {
-            return SettingsService.get();
-          },
+      },
+      data: {
+        pageTitle: 'Edit your locations',
+      },
+    }).
+    state('profile-edit.photo', {
+      url: '/photo',
+      templateUrl: profileEditPhotoTemplateUrl,
+      controller: 'ProfileEditPhotoController',
+      controllerAs: 'profileEditPhoto',
+      requiresAuth: true,
+      resolve: {
+        // A string value resolves to a service
+        SettingsService: 'SettingsService',
+        appSettings: function (SettingsService) {
+          return SettingsService.get();
         },
-        data: {
-          pageTitle: 'Edit your locations',
+      },
+      data: {
+        pageTitle: 'Edit profile photo',
+      },
+    }).
+    state('profile-edit.networks', {
+      url: '/networks',
+      templateUrl: profileEditNetworksTemplateUrl,
+      controller: 'ProfileEditNetworksController',
+      controllerAs: 'profileEditNetworks',
+      requiresAuth: true,
+      data: {
+        pageTitle: 'Edit Profile networks',
+      },
+    }).
+    state('profile-edit.account', {
+      url: '/account',
+      templateUrl: profileEditAccountTemplateUrl,
+      controller: 'ProfileEditAccountController',
+      controllerAs: 'profileEditAccount',
+      requiresAuth: true,
+      data: {
+        pageTitle: 'Account',
+      },
+    }).
+
+    state('profile', {
+      url: '/profile/:username',
+      templateUrl: profileViewClientTemplateUrl,
+      controller: 'ProfileController',
+      controllerAs: 'profileCtrl',
+      requiresAuth: true,
+      abstract: true,
+      resolve: {
+        // A string value resolves to a service
+        UserProfilesService: 'UserProfilesService',
+        ContactByService: 'ContactByService',
+        SettingsService: 'SettingsService',
+        ContactsListService: 'ContactsListService',
+
+        appSettings: function (SettingsService) {
+          return SettingsService.get();
         },
-      }).
-      state('profile-edit.photo', {
-        url: '/photo',
-        templateUrl: profileEditPhotoTemplateUrl,
-        controller: 'ProfileEditPhotoController',
-        controllerAs: 'profileEditPhoto',
-        requiresAuth: true,
-        resolve: {
-          // A string value resolves to a service
-          SettingsService: 'SettingsService',
-          appSettings: function (SettingsService) {
-            return SettingsService.get();
-          },
-        },
-        data: {
-          pageTitle: 'Edit profile photo',
-        },
-      }).
-      state('profile-edit.networks', {
-        url: '/networks',
-        templateUrl: profileEditNetworksTemplateUrl,
-        controller: 'ProfileEditNetworksController',
-        controllerAs: 'profileEditNetworks',
-        requiresAuth: true,
-        data: {
-          pageTitle: 'Edit Profile networks',
-        },
-      }).
-      state('profile-edit.account', {
-        url: '/account',
-        templateUrl: profileEditAccountTemplateUrl,
-        controller: 'ProfileEditAccountController',
-        controllerAs: 'profileEditAccount',
-        requiresAuth: true,
-        data: {
-          pageTitle: 'Account',
-        },
-      }).
 
-      state('profile', {
-        url: '/profile/:username',
-        templateUrl: profileViewClientTemplateUrl,
-        controller: 'ProfileController',
-        controllerAs: 'profileCtrl',
-        requiresAuth: true,
-        abstract: true,
-        resolve: {
-          // A string value resolves to a service
-          UserProfilesService: 'UserProfilesService',
-          ContactByService: 'ContactByService',
-          SettingsService: 'SettingsService',
-          ContactsListService: 'ContactsListService',
+        profile: function (UserProfilesService, $stateParams, $q) {
+          return UserProfilesService.get({
+            username: $stateParams.username,
+          }).$promise
+            .catch(function (e) {
 
-          appSettings: function (SettingsService) {
-            return SettingsService.get();
-          },
-
-          profile: function (UserProfilesService, $stateParams, $q) {
-            return UserProfilesService.get({
-              username: $stateParams.username,
-            }).$promise
-              .catch(function (e) {
-
-                if (e.status === 404) {
-                  // when user was not found, resolving with empty user profile, in order to display the User Not Found error.
-                  return { $promise: $q.resolve({ }), $resolved: true };
-                }
-
-                throw e;
-              });
-          },
-
-          // Contact is loaded only after profile is loaded, because we need the profile ID
-          contact: function (ContactByService, profile, Authentication) {
-            return profile.$promise.then(function (profile) {
-
-              // when user doesn't exist, no need to load contact
-              if (!profile._id) {
-                return;
+              if (e.status === 404) {
+                // when user was not found, resolving with empty user profile, in order to display the User Not Found error.
+                return { $promise: $q.resolve({ }), $resolved: true };
               }
 
-              if (Authentication.user && Authentication.user._id === profile._id) {
-                // No profile found or looking at own profile: no need to load contact
-                return;
-              } else {
-                // Load contact
-                return ContactByService.get({ userId: profile._id });
-              }
-            },
-            // Fetch failures
-            function () {
+              throw e;
+            });
+        },
+
+        // Contact is loaded only after profile is loaded, because we need the profile ID
+        contact: function (ContactByService, profile, Authentication) {
+          return profile.$promise.then(function (profile) {
+
+            // when user doesn't exist, no need to load contact
+            if (!profile._id) {
               return;
-            });
-          },
+            }
 
-          // Contacts list is loaded only after profile is loaded, because we need the profile ID
-          contacts: function (ContactsListService, profile) {
-            return profile.$promise.then(function (profile) {
-
-              // when user doesn't exist, no need to load contacts
-              if (!profile._id) {
-                return;
-              }
-
+            if (Authentication.user && Authentication.user._id === profile._id) {
+              // No profile found or looking at own profile: no need to load contact
+              return;
+            } else {
               // Load contact
-              return ContactsListService.query({
-                listUserId: profile._id,
-              });
+              return ContactByService.get({ userId: profile._id });
+            }
+          },
+          // Fetch failures
+          function () {
+            return;
+          });
+        },
+
+        // Contacts list is loaded only after profile is loaded, because we need the profile ID
+        contacts: function (ContactsListService, profile) {
+          return profile.$promise.then(function (profile) {
+
+            // when user doesn't exist, no need to load contacts
+            if (!profile._id) {
+              return;
+            }
+
+            // Load contact
+            return ContactsListService.query({
+              listUserId: profile._id,
             });
-          },
-
+          });
         },
+
+      },
+      data: {
+        pageTitle: 'Profile',
+      },
+    }).
+    state('profile.about', {
+      url: '',
+      templateUrl: profileViewAboutTemplateUrl,
+      requiresAuth: true,
+      noScrollingTop: true,
+      data: {
+        pageTitle: 'Profile',
+      },
+    }).
+    state('profile.accommodation', {
+      url: '/accommodation',
+      templateUrl: profileviewAccommodationTemplateUrl,
+      requiresAuth: true,
+      noScrollingTop: true,
+      data: {
+        pageTitle: 'Profile accommodation',
+      },
+    }).
+    state('profile.overview', {
+      url: '/overview',
+      templateUrl: profileViewBasicsTemplateUrl,
+      requiresAuth: true,
+      noScrollingTop: true,
+      data: {
+        pageTitle: 'Profile overview',
+      },
+    }).
+    state('profile.contacts', {
+      url: '/contacts',
+      template: '<contact-list onContactRemoved="profileCtrl.removeContact" appUser="app.user" contacts="profileCtrl.contacts"></contact-list>',
+      requiresAuth: true,
+      noScrollingTop: true,
+      data: {
+        pageTitle: 'Profile contacts',
+      },
+    }).
+    state('profile.tribes', {
+      url: '/tribes',
+      templateUrl: profileViewTribesTemplateUrl,
+      requiresAuth: true,
+      noScrollingTop: true,
+      data: {
+        pageTitle: 'Profile tribes',
+      },
+    }).
+
+    // When attempting to look at profile as non-authenticated user
+    state('profile-signup', {
+      url: '/profile-signup',
+      templateUrl: profileSignupTemplateUrl,
+      data: {
+        pageTitle: 'Trustroots profile',
+      },
+    }).
+
+    // Auth routes
+    state('signup', {
+      // `tribe`: preload tribe in suggested tribes list
+      // `code`: prefill invite code
+      // `mwr` used by Matre app if invite list is enabled
+      url: '/signup?tribe&code&mwr',
+      templateUrl: signupTemplateUrl,
+      controller: 'SignupController',
+      controllerAs: 'signup',
+      headerHidden: true,
+      footerHidden: true,
+      // Don't reload ngView when URL parameters are changed
+      reloadOnSearch: false,
+      resolve: {
+        // A string value resolves to a service
+        SettingsService: 'SettingsService',
+
+        appSettings: function (SettingsService) {
+          return SettingsService.get();
+        },
+      },
+      data: {
+        pageTitle: 'Sign up',
+      },
+    }).
+    state('signin', {
+      url: '/signin?continue',
+      templateUrl: signinTemplateUrl,
+      controller: 'AuthenticationController',
+      controllerAs: 'auth',
+      headerHidden: true,
+      footerHidden: true,
+      resolve: {
+        // A string value resolves to a service
+        SettingsService: 'SettingsService',
+
+        appSettings: function (SettingsService) {
+          return SettingsService.get();
+        },
+      },
+      data: {
+        pageTitle: 'Sign in',
+      },
+    }).
+    state('confirm-email', {
+      url: '/confirm-email/:token?signup',
+      templateUrl: confirmTemplateUrl,
+      requiresAuth: false,
+      controller: 'ConfirmEmailController',
+      controllerAs: 'confirmEmail',
+      data: {
+        pageTitle: 'Confirm email',
+      },
+    }).
+    state('confirm-email-invalid', {
+      url: '/confirm-email-invalid',
+      templateUrl: confirmInvalidTemplateUrl,
+      requiresAuth: false,
+      data: {
+        pageTitle: 'Confirm email invalid',
+      },
+    }).
+
+    // Password reset
+    state('forgot', {
+      url: '/password/forgot?userhandle=',
+      templateUrl: forgotPasswordTemplateUrl,
+      controller: 'ForgotPasswordController',
+      controllerAs: 'forgotPassword',
+      footerHidden: true,
+      data: {
+        pageTitle: 'Reset password',
+      },
+    }).
+    state('reset-invalid', {
+      url: '/password/reset/invalid',
+      templateUrl: resetPasswordInvalidTemplateUrl,
+      footerHidden: true,
+      data: {
+        pageTitle: 'Reset password',
+      },
+    }).
+    state('reset-success', {
+      url: '/password/reset/success',
+      templateUrl: resetPasswordSuccessTemplateUrl,
+      footerHidden: true,
+      data: {
+        pageTitle: 'Reset password',
+      },
+    }).
+    state('reset', {
+      url: '/password/reset/:token',
+      templateUrl: resetPasswordTemplateUrl,
+      footerHidden: true,
+      controller: 'ResetPasswordController',
+      controllerAs: 'resetPassword',
+      data: {
+        pageTitle: 'Reset password',
+      },
+    }).
+
+    // Profile removal
+    state('remove', {
+      url: '/remove/:token',
+      templateUrl: profileRemoveTemplateUrl,
+      footerHidden: true,
+      headerHidden: true,
+      requiresAuth: true,
+      controller: 'RemoveProfileController',
+      controllerAs: 'removeProfile',
+      data: {
+        pageTitle: 'Remove profile',
+      },
+    });
+
+  if (AppConfig.appEnv !== 'production') {
+    $stateProvider.
+      state('profile.references', {
+        url: '/references',
+        templateUrl: profileReferencesTemplateUrl,
+        requiresAuth: true,
+        noScrollingTop: true,
+        abstract: true,
         data: {
-          pageTitle: 'Profile',
+          pageTitle: 'Profile references',
         },
       }).
-      state('profile.about', {
+      state('profile.references.list', {
         url: '',
-        templateUrl: profileViewAboutTemplateUrl,
+        template: '',
         requiresAuth: true,
         noScrollingTop: true,
         data: {
-          pageTitle: 'Profile',
+          pageTitle: 'Profile references',
         },
       }).
-      state('profile.accommodation', {
-        url: '/accommodation',
-        templateUrl: profileviewAccommodationTemplateUrl,
+      state('profile.references.new', {
+        url: '/new',
+        template: '<create-reference userTo="profileCtrl.profile" userFrom="app.user"></create-reference>',
         requiresAuth: true,
         noScrollingTop: true,
         data: {
-          pageTitle: 'Profile accommodation',
-        },
-      }).
-      state('profile.overview', {
-        url: '/overview',
-        templateUrl: profileViewBasicsTemplateUrl,
-        requiresAuth: true,
-        noScrollingTop: true,
-        data: {
-          pageTitle: 'Profile overview',
-        },
-      }).
-      state('profile.contacts', {
-        url: '/contacts',
-        template: '<contact-list onContactRemoved="profileCtrl.removeContact" appUser="app.user" contacts="profileCtrl.contacts"></contact-list>',
-        requiresAuth: true,
-        noScrollingTop: true,
-        data: {
-          pageTitle: 'Profile contacts',
-        },
-      }).
-      state('profile.tribes', {
-        url: '/tribes',
-        templateUrl: profileViewTribesTemplateUrl,
-        requiresAuth: true,
-        noScrollingTop: true,
-        data: {
-          pageTitle: 'Profile tribes',
-        },
-      }).
-
-      // When attempting to look at profile as non-authenticated user
-      state('profile-signup', {
-        url: '/profile-signup',
-        templateUrl: profileSignupTemplateUrl,
-        data: {
-          pageTitle: 'Trustroots profile',
-        },
-      }).
-
-      // Auth routes
-      state('signup', {
-        // `tribe`: preload tribe in suggested tribes list
-        // `code`: prefill invite code
-        // `mwr` used by Matre app if invite list is enabled
-        url: '/signup?tribe&code&mwr',
-        templateUrl: signupTemplateUrl,
-        controller: 'SignupController',
-        controllerAs: 'signup',
-        headerHidden: true,
-        footerHidden: true,
-        // Don't reload ngView when URL parameters are changed
-        reloadOnSearch: false,
-        resolve: {
-          // A string value resolves to a service
-          SettingsService: 'SettingsService',
-
-          appSettings: function (SettingsService) {
-            return SettingsService.get();
-          },
-        },
-        data: {
-          pageTitle: 'Sign up',
-        },
-      }).
-      state('signin', {
-        url: '/signin?continue',
-        templateUrl: signinTemplateUrl,
-        controller: 'AuthenticationController',
-        controllerAs: 'auth',
-        headerHidden: true,
-        footerHidden: true,
-        resolve: {
-          // A string value resolves to a service
-          SettingsService: 'SettingsService',
-
-          appSettings: function (SettingsService) {
-            return SettingsService.get();
-          },
-        },
-        data: {
-          pageTitle: 'Sign in',
-        },
-      }).
-      state('confirm-email', {
-        url: '/confirm-email/:token?signup',
-        templateUrl: confirmTemplateUrl,
-        requiresAuth: false,
-        controller: 'ConfirmEmailController',
-        controllerAs: 'confirmEmail',
-        data: {
-          pageTitle: 'Confirm email',
-        },
-      }).
-      state('confirm-email-invalid', {
-        url: '/confirm-email-invalid',
-        templateUrl: confirmInvalidTemplateUrl,
-        requiresAuth: false,
-        data: {
-          pageTitle: 'Confirm email invalid',
-        },
-      }).
-
-      // Password reset
-      state('forgot', {
-        url: '/password/forgot?userhandle=',
-        templateUrl: forgotPasswordTemplateUrl,
-        controller: 'ForgotPasswordController',
-        controllerAs: 'forgotPassword',
-        footerHidden: true,
-        data: {
-          pageTitle: 'Reset password',
-        },
-      }).
-      state('reset-invalid', {
-        url: '/password/reset/invalid',
-        templateUrl: resetPasswordInvalidTemplateUrl,
-        footerHidden: true,
-        data: {
-          pageTitle: 'Reset password',
-        },
-      }).
-      state('reset-success', {
-        url: '/password/reset/success',
-        templateUrl: resetPasswordSuccessTemplateUrl,
-        footerHidden: true,
-        data: {
-          pageTitle: 'Reset password',
-        },
-      }).
-      state('reset', {
-        url: '/password/reset/:token',
-        templateUrl: resetPasswordTemplateUrl,
-        footerHidden: true,
-        controller: 'ResetPasswordController',
-        controllerAs: 'resetPassword',
-        data: {
-          pageTitle: 'Reset password',
-        },
-      }).
-
-      // Profile removal
-      state('remove', {
-        url: '/remove/:token',
-        templateUrl: profileRemoveTemplateUrl,
-        footerHidden: true,
-        headerHidden: true,
-        requiresAuth: true,
-        controller: 'RemoveProfileController',
-        controllerAs: 'removeProfile',
-        data: {
-          pageTitle: 'Remove profile',
+          pageTitle: 'Leave a reference',
         },
       });
-
-    if (AppConfig.appEnv !== 'production') {
-      $stateProvider.
-        state('profile.references', {
-          url: '/references',
-          templateUrl: profileReferencesTemplateUrl,
-          requiresAuth: true,
-          noScrollingTop: true,
-          abstract: true,
-          data: {
-            pageTitle: 'Profile references',
-          },
-        }).
-        state('profile.references.list', {
-          url: '',
-          template: '',
-          requiresAuth: true,
-          noScrollingTop: true,
-          data: {
-            pageTitle: 'Profile references',
-          },
-        }).
-        state('profile.references.new', {
-          url: '/new',
-          template: '<create-reference userTo="profileCtrl.profile" userFrom="app.user"></create-reference>',
-          requiresAuth: true,
-          noScrollingTop: true,
-          data: {
-            pageTitle: 'Leave a reference',
-          },
-        });
-    }
   }
-}());
+}

--- a/modules/users/client/controllers/authentication.client.controller.js
+++ b/modules/users/client/controllers/authentication.client.controller.js
@@ -1,84 +1,82 @@
-(function () {
-  angular
-    .module('users')
-    .controller('AuthenticationController', AuthenticationController);
+angular
+  .module('users')
+  .controller('AuthenticationController', AuthenticationController);
 
-  /* @ngInject */
-  function AuthenticationController($scope, $rootScope, $http, $state, $stateParams, $analytics, Authentication, messageCenterService, Facebook, push, trNativeAppBridge) {
+/* @ngInject */
+function AuthenticationController($scope, $rootScope, $http, $state, $stateParams, $analytics, Authentication, messageCenterService, Facebook, push, trNativeAppBridge) {
 
-    // If user is already signed in then redirect to search page
-    if (Authentication.user) {
-      $state.go('search.map');
-      return;
-    }
-
-    // View Model
-    const vm = this;
-
-    // Exposed to the view
-    vm.signin = signin;
-    vm.continue = ($stateParams.continue);
-    vm.isLoading = false;
-    vm.authError = false;
-
-    /**
-     * Sign in
-     */
-    function signin() {
-      vm.isLoading = true;
-
-      $http.post('/api/auth/signin', vm.credentials)
-        .then(
-          function (response) { // On success function
-            vm.isLoading = false;
-
-            // If successful we assign the data to the global user model
-            Authentication.user = response.data;
-            $scope.$emit('userUpdated');
-
-            // Attach user to $analytics calls from now on
-            $analytics.setUsername(Authentication.user._id);
-
-            $analytics.eventTrack('login.success', {
-              category: 'authentication',
-              label: 'Login success',
-            });
-
-            // Initialize FB SDK
-            Facebook.init();
-
-            // Initialize the push service if available
-            // It will check if user intended to enable push for this browser
-            // and setup the service-worker and backend registration accordingly
-            push.init();
-
-            // Signal native mobile app we've authenticated
-            trNativeAppBridge.signalAuthenticated();
-
-            // Redirect to where we were left off before sign-in page
-            // See modules/core/client/controllers/main.client.controller.js
-            if (vm.continue) {
-              const stateTo = $rootScope.signinState || 'search';
-              const stateToParams = $rootScope.signinStateParams || {};
-              delete $rootScope.signinState;
-              delete $rootScope.signinStateParams;
-              $state.go(stateTo, stateToParams);
-            } else {
-              // Redirect to the search page
-              $state.go('search.map');
-            }
-          },
-          function (error) { // On error function
-            vm.isLoading = false;
-            vm.authError = true;
-            messageCenterService.add('danger', error.data.message || 'Something went wrong.');
-            $analytics.eventTrack('login.failed', {
-              category: 'authentication',
-              label: 'Login failed',
-            });
-          },
-        );
-    }
-
+  // If user is already signed in then redirect to search page
+  if (Authentication.user) {
+    $state.go('search.map');
+    return;
   }
-}());
+
+  // View Model
+  const vm = this;
+
+  // Exposed to the view
+  vm.signin = signin;
+  vm.continue = ($stateParams.continue);
+  vm.isLoading = false;
+  vm.authError = false;
+
+  /**
+   * Sign in
+   */
+  function signin() {
+    vm.isLoading = true;
+
+    $http.post('/api/auth/signin', vm.credentials)
+      .then(
+        function (response) { // On success function
+          vm.isLoading = false;
+
+          // If successful we assign the data to the global user model
+          Authentication.user = response.data;
+          $scope.$emit('userUpdated');
+
+          // Attach user to $analytics calls from now on
+          $analytics.setUsername(Authentication.user._id);
+
+          $analytics.eventTrack('login.success', {
+            category: 'authentication',
+            label: 'Login success',
+          });
+
+          // Initialize FB SDK
+          Facebook.init();
+
+          // Initialize the push service if available
+          // It will check if user intended to enable push for this browser
+          // and setup the service-worker and backend registration accordingly
+          push.init();
+
+          // Signal native mobile app we've authenticated
+          trNativeAppBridge.signalAuthenticated();
+
+          // Redirect to where we were left off before sign-in page
+          // See modules/core/client/controllers/main.client.controller.js
+          if (vm.continue) {
+            const stateTo = $rootScope.signinState || 'search';
+            const stateToParams = $rootScope.signinStateParams || {};
+            delete $rootScope.signinState;
+            delete $rootScope.signinStateParams;
+            $state.go(stateTo, stateToParams);
+          } else {
+            // Redirect to the search page
+            $state.go('search.map');
+          }
+        },
+        function (error) { // On error function
+          vm.isLoading = false;
+          vm.authError = true;
+          messageCenterService.add('danger', error.data.message || 'Something went wrong.');
+          $analytics.eventTrack('login.failed', {
+            category: 'authentication',
+            label: 'Login failed',
+          });
+        },
+      );
+  }
+
+}

--- a/modules/users/client/controllers/avatar-editor.client.controller.js
+++ b/modules/users/client/controllers/avatar-editor.client.controller.js
@@ -1,112 +1,110 @@
-(function () {
-  angular
-    .module('users')
-    .controller('AvatarEditorController', AvatarEditorController);
+angular
+  .module('users')
+  .controller('AvatarEditorController', AvatarEditorController);
 
-  /* @ngInject */
-  function AvatarEditorController($scope, $uibModalInstance, Upload, messageCenterService, user, appSettings) {
+/* @ngInject */
+function AvatarEditorController($scope, $uibModalInstance, Upload, messageCenterService, user, appSettings) {
 
-    const lastAvatarSource = user.avatarSource;
-    let fileAvatar = {};
+  const lastAvatarSource = user.avatarSource;
+  let fileAvatar = {};
 
-    // View model
-    const vm = this;
+  // View model
+  const vm = this;
 
-    // Exposed to the view
-    vm.user = user;
-    vm.avatarPreview = false;
-    vm.dismissModal = dismissModal;
-    vm.saveAvatar = saveAvatar;
-    vm.fileSelected = fileSelected;
+  // Exposed to the view
+  vm.user = user;
+  vm.avatarPreview = false;
+  vm.dismissModal = dismissModal;
+  vm.saveAvatar = saveAvatar;
+  vm.fileSelected = fileSelected;
 
-    /**
-     * Dismiss modal
-     */
-    function dismissModal() {
-      $uibModalInstance.dismiss('cancel');
+  /**
+   * Dismiss modal
+   */
+  function dismissModal() {
+    $uibModalInstance.dismiss('cancel');
+  }
+
+  /**
+   * Save avatar changes
+   */
+  function saveAvatar() {
+
+    // Uploaded new file
+    if (vm.user.avatarSource === 'local' && vm.avatarPreview === true) {
+      // Upload the new file
+      vm.avatarUploading = true;
+      vm.upload = Upload.upload({
+        url: '/api/users-avatar',
+        method: 'POST',
+        headers: {
+          'Content-Type': (fileAvatar.type !== '' ? fileAvatar.type : 'application/octet-stream'),
+        },
+        data: {
+          avatar: fileAvatar,
+        },
+      }).success(function () {
+        vm.avatarUploading = false;
+        $uibModalInstance.close(vm.user);
+      }).error(function () {
+        messageCenterService.add('danger', 'Oops! Something went wrong. Try again later.');
+        vm.avatarUploading = false;
+      });
+    } else if (lastAvatarSource !== vm.user.avatarSource) {
+      // Close modal due user changed avatar selection (but didn't upload a new file)
+      $uibModalInstance.close(vm.user);
+    } else {
+      // No changes, just dismiss...
+      dismissModal();
+    }
+  }
+
+  /**
+   * Process preview after file is selected via fileinput / dropped to window / received from camera
+   */
+  function fileSelected($files) {
+    // Too early
+    if ($files && $files.length === 0) {
+      return;
     }
 
-    /**
-     * Save avatar changes
-     */
-    function saveAvatar() {
+    // Accept only one file at once
+    const file = $files[0];
+    fileAvatar = file;
+    vm.user.avatarSource = 'local';
 
-      // Uploaded new file
-      if (vm.user.avatarSource === 'local' && vm.avatarPreview === true) {
-        // Upload the new file
-        vm.avatarUploading = true;
-        vm.upload = Upload.upload({
-          url: '/api/users-avatar',
-          method: 'POST',
-          headers: {
-            'Content-Type': (fileAvatar.type !== '' ? fileAvatar.type : 'application/octet-stream'),
-          },
-          data: {
-            avatar: fileAvatar,
-          },
-        }).success(function () {
-          vm.avatarUploading = false;
-          $uibModalInstance.close(vm.user);
-        }).error(function () {
-          messageCenterService.add('danger', 'Oops! Something went wrong. Try again later.');
+    // Validate file
+    if (file.type.indexOf('jpeg') === -1 && file.type.indexOf('gif') === -1 && file.type.indexOf('png') === -1) {
+      messageCenterService.add('danger', 'Please give a jpg, gif, or png image.');
+    } else if (file.size > appSettings.maxUploadSize) {
+      messageCenterService.add('danger', 'Whoops, your file is too big. Please keep it up to ' + bytesToSize(appSettings.maxUploadSize) + '. Sorry!');
+    } else {
+      vm.avatarUploading = true;
+
+      // Show the local file as a preview
+      const fileReader = new FileReader();
+      fileReader.readAsDataURL(file);
+      fileReader.onloadend = function () {
+        vm.avatarPreview = true;
+        $scope.$apply(function () {
+          vm.previewStyle = fileReader.result;
           vm.avatarUploading = false;
         });
-      } else if (lastAvatarSource !== vm.user.avatarSource) {
-        // Close modal due user changed avatar selection (but didn't upload a new file)
-        $uibModalInstance.close(vm.user);
-      } else {
-        // No changes, just dismiss...
-        dismissModal();
-      }
+      };
     }
-
-    /**
-     * Process preview after file is selected via fileinput / dropped to window / received from camera
-     */
-    function fileSelected($files) {
-      // Too early
-      if ($files && $files.length === 0) {
-        return;
-      }
-
-      // Accept only one file at once
-      const file = $files[0];
-      fileAvatar = file;
-      vm.user.avatarSource = 'local';
-
-      // Validate file
-      if (file.type.indexOf('jpeg') === -1 && file.type.indexOf('gif') === -1 && file.type.indexOf('png') === -1) {
-        messageCenterService.add('danger', 'Please give a jpg, gif, or png image.');
-      } else if (file.size > appSettings.maxUploadSize) {
-        messageCenterService.add('danger', 'Whoops, your file is too big. Please keep it up to ' + bytesToSize(appSettings.maxUploadSize) + '. Sorry!');
-      } else {
-        vm.avatarUploading = true;
-
-        // Show the local file as a preview
-        const fileReader = new FileReader();
-        fileReader.readAsDataURL(file);
-        fileReader.onloadend = function () {
-          vm.avatarPreview = true;
-          $scope.$apply(function () {
-            vm.previewStyle = fileReader.result;
-            vm.avatarUploading = false;
-          });
-        };
-      }
-    }
-
-    /**
-     * Return bytes in human readable size.
-     * E.g. bytesToSize(10000000) => "10 MB"
-     *
-     * @link http://stackoverflow.com/a/18650828
-     */
-    function bytesToSize(bytes) {
-      const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
-      if (bytes === 0) return '0 Byte';
-      const i = parseInt(Math.floor(Math.log(bytes) / Math.log(1024)), 10);
-      return Math.round(bytes / Math.pow(1024, i), 2) + ' ' + sizes[i];
-    }
-
   }
-}());
+
+  /**
+   * Return bytes in human readable size.
+   * E.g. bytesToSize(10000000) => "10 MB"
+   *
+   * @link http://stackoverflow.com/a/18650828
+   */
+  function bytesToSize(bytes) {
+    const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+    if (bytes === 0) return '0 Byte';
+    const i = parseInt(Math.floor(Math.log(bytes) / Math.log(1024)), 10);
+    return Math.round(bytes / Math.pow(1024, i), 2) + ' ' + sizes[i];
+  }
+
+}

--- a/modules/users/client/controllers/confirm-email.client.controller.js
+++ b/modules/users/client/controllers/confirm-email.client.controller.js
@@ -1,63 +1,61 @@
-(function () {
-  angular
-    .module('users')
-    .controller('ConfirmEmailController', ConfirmEmailController);
+angular
+  .module('users')
+  .controller('ConfirmEmailController', ConfirmEmailController);
 
-  function getEmailFromToken(token) {
-    // old tokens have lenght 40 symbols. pullrequest #465
-    if (token.length <= 40) {
-      return null;
-    }
-    let str = '';
-    for (let i = 40; i < token.length; i += 2) {
-      str += String.fromCharCode(parseInt(token.substr(i, 2), 16));
-    }
-    return str;
+function getEmailFromToken(token) {
+  // old tokens have lenght 40 symbols. pullrequest #465
+  if (token.length <= 40) {
+    return null;
+  }
+  let str = '';
+  for (let i = 40; i < token.length; i += 2) {
+    str += String.fromCharCode(parseInt(token.substr(i, 2), 16));
+  }
+  return str;
+}
+
+/* @ngInject */
+function ConfirmEmailController($rootScope, $http, $state, $stateParams, Authentication) {
+
+  // ViewModel
+  const vm = this;
+
+  // Exposed to the view
+  vm.confirmEmail = confirmEmail;
+  vm.success = null;
+  vm.error = null;
+  vm.isLoading = false;
+  vm.email = getEmailFromToken($stateParams.token);
+
+  // Is ?signup at the url (set only for first email confirms)
+  vm.signup = angular.isDefined($stateParams.signup);
+
+  // Change user password
+  function confirmEmail() {
+    vm.isLoading = true;
+    vm.success = vm.error = null;
+
+    $http.post('/api/auth/confirm-email/' + $stateParams.token)
+      .then(
+        function (response) { // On success function
+
+          // Attach user profile
+          Authentication.user = response.data.user;
+          $rootScope.$broadcast('userUpdated');
+
+          if (response.data.profileMadePublic) {
+            // If successful and this was user's first confirm, welcome them to the community
+            $state.go('welcome');
+          } else {
+          // If succesfull and wasn't first time, say yay!
+            vm.success = true;
+          }
+
+        },
+        function () { // On error function
+          vm.error = true;
+        },
+      );
   }
 
-  /* @ngInject */
-  function ConfirmEmailController($rootScope, $http, $state, $stateParams, Authentication) {
-
-    // ViewModel
-    const vm = this;
-
-    // Exposed to the view
-    vm.confirmEmail = confirmEmail;
-    vm.success = null;
-    vm.error = null;
-    vm.isLoading = false;
-    vm.email = getEmailFromToken($stateParams.token);
-
-    // Is ?signup at the url (set only for first email confirms)
-    vm.signup = angular.isDefined($stateParams.signup);
-
-    // Change user password
-    function confirmEmail() {
-      vm.isLoading = true;
-      vm.success = vm.error = null;
-
-      $http.post('/api/auth/confirm-email/' + $stateParams.token)
-        .then(
-          function (response) { // On success function
-
-            // Attach user profile
-            Authentication.user = response.data.user;
-            $rootScope.$broadcast('userUpdated');
-
-            if (response.data.profileMadePublic) {
-              // If successful and this was user's first confirm, welcome them to the community
-              $state.go('welcome');
-            } else {
-            // If succesfull and wasn't first time, say yay!
-              vm.success = true;
-            }
-
-          },
-          function () { // On error function
-            vm.error = true;
-          },
-        );
-    }
-
-  }
-}());
+}

--- a/modules/users/client/controllers/password-forgot.client.controller.js
+++ b/modules/users/client/controllers/password-forgot.client.controller.js
@@ -1,42 +1,40 @@
-(function () {
-  angular
-    .module('users')
-    .controller('ForgotPasswordController', ForgotPasswordController);
+angular
+  .module('users')
+  .controller('ForgotPasswordController', ForgotPasswordController);
 
-  /* @ngInject */
-  function ForgotPasswordController($http, $stateParams) {
+/* @ngInject */
+function ForgotPasswordController($http, $stateParams) {
 
-    // ViewModel
-    const vm = this;
+  // ViewModel
+  const vm = this;
 
-    // Exposed to the view
-    vm.success = null;
-    vm.error = null;
-    vm.isLoading = false;
-    vm.credentials = {
-      // Prefill input from URL if available
-      username: $stateParams.userhandle ? $stateParams.userhandle : '',
-    };
-    vm.askForPasswordReset = askForPasswordReset;
+  // Exposed to the view
+  vm.success = null;
+  vm.error = null;
+  vm.isLoading = false;
+  vm.credentials = {
+    // Prefill input from URL if available
+    username: $stateParams.userhandle ? $stateParams.userhandle : '',
+  };
+  vm.askForPasswordReset = askForPasswordReset;
 
-    // Submit forgotten password account id
-    function askForPasswordReset() {
-      vm.success = vm.error = null;
-      vm.isLoading = true;
-      $http.post('/api/auth/forgot', vm.credentials)
-        .then(
-          function (response) { // On success function
-          // Show user success message and clear form
-            vm.credentials = null;
-            vm.success = response.data.message;
-            vm.isLoading = false;
-          },
-          function (response) { // On error function
-          // Show user error message
-            vm.isLoading = false;
-            vm.error = response.data.message;
-          },
-        );
-    }
+  // Submit forgotten password account id
+  function askForPasswordReset() {
+    vm.success = vm.error = null;
+    vm.isLoading = true;
+    $http.post('/api/auth/forgot', vm.credentials)
+      .then(
+        function (response) { // On success function
+        // Show user success message and clear form
+          vm.credentials = null;
+          vm.success = response.data.message;
+          vm.isLoading = false;
+        },
+        function (response) { // On error function
+        // Show user error message
+          vm.isLoading = false;
+          vm.error = response.data.message;
+        },
+      );
   }
-}());
+}

--- a/modules/users/client/controllers/password-reset.client.controller.js
+++ b/modules/users/client/controllers/password-reset.client.controller.js
@@ -1,45 +1,43 @@
-(function () {
-  angular
-    .module('users')
-    .controller('ResetPasswordController', ResetPasswordController);
+angular
+  .module('users')
+  .controller('ResetPasswordController', ResetPasswordController);
 
-  /* @ngInject */
-  function ResetPasswordController($rootScope, $stateParams, $http, $state, Authentication) {
+/* @ngInject */
+function ResetPasswordController($rootScope, $stateParams, $http, $state, Authentication) {
 
-    // ViewModel
-    const vm = this;
+  // ViewModel
+  const vm = this;
 
-    // Exposed to the view
+  // Exposed to the view
+  vm.error = null;
+  vm.isLoading = false;
+  vm.passwordDetails = null;
+  vm.resetUserPassword = resetUserPassword;
+
+  // Change user password
+  function resetUserPassword() {
     vm.error = null;
-    vm.isLoading = false;
-    vm.passwordDetails = null;
-    vm.resetUserPassword = resetUserPassword;
+    vm.isLoading = true;
 
-    // Change user password
-    function resetUserPassword() {
-      vm.error = null;
-      vm.isLoading = true;
+    $http.post('/api/auth/reset/' + $stateParams.token, vm.passwordDetails)
+      .then(
+        function (response) { // On success function
+        // Clear form
+          vm.passwordDetails = null;
 
-      $http.post('/api/auth/reset/' + $stateParams.token, vm.passwordDetails)
-        .then(
-          function (response) { // On success function
-          // Clear form
-            vm.passwordDetails = null;
+          // Attach user profile
+          Authentication.user = response.data;
 
-            // Attach user profile
-            Authentication.user = response.data;
+          // Notify app
+          $rootScope.$broadcast('userUpdated');
 
-            // Notify app
-            $rootScope.$broadcast('userUpdated');
-
-            // And redirect to the success page
-            $state.go('reset-success');
-          },
-          function (response) { // On error function
-            vm.error = response.data.message;
-            vm.isLoading = false;
-          },
-        );
-    }
+          // And redirect to the success page
+          $state.go('reset-success');
+        },
+        function (response) { // On error function
+          vm.error = response.data.message;
+          vm.isLoading = false;
+        },
+      );
   }
-}());
+}

--- a/modules/users/client/controllers/profile-edit-about.client.controller.js
+++ b/modules/users/client/controllers/profile-edit-about.client.controller.js
@@ -1,46 +1,44 @@
-(function () {
-  angular
-    .module('users')
-    .controller('ProfileEditAboutController', ProfileEditAboutController);
+angular
+  .module('users')
+  .controller('ProfileEditAboutController', ProfileEditAboutController);
 
-  /* @ngInject */
-  function ProfileEditAboutController($scope, $state, Users, Authentication, messageCenterService) {
+/* @ngInject */
+function ProfileEditAboutController($scope, $state, Users, Authentication, messageCenterService) {
 
-    // ViewModel
-    const vm = this;
+  // ViewModel
+  const vm = this;
 
-    // Copy user to make a temporary buffer for changes.
-    // Prevents changes remaining here when cancelling profile editing.
-    vm.user = new Users(Authentication.user);
+  // Copy user to make a temporary buffer for changes.
+  // Prevents changes remaining here when cancelling profile editing.
+  vm.user = new Users(Authentication.user);
 
-    // Exposed to view
-    vm.updateUserProfile = updateUserProfile;
+  // Exposed to view
+  vm.updateUserProfile = updateUserProfile;
 
-    // Get profile URL, i.e. `www.trustroots.org/profile/username`
-    // - Remove `http(s)://`
-    // - Highlight username part
-    vm.profileURL = $state
-      .href('profile', { username: vm.user.username }, { absolute: true })
-      .replace(/^(https?):\/\//, '')
-      .replace(vm.user.username, '<strong>' + vm.user.username + '</strong>');
+  // Get profile URL, i.e. `www.trustroots.org/profile/username`
+  // - Remove `http(s)://`
+  // - Highlight username part
+  vm.profileURL = $state
+    .href('profile', { username: vm.user.username }, { absolute: true })
+    .replace(/^(https?):\/\//, '')
+    .replace(vm.user.username, '<strong>' + vm.user.username + '</strong>');
 
-    /**
-     * Update a user profile
-     */
-    function updateUserProfile(isValid) {
-      if (isValid) {
-        vm.user.$update(function (response) {
-          Authentication.user = response;
-          $scope.$emit('userUpdated');
-          messageCenterService.add('success', 'Profile updated.');
-        }, function (response) {
-          messageCenterService.add('danger', response.data.message || 'Something went wrong. Please try again!', { timeout: 10000 });
-        });
-      } else {
-        messageCenterService.add('danger', 'Please fix errors from your profile and try again.', { timeout: 10000 });
-      }
+  /**
+   * Update a user profile
+   */
+  function updateUserProfile(isValid) {
+    if (isValid) {
+      vm.user.$update(function (response) {
+        Authentication.user = response;
+        $scope.$emit('userUpdated');
+        messageCenterService.add('success', 'Profile updated.');
+      }, function (response) {
+        messageCenterService.add('danger', response.data.message || 'Something went wrong. Please try again!', { timeout: 10000 });
+      });
+    } else {
+      messageCenterService.add('danger', 'Please fix errors from your profile and try again.', { timeout: 10000 });
     }
-
-
   }
-}());
+
+
+}

--- a/modules/users/client/controllers/profile-edit-account.client.controller.js
+++ b/modules/users/client/controllers/profile-edit-account.client.controller.js
@@ -1,229 +1,227 @@
-(function () {
-  angular
-    .module('users')
-    .controller('ProfileEditAccountController', ProfileEditAccountController);
+angular
+  .module('users')
+  .controller('ProfileEditAccountController', ProfileEditAccountController);
 
-  /* @ngInject */
-  function ProfileEditAccountController(
-    $http, Users, Authentication, messageCenterService, push, $scope, trNativeAppBridge) {
+/* @ngInject */
+function ProfileEditAccountController(
+  $http, Users, Authentication, messageCenterService, push, $scope, trNativeAppBridge) {
 
-    // ViewModel
-    const vm = this;
+  // ViewModel
+  const vm = this;
 
-    // Exposed
-    vm.updateUsername = updateUsername;
-    vm.updateUserEmail = updateUserEmail;
-    vm.resendUserEmailConfirm = resendUserEmailConfirm;
-    vm.updateUserSubscriptions = updateUserSubscriptions;
-    vm.updatingUserSubscriptions = false;
-    vm.changeUserPassword = changeUserPassword;
-    vm.user = Authentication.user;
-    vm.getUsernameValidationError = getUsernameValidationError;
+  // Exposed
+  vm.updateUsername = updateUsername;
+  vm.updateUserEmail = updateUserEmail;
+  vm.resendUserEmailConfirm = resendUserEmailConfirm;
+  vm.updateUserSubscriptions = updateUserSubscriptions;
+  vm.updatingUserSubscriptions = false;
+  vm.changeUserPassword = changeUserPassword;
+  vm.user = Authentication.user;
+  vm.getUsernameValidationError = getUsernameValidationError;
 
-    // Related to profile removal
-    vm.removeProfileConfirm = false;
-    vm.removeProfileLoading = false;
-    vm.removeProfileInitialized = '';
-    vm.removeProfile = removeProfile;
+  // Related to profile removal
+  vm.removeProfileConfirm = false;
+  vm.removeProfileLoading = false;
+  vm.removeProfileInitialized = '';
+  vm.removeProfile = removeProfile;
 
-    // Related to password reset
-    vm.changeUserPasswordLoading = false;
-    vm.currentPassword = '';
-    vm.newPassword = '';
-    vm.verifyPassword = '';
+  // Related to password reset
+  vm.changeUserPasswordLoading = false;
+  vm.currentPassword = '';
+  vm.newPassword = '';
+  vm.verifyPassword = '';
 
-    // Push notifications
-    vm.push = push;
-    vm.pushUpdate = pushUpdate;
-    vm.pushIsDisabled = pushIsDisabled;
+  // Push notifications
+  vm.push = push;
+  vm.pushUpdate = pushUpdate;
+  vm.pushIsDisabled = pushIsDisabled;
 
-    vm.isNativeMobileApp = trNativeAppBridge.isNativeMobileApp();
+  vm.isNativeMobileApp = trNativeAppBridge.isNativeMobileApp();
 
-    activate();
+  activate();
 
-    /**
-     * Parse $error and return a string
-     * @param {Object} usernameModel - Angular model for username form input
-     * @returns {String} error text
-     */
-    function getUsernameValidationError(usernameModel) {
-      if (!usernameModel || !usernameModel.$dirty || usernameModel.$valid) {
-        return '';
-      }
+  /**
+   * Parse $error and return a string
+   * @param {Object} usernameModel - Angular model for username form input
+   * @returns {String} error text
+   */
+  function getUsernameValidationError(usernameModel) {
+    if (!usernameModel || !usernameModel.$dirty || usernameModel.$valid) {
+      return '';
+    }
 
-      const err = usernameModel.$error || {};
+    const err = usernameModel.$error || {};
 
-      if (err.required || usernameModel.$usernameValue === '') {
-        return 'Username is required.';
-      }
+    if (err.required || usernameModel.$usernameValue === '') {
+      return 'Username is required.';
+    }
 
-      if (err.maxlength) {
-        return 'Too long, maximum length is 34 characters.';
-      }
+    if (err.maxlength) {
+      return 'Too long, maximum length is 34 characters.';
+    }
 
-      if (err.minlength) {
-        return 'Too short, minumum length is 3 characters.';
-      }
+    if (err.minlength) {
+      return 'Too short, minumum length is 3 characters.';
+    }
 
-      if (err.pattern) {
-        return 'Invalid username.';
-      }
-
-      if (err.username) {
-        return 'This username is already in use or invalid.';
-      }
-
+    if (err.pattern) {
       return 'Invalid username.';
     }
 
-    // Activate controller
-    function activate() {
-      $scope.$watch(function () {
-        return push.isEnabled;
-      }, function (val) {
-        vm.pushEnabled = val;
-      });
+    if (err.username) {
+      return 'This username is already in use or invalid.';
     }
 
-    function pushUpdate() {
-      if (vm.pushEnabled) {
-        push.enable();
-      } else {
-        push.disable();
-      }
+    return 'Invalid username.';
+  }
+
+  // Activate controller
+  function activate() {
+    $scope.$watch(function () {
+      return push.isEnabled;
+    }, function (val) {
+      vm.pushEnabled = val;
+    });
+  }
+
+  function pushUpdate() {
+    if (vm.pushEnabled) {
+      push.enable();
+    } else {
+      push.disable();
     }
+  }
 
-    function pushIsDisabled() {
-      return vm.isNativeMobileApp || push.isBusy || push.isBlocked || !push.isSupported;
+  function pushIsDisabled() {
+    return vm.isNativeMobileApp || push.isBusy || push.isBlocked || !push.isSupported;
+  }
+
+  /**
+   * Change username
+   */
+  function updateUsername() {
+    vm.usernameSuccess = vm.usernameError = null;
+    const user = new Users(Authentication.user);
+    /* Just in case the user has changed the e-mail input */
+    delete user.email;
+
+    user.$update(function (response) {
+      messageCenterService.add('success', 'Username updated.');
+      vm.usernameSuccess = '';
+      vm.user = Authentication.user = response;
+    }, function (response) {
+      vm.usernameError = (response.data && response.data.message) || 'Something went wrong';
+    });
+  }
+  /**
+   * Change user email
+   */
+  function updateUserEmail() {
+    vm.emailSuccess = vm.emailError = null;
+    const user = new Users(Authentication.user);
+    /* Just in case the user has changed the username input */
+    delete user.username;
+
+    user.$update(function (response) {
+      messageCenterService.add('success', 'Check your email for further instructions.');
+      vm.emailSuccess = 'We sent you an email to ' + response.emailTemporary + ' with further instructions. ' +
+                        'Email change will not be active until that. ' +
+                        'If you don\'t see this email in your inbox within 15 minutes, look for it in your junk mail folder. If you find it there, please mark it as "Not Junk".';
+      vm.user = Authentication.user = response;
+    }, function (response) {
+      vm.emailError = (response.data && response.data.message) || 'Something went wrong.';
+    });
+  }
+
+  /**
+   * Resend confirmation email for already sent email
+   */
+  function resendUserEmailConfirm($event) {
+    if ($event) {
+      $event.preventDefault();
     }
-
-    /**
-     * Change username
-     */
-    function updateUsername() {
-      vm.usernameSuccess = vm.usernameError = null;
-      const user = new Users(Authentication.user);
-      /* Just in case the user has changed the e-mail input */
-      delete user.email;
-
-      user.$update(function (response) {
-        messageCenterService.add('success', 'Username updated.');
-        vm.usernameSuccess = '';
-        vm.user = Authentication.user = response;
-      }, function (response) {
-        vm.usernameError = (response.data && response.data.message) || 'Something went wrong';
-      });
-    }
-    /**
-     * Change user email
-     */
-    function updateUserEmail() {
-      vm.emailSuccess = vm.emailError = null;
-      const user = new Users(Authentication.user);
-      /* Just in case the user has changed the username input */
-      delete user.username;
-
-      user.$update(function (response) {
-        messageCenterService.add('success', 'Check your email for further instructions.');
-        vm.emailSuccess = 'We sent you an email to ' + response.emailTemporary + ' with further instructions. ' +
-                          'Email change will not be active until that. ' +
-                          'If you don\'t see this email in your inbox within 15 minutes, look for it in your junk mail folder. If you find it there, please mark it as "Not Junk".';
-        vm.user = Authentication.user = response;
-      }, function (response) {
-        vm.emailError = (response.data && response.data.message) || 'Something went wrong.';
-      });
-    }
-
-    /**
-     * Resend confirmation email for already sent email
-     */
-    function resendUserEmailConfirm($event) {
-      if ($event) {
-        $event.preventDefault();
-      }
-      if (vm.user.emailTemporary) {
-        $http.post('/api/auth/resend-confirmation')
-          .then(function () {
-            messageCenterService.add('success', 'Confirmation email resent.');
-          })
-          .catch(function (response) {
-            let errorMessage;
-            if (response) {
-              errorMessage = 'Error: ' + ((response.data && response.data.message) || 'Something went wrong.');
-            } else {
-              errorMessage = 'Something went wrong.';
-            }
-            messageCenterService.add('danger', errorMessage);
-          });
-      }
-    }
-
-    /**
-     * Change user email subscriptions
-     */
-    function updateUserSubscriptions() {
-      vm.updatingUserSubscriptions = true;
-      const user = new Users(Authentication.user);
-      user.$update(function (response) {
-        messageCenterService.add('success', 'Subscriptions updated.');
-        vm.user = Authentication.user = response;
-        vm.updatingUserSubscriptions = false;
-      }, function (response) {
-        vm.updatingUserSubscriptions = false;
-        messageCenterService.add('error', 'Error: ' + response.data.message);
-      });
-    }
-
-    /**
-     * Change user password
-     */
-    function changeUserPassword() {
-
-      vm.changeUserPasswordLoading = true;
-
-      $http.post('/api/users/password', {
-        currentPassword: vm.currentPassword,
-        newPassword: vm.newPassword,
-        verifyPassword: vm.verifyPassword,
-      })
-        .then(
-          function (response) { // On success function
-            vm.currentPassword = '';
-            vm.newPassword = '';
-            vm.verifyPassword = '';
-            angular.element('#newPassword').val(''); // Fix to bypass password verification directive
-            vm.changeUserPasswordLoading = false;
-            vm.user = Authentication.user = response.data.user;
-            messageCenterService.add('success', 'Your password is now changed. Have a nice day!');
-          },
-          function (response) { // On error function
-            vm.changeUserPasswordLoading = false;
-            messageCenterService.add('danger', ((response.data.message && response.data.message !== '') ? response.data.message : 'Password not changed due error, try again.'), { timeout: 10000 });
-          },
-        );
-
-    }
-
-    function removeProfile() {
-      if (!vm.removeProfileConfirm) {
-        return;
-      }
-
-      vm.removeProfileLoading = true;
-
-      new Users(Authentication.user).$delete()
-        .then(function (response) {
-          vm.removeProfileInitialized = response.message || 'Success.';
+    if (vm.user.emailTemporary) {
+      $http.post('/api/auth/resend-confirmation')
+        .then(function () {
+          messageCenterService.add('success', 'Confirmation email resent.');
         })
         .catch(function (response) {
-          vm.removeProfileLoading = false;
-          messageCenterService.add(
-            'danger',
-            response.message || 'Something went wrong while initializing profile removal, try again.',
-            { timeout: 10000 },
-          );
+          let errorMessage;
+          if (response) {
+            errorMessage = 'Error: ' + ((response.data && response.data.message) || 'Something went wrong.');
+          } else {
+            errorMessage = 'Something went wrong.';
+          }
+          messageCenterService.add('danger', errorMessage);
         });
     }
+  }
+
+  /**
+   * Change user email subscriptions
+   */
+  function updateUserSubscriptions() {
+    vm.updatingUserSubscriptions = true;
+    const user = new Users(Authentication.user);
+    user.$update(function (response) {
+      messageCenterService.add('success', 'Subscriptions updated.');
+      vm.user = Authentication.user = response;
+      vm.updatingUserSubscriptions = false;
+    }, function (response) {
+      vm.updatingUserSubscriptions = false;
+      messageCenterService.add('error', 'Error: ' + response.data.message);
+    });
+  }
+
+  /**
+   * Change user password
+   */
+  function changeUserPassword() {
+
+    vm.changeUserPasswordLoading = true;
+
+    $http.post('/api/users/password', {
+      currentPassword: vm.currentPassword,
+      newPassword: vm.newPassword,
+      verifyPassword: vm.verifyPassword,
+    })
+      .then(
+        function (response) { // On success function
+          vm.currentPassword = '';
+          vm.newPassword = '';
+          vm.verifyPassword = '';
+          angular.element('#newPassword').val(''); // Fix to bypass password verification directive
+          vm.changeUserPasswordLoading = false;
+          vm.user = Authentication.user = response.data.user;
+          messageCenterService.add('success', 'Your password is now changed. Have a nice day!');
+        },
+        function (response) { // On error function
+          vm.changeUserPasswordLoading = false;
+          messageCenterService.add('danger', ((response.data.message && response.data.message !== '') ? response.data.message : 'Password not changed due error, try again.'), { timeout: 10000 });
+        },
+      );
 
   }
-}());
+
+  function removeProfile() {
+    if (!vm.removeProfileConfirm) {
+      return;
+    }
+
+    vm.removeProfileLoading = true;
+
+    new Users(Authentication.user).$delete()
+      .then(function (response) {
+        vm.removeProfileInitialized = response.message || 'Success.';
+      })
+      .catch(function (response) {
+        vm.removeProfileLoading = false;
+        messageCenterService.add(
+          'danger',
+          response.message || 'Something went wrong while initializing profile removal, try again.',
+          { timeout: 10000 },
+        );
+      });
+  }
+
+}

--- a/modules/users/client/controllers/profile-edit-locations.client.controller.js
+++ b/modules/users/client/controllers/profile-edit-locations.client.controller.js
@@ -1,37 +1,35 @@
-(function () {
-  angular
-    .module('users')
-    .controller('ProfileEditLocationsController', ProfileEditLocationsController);
+angular
+  .module('users')
+  .controller('ProfileEditLocationsController', ProfileEditLocationsController);
 
-  /* @ngInject */
-  function ProfileEditLocationsController($scope, Users, Authentication, messageCenterService) {
+/* @ngInject */
+function ProfileEditLocationsController($scope, Users, Authentication, messageCenterService) {
 
-    // ViewModel
-    const vm = this;
+  // ViewModel
+  const vm = this;
 
-    // Copy user to make a temporary buffer for changes.
-    // Prevents changes remaining here when cancelling profile editing.
-    vm.user = new Users(Authentication.user);
+  // Copy user to make a temporary buffer for changes.
+  // Prevents changes remaining here when cancelling profile editing.
+  vm.user = new Users(Authentication.user);
 
-    // Exposed
-    vm.updateUserProfile = updateUserProfile;
+  // Exposed
+  vm.updateUserProfile = updateUserProfile;
 
-    /**
-     * Update a user profile
-     */
-    function updateUserProfile(isValid) {
-      if (isValid) {
-        vm.user.$update(function (response) {
-          Authentication.user = response;
-          $scope.$emit('userUpdated');
-          messageCenterService.add('success', 'Profile updated.');
-        }, function (response) {
-          messageCenterService.add('danger', response.data.message || 'Something went wrong. Please try again!', { timeout: 10000 });
-        });
-      } else {
-        messageCenterService.add('danger', 'Please fix errors from your profile and try again.', { timeout: 10000 });
-      }
+  /**
+   * Update a user profile
+   */
+  function updateUserProfile(isValid) {
+    if (isValid) {
+      vm.user.$update(function (response) {
+        Authentication.user = response;
+        $scope.$emit('userUpdated');
+        messageCenterService.add('success', 'Profile updated.');
+      }, function (response) {
+        messageCenterService.add('danger', response.data.message || 'Something went wrong. Please try again!', { timeout: 10000 });
+      });
+    } else {
+      messageCenterService.add('danger', 'Please fix errors from your profile and try again.', { timeout: 10000 });
     }
-
   }
-}());
+
+}

--- a/modules/users/client/controllers/profile-edit-networks.client.controller.js
+++ b/modules/users/client/controllers/profile-edit-networks.client.controller.js
@@ -1,82 +1,80 @@
-(function () {
-  angular
-    .module('users')
-    .controller('ProfileEditNetworksController', ProfileEditNetworksController);
+angular
+  .module('users')
+  .controller('ProfileEditNetworksController', ProfileEditNetworksController);
 
-  /* @ngInject */
-  function ProfileEditNetworksController($scope, $http, Users, Authentication, messageCenterService) {
+/* @ngInject */
+function ProfileEditNetworksController($scope, $http, Users, Authentication, messageCenterService) {
 
-    // ViewModel
-    const vm = this;
+  // ViewModel
+  const vm = this;
 
-    // Copy user to make a temporary buffer for changes.
-    // Prevents changes remaining here when cancelling profile editing.
-    vm.user = new Users(Authentication.user);
+  // Copy user to make a temporary buffer for changes.
+  // Prevents changes remaining here when cancelling profile editing.
+  vm.user = new Users(Authentication.user);
 
-    // Exposed
-    vm.updateUserProfile = updateUserProfile;
-    vm.removingSocialAccount = false;
-    vm.removeUserSocialAccount = removeUserSocialAccount;
-    vm.isConnectedSocialAccount = isConnectedSocialAccount;
-    vm.hasConnectedAdditionalSocialAccounts = hasConnectedAdditionalSocialAccounts;
-    vm.isWarmshowersId = isWarmshowersId;
+  // Exposed
+  vm.updateUserProfile = updateUserProfile;
+  vm.removingSocialAccount = false;
+  vm.removeUserSocialAccount = removeUserSocialAccount;
+  vm.isConnectedSocialAccount = isConnectedSocialAccount;
+  vm.hasConnectedAdditionalSocialAccounts = hasConnectedAdditionalSocialAccounts;
+  vm.isWarmshowersId = isWarmshowersId;
 
-    /**
-     * Determine if given user handle for Warmshowers is an id or username
-     * @link https://github.com/Trustroots/trustroots/issues/308
-     */
-    function isWarmshowersId() {
-      let x;
-      return isNaN(vm.user.extSitesWS) ? !1 : (x = parseFloat(vm.user.extSitesWS), (0 | x) === x);
-    }
-
-    /**
-     * Check if there are additional accounts
-     */
-    function hasConnectedAdditionalSocialAccounts() {
-      return (vm.user.additionalProvidersData && Object.keys(vm.user.additionalProvidersData).length);
-    }
-
-    /**
-     * Check if provider is already in use with current user
-     */
-    function isConnectedSocialAccount(provider) {
-      return vm.user.additionalProvidersData && vm.user.additionalProvidersData[provider];
-    }
-
-    /**
-     * Remove a user social account
-     */
-    function removeUserSocialAccount(provider) {
-      $http.delete('/api/users/accounts/' + provider)
-        .then(
-          function (response) { // On success function
-            messageCenterService.add('success', 'Succesfully disconnected from ' + provider);
-            vm.user = Authentication.user = response.data;
-            $scope.$emit('userUpdated');
-          },
-          function (response) { // On error function
-            messageCenterService.add('danger', response.data.message || 'Something went wrong. Try again or contact us to disconnect your profile.', { timeout: 10000 });
-          },
-        );
-    }
-
-    /**
-     * Update a user profile
-     */
-    function updateUserProfile(isValid) {
-      if (isValid) {
-        vm.user.$update(function (response) {
-          Authentication.user = response;
-          $scope.$emit('userUpdated');
-          messageCenterService.add('success', 'Hospitality networks updated.');
-        }, function (response) {
-          messageCenterService.add('danger', response.data.message || 'Something went wrong. Please try again!', { timeout: 10000 });
-        });
-      } else {
-        messageCenterService.add('danger', 'Please fix errors from your profile and try again.', { timeout: 10000 });
-      }
-    }
-
+  /**
+   * Determine if given user handle for Warmshowers is an id or username
+   * @link https://github.com/Trustroots/trustroots/issues/308
+   */
+  function isWarmshowersId() {
+    let x;
+    return isNaN(vm.user.extSitesWS) ? !1 : (x = parseFloat(vm.user.extSitesWS), (0 | x) === x);
   }
-}());
+
+  /**
+   * Check if there are additional accounts
+   */
+  function hasConnectedAdditionalSocialAccounts() {
+    return (vm.user.additionalProvidersData && Object.keys(vm.user.additionalProvidersData).length);
+  }
+
+  /**
+   * Check if provider is already in use with current user
+   */
+  function isConnectedSocialAccount(provider) {
+    return vm.user.additionalProvidersData && vm.user.additionalProvidersData[provider];
+  }
+
+  /**
+   * Remove a user social account
+   */
+  function removeUserSocialAccount(provider) {
+    $http.delete('/api/users/accounts/' + provider)
+      .then(
+        function (response) { // On success function
+          messageCenterService.add('success', 'Succesfully disconnected from ' + provider);
+          vm.user = Authentication.user = response.data;
+          $scope.$emit('userUpdated');
+        },
+        function (response) { // On error function
+          messageCenterService.add('danger', response.data.message || 'Something went wrong. Try again or contact us to disconnect your profile.', { timeout: 10000 });
+        },
+      );
+  }
+
+  /**
+   * Update a user profile
+   */
+  function updateUserProfile(isValid) {
+    if (isValid) {
+      vm.user.$update(function (response) {
+        Authentication.user = response;
+        $scope.$emit('userUpdated');
+        messageCenterService.add('success', 'Hospitality networks updated.');
+      }, function (response) {
+        messageCenterService.add('danger', response.data.message || 'Something went wrong. Please try again!', { timeout: 10000 });
+      });
+    } else {
+      messageCenterService.add('danger', 'Please fix errors from your profile and try again.', { timeout: 10000 });
+    }
+  }
+
+}

--- a/modules/users/client/controllers/profile-edit-photo.client.controller.js
+++ b/modules/users/client/controllers/profile-edit-photo.client.controller.js
@@ -1,165 +1,163 @@
-(function () {
-  angular
-    .module('users')
-    .controller('ProfileEditPhotoController', ProfileEditPhotoController);
+angular
+  .module('users')
+  .controller('ProfileEditPhotoController', ProfileEditPhotoController);
 
-  /* @ngInject */
-  function ProfileEditPhotoController($scope, $window, Users, Authentication, messageCenterService, Upload, appSettings) {
+/* @ngInject */
+function ProfileEditPhotoController($scope, $window, Users, Authentication, messageCenterService, Upload, appSettings) {
 
-    // ViewModel
-    const vm = this;
+  // ViewModel
+  const vm = this;
 
-    // Copy user to make a temporary buffer for changes.
-    // Prevents changes remaining here when cancelling profile editing.
-    vm.user = new Users(Authentication.user);
+  // Copy user to make a temporary buffer for changes.
+  // Prevents changes remaining here when cancelling profile editing.
+  vm.user = new Users(Authentication.user);
 
-    let fileAvatar = {};
+  let fileAvatar = {};
 
-    // Exposed
-    vm.showDropzone = false;
-    vm.avatarPreview = false;
-    vm.fileSelected = fileSelected;
-    vm.updateUserProfile = updateUserProfile;
+  // Exposed
+  vm.showDropzone = false;
+  vm.avatarPreview = false;
+  vm.fileSelected = fileSelected;
+  vm.updateUserProfile = updateUserProfile;
 
-    // Initialize controller
-    activate();
+  // Initialize controller
+  activate();
 
-    function activate() {
-      $window.addEventListener('dragenter', function () {
-        showDropZone();
+  function activate() {
+    $window.addEventListener('dragenter', function () {
+      showDropZone();
+    });
+    $window.addEventListener('drop', function () {
+      hideDropZone();
+    });
+    angular.element('#profile-edit-avatar-drop')[0].addEventListener('dragleave', function () {
+      hideDropZone();
+    });
+  }
+
+  function showDropZone() {
+    $scope.$apply(function () {
+      vm.showDropzone = true;
+    });
+  }
+  function hideDropZone() {
+    $scope.$apply(function () {
+      vm.showDropzone = false;
+    });
+  }
+
+  /**
+   * Save avatar changes
+   */
+  function saveAvatar() {
+    // Uploaded new file
+    if (vm.user.avatarSource === 'local' && vm.avatarPreview === true) {
+      // Upload the new file
+      vm.avatarUploading = true;
+      vm.upload = Upload.upload({
+        url: '/api/users-avatar',
+        method: 'POST',
+        headers: {
+          'Content-Type': (fileAvatar.type !== '' ? fileAvatar.type : 'application/octet-stream'),
+        },
+        data: {
+          avatar: fileAvatar,
+        },
+      }).success(function () {
+        vm.avatarUploading = false;
+        updateUserProfile();
+      }).error(function (data, status) {
+        // Default error
+        let saveAvatarErr = 'Oops! Something went wrong. Try again later.';
+
+        if (status === 422) {
+          // Could not process file
+          saveAvatarErr = 'Sorry, we could not process this file.';
+        } else if (status === 413) {
+          // File too large
+          saveAvatarErr = 'Whoops, your file is too big. Please keep it up to ' + bytesToSize(appSettings.maxUploadSize) + '.';
+        } else if (status === 415) {
+          // Unsupported media type
+          saveAvatarErr = 'Sorry, we do not support this type of file.';
+        }
+
+        messageCenterService.add('danger', saveAvatarErr);
+        vm.avatarUploading = false;
+        vm.avatarPreview = false;
       });
-      $window.addEventListener('drop', function () {
-        hideDropZone();
-      });
-      angular.element('#profile-edit-avatar-drop')[0].addEventListener('dragleave', function () {
-        hideDropZone();
-      });
     }
-
-    function showDropZone() {
-      $scope.$apply(function () {
-        vm.showDropzone = true;
-      });
-    }
-    function hideDropZone() {
-      $scope.$apply(function () {
-        vm.showDropzone = false;
-      });
-    }
-
-    /**
-     * Save avatar changes
-     */
-    function saveAvatar() {
-      // Uploaded new file
-      if (vm.user.avatarSource === 'local' && vm.avatarPreview === true) {
-        // Upload the new file
-        vm.avatarUploading = true;
-        vm.upload = Upload.upload({
-          url: '/api/users-avatar',
-          method: 'POST',
-          headers: {
-            'Content-Type': (fileAvatar.type !== '' ? fileAvatar.type : 'application/octet-stream'),
-          },
-          data: {
-            avatar: fileAvatar,
-          },
-        }).success(function () {
-          vm.avatarUploading = false;
-          updateUserProfile();
-        }).error(function (data, status) {
-          // Default error
-          let saveAvatarErr = 'Oops! Something went wrong. Try again later.';
-
-          if (status === 422) {
-            // Could not process file
-            saveAvatarErr = 'Sorry, we could not process this file.';
-          } else if (status === 413) {
-            // File too large
-            saveAvatarErr = 'Whoops, your file is too big. Please keep it up to ' + bytesToSize(appSettings.maxUploadSize) + '.';
-          } else if (status === 415) {
-            // Unsupported media type
-            saveAvatarErr = 'Sorry, we do not support this type of file.';
-          }
-
-          messageCenterService.add('danger', saveAvatarErr);
-          vm.avatarUploading = false;
-          vm.avatarPreview = false;
-        });
-      }
-
-    }
-
-    /**
-     * Process preview after file is selected via fileinput / dropped to window / received from camera
-     */
-    function fileSelected($files) {
-      // Too early
-      if ($files && $files.length === 0) {
-        return;
-      }
-
-      // Accept only one file at once
-      const file = $files[0];
-      fileAvatar = file;
-      vm.user.avatarSource = 'local';
-      vm.user.avatarUploaded = true;
-
-      // Validate filetype
-      if (file.type.indexOf('jpeg') === -1 && file.type.indexOf('gif') === -1 && file.type.indexOf('png') === -1) {
-        messageCenterService.add('danger', 'Please give a jpg, gif, or png image.');
-      // Validate filesize
-      } else if (file.size > appSettings.maxUploadSize) {
-        messageCenterService.add('danger', 'Whoops, your file is too big. Please keep it up to ' + bytesToSize(appSettings.maxUploadSize) + '.');
-      // All good, uploading file...
-      } else {
-        vm.avatarUploading = true;
-
-        // Show the local file as a preview
-        const fileReader = new FileReader();
-        fileReader.readAsDataURL(file);
-        fileReader.onloadend = function () {
-          vm.avatarPreview = true;
-          $scope.$apply(function () {
-            vm.previewStyle = fileReader.result;
-            vm.avatarUploading = false;
-            saveAvatar();
-          });
-        };
-      }
-    }
-
-    /**
-     * Save profile
-     */
-    function updateUserProfile() {
-      // Note that this won't end up to the DB as is, it's just used as a cache-buster for new avatar
-      vm.user.updated = new Date();
-
-      vm.user.$update(function (updatedUser) {
-        vm.user = Authentication.user = updatedUser;
-        // Notify AppController
-        $scope.$emit('userUpdated', updatedUser);
-        messageCenterService.add('success', 'Profile photo updated.');
-      }, function (err) {
-        messageCenterService.add('danger', err.data.message || 'Oops! Something went wrong.');
-      });
-
-    }
-
-    /**
-     * Return bytes in human readable size.
-     * E.g. bytesToSize(10000000) => "10 MB"
-     *
-     * @link http://stackoverflow.com/a/18650828
-     */
-    function bytesToSize(bytes) {
-      const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
-      if (bytes === 0) return '0 Byte';
-      const i = parseInt(Math.floor(Math.log(bytes) / Math.log(1024)), 10);
-      return Math.round(bytes / Math.pow(1024, i), 2) + ' ' + sizes[i];
-    }
-
 
   }
-}());
+
+  /**
+   * Process preview after file is selected via fileinput / dropped to window / received from camera
+   */
+  function fileSelected($files) {
+    // Too early
+    if ($files && $files.length === 0) {
+      return;
+    }
+
+    // Accept only one file at once
+    const file = $files[0];
+    fileAvatar = file;
+    vm.user.avatarSource = 'local';
+    vm.user.avatarUploaded = true;
+
+    // Validate filetype
+    if (file.type.indexOf('jpeg') === -1 && file.type.indexOf('gif') === -1 && file.type.indexOf('png') === -1) {
+      messageCenterService.add('danger', 'Please give a jpg, gif, or png image.');
+    // Validate filesize
+    } else if (file.size > appSettings.maxUploadSize) {
+      messageCenterService.add('danger', 'Whoops, your file is too big. Please keep it up to ' + bytesToSize(appSettings.maxUploadSize) + '.');
+    // All good, uploading file...
+    } else {
+      vm.avatarUploading = true;
+
+      // Show the local file as a preview
+      const fileReader = new FileReader();
+      fileReader.readAsDataURL(file);
+      fileReader.onloadend = function () {
+        vm.avatarPreview = true;
+        $scope.$apply(function () {
+          vm.previewStyle = fileReader.result;
+          vm.avatarUploading = false;
+          saveAvatar();
+        });
+      };
+    }
+  }
+
+  /**
+   * Save profile
+   */
+  function updateUserProfile() {
+    // Note that this won't end up to the DB as is, it's just used as a cache-buster for new avatar
+    vm.user.updated = new Date();
+
+    vm.user.$update(function (updatedUser) {
+      vm.user = Authentication.user = updatedUser;
+      // Notify AppController
+      $scope.$emit('userUpdated', updatedUser);
+      messageCenterService.add('success', 'Profile photo updated.');
+    }, function (err) {
+      messageCenterService.add('danger', err.data.message || 'Oops! Something went wrong.');
+    });
+
+  }
+
+  /**
+   * Return bytes in human readable size.
+   * E.g. bytesToSize(10000000) => "10 MB"
+   *
+   * @link http://stackoverflow.com/a/18650828
+   */
+  function bytesToSize(bytes) {
+    const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+    if (bytes === 0) return '0 Byte';
+    const i = parseInt(Math.floor(Math.log(bytes) / Math.log(1024)), 10);
+    return Math.round(bytes / Math.pow(1024, i), 2) + ' ' + sizes[i];
+  }
+
+
+}

--- a/modules/users/client/controllers/profile-edit-tribes.client.controller.js
+++ b/modules/users/client/controllers/profile-edit-tribes.client.controller.js
@@ -1,37 +1,35 @@
-(function () {
-  angular
-    .module('users')
-    .controller('ProfileEditTribesController', ProfileEditTribesController);
+angular
+  .module('users')
+  .controller('ProfileEditTribesController', ProfileEditTribesController);
 
-  /* @ngInject */
-  function ProfileEditTribesController($scope, Users, Authentication, messageCenterService) {
+/* @ngInject */
+function ProfileEditTribesController($scope, Users, Authentication, messageCenterService) {
 
-    // ViewModel
-    const vm = this;
+  // ViewModel
+  const vm = this;
 
-    // Copy user to make a temporary buffer for changes.
-    // Prevents changes remaining here when cancelling profile editing.
-    vm.user = new Users(Authentication.user);
+  // Copy user to make a temporary buffer for changes.
+  // Prevents changes remaining here when cancelling profile editing.
+  vm.user = new Users(Authentication.user);
 
-    // Exposed
-    vm.updateUserProfile = updateUserProfile;
+  // Exposed
+  vm.updateUserProfile = updateUserProfile;
 
-    /**
-     * Update a user profile
-     */
-    function updateUserProfile(isValid) {
-      if (isValid) {
-        vm.user.$update(function (response) {
-          Authentication.user = response;
-          $scope.$emit('userUpdated');
-          messageCenterService.add('success', 'Profile updated.');
-        }, function (response) {
-          messageCenterService.add('danger', response.data.message || 'Something went wrong. Please try again!', { timeout: 10000 });
-        });
-      } else {
-        messageCenterService.add('danger', 'Please fix errors from your profile and try again.', { timeout: 10000 });
-      }
+  /**
+   * Update a user profile
+   */
+  function updateUserProfile(isValid) {
+    if (isValid) {
+      vm.user.$update(function (response) {
+        Authentication.user = response;
+        $scope.$emit('userUpdated');
+        messageCenterService.add('success', 'Profile updated.');
+      }, function (response) {
+        messageCenterService.add('danger', response.data.message || 'Something went wrong. Please try again!', { timeout: 10000 });
+      });
+    } else {
+      messageCenterService.add('danger', 'Please fix errors from your profile and try again.', { timeout: 10000 });
     }
-
   }
-}());
+
+}

--- a/modules/users/client/controllers/profile-edit.client.controller.js
+++ b/modules/users/client/controllers/profile-edit.client.controller.js
@@ -1,44 +1,42 @@
-(function () {
-  angular
-    .module('users')
-    .controller('ProfileEditController', ProfileEditController);
+angular
+  .module('users')
+  .controller('ProfileEditController', ProfileEditController);
 
-  /* @ngInject */
-  function ProfileEditController($scope, $confirm, $state) {
+/* @ngInject */
+function ProfileEditController($scope, $confirm, $state) {
 
-    // ViewModel
-    const vm = this;
+  // ViewModel
+  const vm = this;
 
-    // Exposed to the view
+  // Exposed to the view
+  vm.unsavedModifications = false;
+
+  // Clear modifications
+  $scope.$on('userUpdated', function () {
     vm.unsavedModifications = false;
+  });
 
-    // Clear modifications
-    $scope.$on('userUpdated', function () {
-      vm.unsavedModifications = false;
-    });
+  // React when state changes and there are unsaved modifications
+  $scope.$on('$stateChangeStart', function (event, toState, toParams) {
+    if (vm.unsavedModifications) {
+      // Cancel original $state transition
+      // transitionTo() promise will be rejected with
+      // a 'transition prevented' error
+      event.preventDefault();
 
-    // React when state changes and there are unsaved modifications
-    $scope.$on('$stateChangeStart', function (event, toState, toParams) {
-      if (vm.unsavedModifications) {
-        // Cancel original $state transition
-        // transitionTo() promise will be rejected with
-        // a 'transition prevented' error
-        event.preventDefault();
+      // Ask for confirmation
+      $confirm({
+        title: 'Are you sure?',
+        text: 'Your changes would be lost. Return and press "Save" to keep the changes, or press "Continue" to discard them.',
+        ok: 'Continue',
+        cancel: 'Cancel',
+      })
+      // If user pressed "continue", create another state go
+        .then(function () {
+          vm.unsavedModifications = false;
+          $state.go(toState.name, toParams);
+        });
+    }
+  });
 
-        // Ask for confirmation
-        $confirm({
-          title: 'Are you sure?',
-          text: 'Your changes would be lost. Return and press "Save" to keep the changes, or press "Continue" to discard them.',
-          ok: 'Continue',
-          cancel: 'Cancel',
-        })
-        // If user pressed "continue", create another state go
-          .then(function () {
-            vm.unsavedModifications = false;
-            $state.go(toState.name, toParams);
-          });
-      }
-    });
-
-  }
-}());
+}

--- a/modules/users/client/controllers/profile.client.controller.js
+++ b/modules/users/client/controllers/profile.client.controller.js
@@ -1,112 +1,110 @@
-(function () {
-  angular
-    .module('users')
-    .controller('ProfileController', ProfileController);
+angular
+  .module('users')
+  .controller('ProfileController', ProfileController);
 
-  /* @ngInject */
-  function ProfileController($scope, $stateParams, $state, $filter, Authentication, $timeout, profile, contact, contacts) {
+/* @ngInject */
+function ProfileController($scope, $stateParams, $state, $filter, Authentication, $timeout, profile, contact, contacts) {
 
-    // No user defined at URL, just redirect to user's own profile
-    if (!$stateParams.username) {
-      $state.go('profile.about', { username: Authentication.user.username });
-    }
-
-    // ViewModel
-    const vm = this;
-    vm.profile = profile;
-    vm.contact = contact;
-    vm.contacts = contacts;
-
-    // Exposed to the view
-    vm.hasConnectedAdditionalSocialAccounts = hasConnectedAdditionalSocialAccounts;
-    vm.isConnectedSocialAccount = isConnectedSocialAccount;
-    vm.socialAccountLink = socialAccountLink;
-    vm.isWarmshowersId = isWarmshowersId;
-
-    /**
-     * Remove contact via React RemoveContact component
-     */
-    vm.removeContact = function (contact) {
-      vm.contacts.splice(vm.contacts.indexOf(contact), 1);
-    };
-
-
-    activate();
-
-    /**
-     * Initialize controller
-     */
-    function activate() {
-      // When on small screen...
-      if (angular.element('body').width() <= 480) {
-        // By default we land to `about` tab of this controller
-        // If we're on small screens, direct to `overview` tab instead
-        if ($state.current.name === 'profile.about') {
-          // Timeout ensures `ui-sref-active=""` gets updated at the templates
-          $timeout(function () {
-            $state.go('profile.overview', { username: profile.username });
-          }, 25);
-        }
-      // When on bigger screen...
-      // Redirect "mobile only" tabs to about tab
-      } else if (['profile.overview', 'profile.accommodation'].indexOf($state.current.name) > -1) {
-        $state.go('profile.about', { username: profile.username });
-      }
-
-      // If this is authenticated user's own profile, measure profile description length
-      if (Authentication.user._id === profile._id) {
-        vm.profileDescriptionLength = Authentication.user.description ? $filter('plainTextLength')(Authentication.user.description) : 0;
-      }
-
-      /**
-       * When contact removal modal signals that the contact was removed, remove it from this scope as well
-       * @todo: any better way to keep vm.contact $resolved but wipe out the actual content?
-       */
-      $scope.$on('contactRemoved', function () {
-        if (vm.contact) {
-          delete vm.contact._id;
-        }
-      });
-    }
-
-    /**
-     * Determine if given user handle for Warmshowers is an id or username
-     * @link https://github.com/Trustroots/trustroots/issues/308
-     */
-    function isWarmshowersId() {
-      let x;
-      return isNaN(vm.profile.extSitesWS) ? !1 : (x = parseFloat(vm.profile.extSitesWS), (0 | x) === x);
-    }
-
-    /**
-     * Check if there are additional accounts
-     */
-    function hasConnectedAdditionalSocialAccounts() {
-      return (vm.profile.additionalProvidersData && Object.keys(vm.profile.additionalProvidersData).length);
-    }
-
-    /**
-     * Check if provider is already in use with profile
-     */
-    function isConnectedSocialAccount(provider) {
-      return vm.profile.provider === provider || (vm.profile.additionalProvidersData && vm.profile.additionalProvidersData[provider]);
-    }
-
-    /**
-     * Return an URL for user's social media profiles
-     * Ensure these values are published at users.profile.server.controller.js
-     */
-    function socialAccountLink(providerName, providerData) {
-      if (providerName === 'facebook' && providerData.id) {
-        return 'https://www.facebook.com/app_scoped_user_id/' + providerData.id;
-      } else if (providerName === 'twitter' && providerData.screen_name) {
-        return 'https://twitter.com/' + providerData.screen_name;
-      } else if (providerName === 'github' && providerData.login) {
-        return 'https://github.com/' + providerData.login;
-      } else {
-        return '#';
-      }
-    }
-
+  // No user defined at URL, just redirect to user's own profile
+  if (!$stateParams.username) {
+    $state.go('profile.about', { username: Authentication.user.username });
   }
-}());
+
+  // ViewModel
+  const vm = this;
+  vm.profile = profile;
+  vm.contact = contact;
+  vm.contacts = contacts;
+
+  // Exposed to the view
+  vm.hasConnectedAdditionalSocialAccounts = hasConnectedAdditionalSocialAccounts;
+  vm.isConnectedSocialAccount = isConnectedSocialAccount;
+  vm.socialAccountLink = socialAccountLink;
+  vm.isWarmshowersId = isWarmshowersId;
+
+  /**
+   * Remove contact via React RemoveContact component
+   */
+  vm.removeContact = function (contact) {
+    vm.contacts.splice(vm.contacts.indexOf(contact), 1);
+  };
+
+
+  activate();
+
+  /**
+   * Initialize controller
+   */
+  function activate() {
+    // When on small screen...
+    if (angular.element('body').width() <= 480) {
+      // By default we land to `about` tab of this controller
+      // If we're on small screens, direct to `overview` tab instead
+      if ($state.current.name === 'profile.about') {
+        // Timeout ensures `ui-sref-active=""` gets updated at the templates
+        $timeout(function () {
+          $state.go('profile.overview', { username: profile.username });
+        }, 25);
+      }
+    // When on bigger screen...
+    // Redirect "mobile only" tabs to about tab
+    } else if (['profile.overview', 'profile.accommodation'].indexOf($state.current.name) > -1) {
+      $state.go('profile.about', { username: profile.username });
+    }
+
+    // If this is authenticated user's own profile, measure profile description length
+    if (Authentication.user._id === profile._id) {
+      vm.profileDescriptionLength = Authentication.user.description ? $filter('plainTextLength')(Authentication.user.description) : 0;
+    }
+
+    /**
+     * When contact removal modal signals that the contact was removed, remove it from this scope as well
+     * @todo: any better way to keep vm.contact $resolved but wipe out the actual content?
+     */
+    $scope.$on('contactRemoved', function () {
+      if (vm.contact) {
+        delete vm.contact._id;
+      }
+    });
+  }
+
+  /**
+   * Determine if given user handle for Warmshowers is an id or username
+   * @link https://github.com/Trustroots/trustroots/issues/308
+   */
+  function isWarmshowersId() {
+    let x;
+    return isNaN(vm.profile.extSitesWS) ? !1 : (x = parseFloat(vm.profile.extSitesWS), (0 | x) === x);
+  }
+
+  /**
+   * Check if there are additional accounts
+   */
+  function hasConnectedAdditionalSocialAccounts() {
+    return (vm.profile.additionalProvidersData && Object.keys(vm.profile.additionalProvidersData).length);
+  }
+
+  /**
+   * Check if provider is already in use with profile
+   */
+  function isConnectedSocialAccount(provider) {
+    return vm.profile.provider === provider || (vm.profile.additionalProvidersData && vm.profile.additionalProvidersData[provider]);
+  }
+
+  /**
+   * Return an URL for user's social media profiles
+   * Ensure these values are published at users.profile.server.controller.js
+   */
+  function socialAccountLink(providerName, providerData) {
+    if (providerName === 'facebook' && providerData.id) {
+      return 'https://www.facebook.com/app_scoped_user_id/' + providerData.id;
+    } else if (providerName === 'twitter' && providerData.screen_name) {
+      return 'https://twitter.com/' + providerData.screen_name;
+    } else if (providerName === 'github' && providerData.login) {
+      return 'https://github.com/' + providerData.login;
+    } else {
+      return '#';
+    }
+  }
+
+}

--- a/modules/users/client/controllers/remove.client.controller.js
+++ b/modules/users/client/controllers/remove.client.controller.js
@@ -1,51 +1,49 @@
-(function () {
-  angular
-    .module('users')
-    .controller('RemoveProfileController', RemoveProfileController);
+angular
+  .module('users')
+  .controller('RemoveProfileController', RemoveProfileController);
 
-  /* @ngInject */
-  function RemoveProfileController($stateParams, Users, Authentication, messageCenterService) {
+/* @ngInject */
+function RemoveProfileController($stateParams, Users, Authentication, messageCenterService) {
 
-    // ViewModel
-    const vm = this;
+  // ViewModel
+  const vm = this;
 
-    // Exposed to the view
-    vm.removeProfile = removeProfile;
-    vm.resendConfirmation = resendConfirmation;
-    vm.resendConfirmationLoading = false;
+  // Exposed to the view
+  vm.removeProfile = removeProfile;
+  vm.resendConfirmation = resendConfirmation;
+  vm.resendConfirmationLoading = false;
+  vm.state = 'loading';
+
+  removeProfile();
+
+  // Remove user profile
+  function removeProfile() {
     vm.state = 'loading';
 
-    removeProfile();
-
-    // Remove user profile
-    function removeProfile() {
-      vm.state = 'loading';
-
-      Users.deleteWithToken($stateParams.token)
-        .then(function () {
-          vm.state = 'success';
-        })
-        .catch(function () {
-          vm.state = 'failure';
-        });
-    }
-
-    // Get a new confirmation email
-    function resendConfirmation() {
-      vm.resendConfirmationLoading = true;
-      new Users(Authentication.user).$delete()
-        .then(function (response) {
-          vm.removeProfileInitialized = response.message || 'Success.';
-        })
-        .catch(function (response) {
-          vm.removeProfileLoading = false;
-          messageCenterService.add(
-            'danger',
-            response.message || 'Something went wrong while initializing profile removal, try again.',
-            { timeout: 10000 },
-          );
-        });
-    }
-
+    Users.deleteWithToken($stateParams.token)
+      .then(function () {
+        vm.state = 'success';
+      })
+      .catch(function () {
+        vm.state = 'failure';
+      });
   }
-}());
+
+  // Get a new confirmation email
+  function resendConfirmation() {
+    vm.resendConfirmationLoading = true;
+    new Users(Authentication.user).$delete()
+      .then(function (response) {
+        vm.removeProfileInitialized = response.message || 'Success.';
+      })
+      .catch(function (response) {
+        vm.removeProfileLoading = false;
+        messageCenterService.add(
+          'danger',
+          response.message || 'Something went wrong while initializing profile removal, try again.',
+          { timeout: 10000 },
+        );
+      });
+  }
+
+}

--- a/modules/users/client/controllers/signup.client.controller.js
+++ b/modules/users/client/controllers/signup.client.controller.js
@@ -1,360 +1,358 @@
 import rulesModalTemplateUrl from '@/modules/users/client/views/authentication/rules-modal.client.view.html';
 
-(function (jQuery) {
-  angular
-    .module('users')
-    .controller('SignupController', SignupController);
+angular
+  .module('users')
+  .controller('SignupController', SignupController);
 
-  /* @ngInject */
-  function SignupController($rootScope, $http, $q, $state, $stateParams, $location, $uibModal, $analytics, $window, Authentication, UserMembershipsService, messageCenterService, TribeService, TribesService, InvitationService, SettingsFactory, locker) {
+/* @ngInject */
+function SignupController($rootScope, $http, $q, $state, $stateParams, $location, $uibModal, $analytics, $window, Authentication, UserMembershipsService, messageCenterService, TribeService, TribesService, InvitationService, SettingsFactory, locker) {
 
-    // If user is already signed in then redirect to search page
-    if (Authentication.user) {
-      $state.go('search.map');
-      return;
+  // If user is already signed in then redirect to search page
+  if (Authentication.user) {
+    $state.go('search.map');
+    return;
+  }
+
+  const appSettings = SettingsFactory.get();
+
+  // View Model
+  const vm = this;
+
+  // Exposed to the view
+  vm.credentials = {};
+  vm.step = 1;
+  vm.isLoading = false;
+  vm.submitSignup = submitSignup;
+  vm.getUsernameValidationError = getUsernameValidationError;
+  vm.openRules = openRules;
+  vm.tribe = null;
+  vm.suggestedTribes = [];
+
+  // Variables for invitation feature
+  vm.invitationCode = $stateParams.code || '';
+  vm.invitationCodeValid = false;
+  vm.invitationCodeError = false;
+  vm.validateInvitationCode = validateInvitationCode;
+  vm.isWaitingListEnabled = false;
+  vm.waitinglistInvitation = Boolean($stateParams.mwr);
+  vm.usernameMinlength = 3;
+  vm.usernameMaxlength = 34;
+  vm.suggestedTribesLimit = 4;
+
+  // Initialize controller
+  activate();
+
+
+  /**
+   * Initalize controller
+   */
+  function activate() {
+    // If invitation code was passed to the page (via URL), validate it
+    validateInvitationCode()
+      .finally(function () {
+        // Initialise waitinglist
+        initWaitingList();
+      });
+
+    // Get list of suggested tribes
+    initSuggstedTribes();
+  }
+
+  /**
+   * Parse $error and return a string
+   * @param {Object} usernameModel - Angular model for username form input
+   * @returns {String} error text
+   */
+  function getUsernameValidationError(usernameModel) {
+
+    if (!usernameModel || !usernameModel.$dirty || usernameModel.$valid) {
+      return '';
     }
 
-    const appSettings = SettingsFactory.get();
+    const err = usernameModel.$error || {};
 
-    // View Model
-    const vm = this;
-
-    // Exposed to the view
-    vm.credentials = {};
-    vm.step = 1;
-    vm.isLoading = false;
-    vm.submitSignup = submitSignup;
-    vm.getUsernameValidationError = getUsernameValidationError;
-    vm.openRules = openRules;
-    vm.tribe = null;
-    vm.suggestedTribes = [];
-
-    // Variables for invitation feature
-    vm.invitationCode = $stateParams.code || '';
-    vm.invitationCodeValid = false;
-    vm.invitationCodeError = false;
-    vm.validateInvitationCode = validateInvitationCode;
-    vm.isWaitingListEnabled = false;
-    vm.waitinglistInvitation = Boolean($stateParams.mwr);
-    vm.usernameMinlength = 3;
-    vm.usernameMaxlength = 34;
-    vm.suggestedTribesLimit = 4;
-
-    // Initialize controller
-    activate();
-
-
-    /**
-     * Initalize controller
-     */
-    function activate() {
-      // If invitation code was passed to the page (via URL), validate it
-      validateInvitationCode()
-        .finally(function () {
-          // Initialise waitinglist
-          initWaitingList();
-        });
-
-      // Get list of suggested tribes
-      initSuggstedTribes();
+    if (err.required || usernameModel.$usernameValue === '') {
+      return 'Username is required.';
     }
 
-    /**
-     * Parse $error and return a string
-     * @param {Object} usernameModel - Angular model for username form input
-     * @returns {String} error text
-     */
-    function getUsernameValidationError(usernameModel) {
+    if (err.maxlength) {
+      return 'Too long, maximum length is ' + vm.usernameMaxlength + ' characters.';
+    }
 
-      if (!usernameModel || !usernameModel.$dirty || usernameModel.$valid) {
-        return '';
-      }
+    if (err.minlength) {
+      return 'Too short, minumum length is ' + vm.usernameMinlength + ' characters.';
+    }
 
-      const err = usernameModel.$error || {};
-
-      if (err.required || usernameModel.$usernameValue === '') {
-        return 'Username is required.';
-      }
-
-      if (err.maxlength) {
-        return 'Too long, maximum length is ' + vm.usernameMaxlength + ' characters.';
-      }
-
-      if (err.minlength) {
-        return 'Too short, minumum length is ' + vm.usernameMinlength + ' characters.';
-      }
-
-      if (err.pattern) {
-        return 'Invalid username.';
-      }
-
-      if (err.username) {
-        return 'This username is already in use.';
-      }
-
+    if (err.pattern) {
       return 'Invalid username.';
     }
 
-    /**
-     * Initialize list of tribes to suggest
-     * Fetches information about a tribes we suggest at signup
-     * Includes specific tribe if it was refered as an URL param
-     */
-    function initSuggstedTribes() {
-      if ($stateParams.tribe) {
-        // Fetch information about referred tribe
-        TribeService.get({
-          tribeSlug: $stateParams.tribe,
-        })
-          .then(function (tribe) {
+    if (err.username) {
+      return 'This username is already in use.';
+    }
 
-            // Got it
-            if (tribe._id) {
-              vm.tribe = tribe;
-            }
+    return 'Invalid username.';
+  }
 
-            // Fetch suggested tribes list without this tribe
-            getSuggestedTribes(tribe._id || null);
+  /**
+   * Initialize list of tribes to suggest
+   * Fetches information about a tribes we suggest at signup
+   * Includes specific tribe if it was refered as an URL param
+   */
+  function initSuggstedTribes() {
+    if ($stateParams.tribe) {
+      // Fetch information about referred tribe
+      TribeService.get({
+        tribeSlug: $stateParams.tribe,
+      })
+        .then(function (tribe) {
 
-          });
+          // Got it
+          if (tribe._id) {
+            vm.tribe = tribe;
+          }
+
+          // Fetch suggested tribes list without this tribe
+          getSuggestedTribes(tribe._id || null);
+
+        });
+    } else {
+      // Fetch suggested tribes list
+      getSuggestedTribes();
+    }
+  }
+
+  /**
+   * Get suggested tribes
+   *
+   * @param withoutTribeId {String} Tribe id to take away from array
+   */
+  function getSuggestedTribes(withoutTribeId) {
+    TribesService.query({
+      limit: 20,
+    },
+    function (tribes) {
+      const suggestedTribes = [];
+
+      // Make sure to remove referred tribe from suggested tribes so that we won't have dublicates
+      // We'll always show 2 or 3 of these at the frontend depending on if referred tribe is shown.
+      if (withoutTribeId) {
+        angular.forEach(tribes, function (suggestedTribe) {
+          if (suggestedTribe._id !== withoutTribeId) {
+            // eslint-disable-next-line angular/controller-as-vm
+            this.push(suggestedTribe);
+          }
+        }, suggestedTribes);
+        vm.suggestedTribes = suggestedTribes;
       } else {
-        // Fetch suggested tribes list
-        getSuggestedTribes();
+        vm.suggestedTribes = tribes;
       }
-    }
+    });
+  }
 
-    /**
-     * Get suggested tribes
-     *
-     * @param withoutTribeId {String} Tribe id to take away from array
-     */
-    function getSuggestedTribes(withoutTribeId) {
-      TribesService.query({
-        limit: 20,
-      },
-      function (tribes) {
-        const suggestedTribes = [];
+  /**
+   * Register
+   */
+  function submitSignup() {
+    vm.isLoading = true;
 
-        // Make sure to remove referred tribe from suggested tribes so that we won't have dublicates
-        // We'll always show 2 or 3 of these at the frontend depending on if referred tribe is shown.
-        if (withoutTribeId) {
-          angular.forEach(tribes, function (suggestedTribe) {
-            if (suggestedTribe._id !== withoutTribeId) {
-              // eslint-disable-next-line angular/controller-as-vm
-              this.push(suggestedTribe);
-            }
-          }, suggestedTribes);
-          vm.suggestedTribes = suggestedTribes;
-        } else {
-          vm.suggestedTribes = tribes;
-        }
-      });
-    }
+    $http
+      .post('/api/auth/signup', vm.credentials)
+      .then(
+        function (newUser) { // On success function
 
-    /**
-     * Register
-     */
-    function submitSignup() {
-      vm.isLoading = true;
-
-      $http
-        .post('/api/auth/signup', vm.credentials)
-        .then(
-          function (newUser) { // On success function
-
-            // If there is referred tribe, add user to that next up
-            if (vm.tribe && vm.tribe._id) {
-              UserMembershipsService.post({
-                tribeId: vm.tribe._id,
-              },
-              function (data) {
-                updateUser(data.user || newUser.data);
-                vm.isLoading = false;
-                vm.step = 2;
-              });
-            } else {
-              // No tribe to join, just continue
-              updateUser(newUser.data);
+          // If there is referred tribe, add user to that next up
+          if (vm.tribe && vm.tribe._id) {
+            UserMembershipsService.post({
+              tribeId: vm.tribe._id,
+            },
+            function (data) {
+              updateUser(data.user || newUser.data);
               vm.isLoading = false;
               vm.step = 2;
-            }
-          },
-          function (error) { // On error function
-            vm.isLoading = false;
-            const errorMessage = error.data && error.data.message ? error.data.message : 'Something went wrong while signing you up. Try again!';
-            messageCenterService.add('danger', errorMessage);
-          },
-        );
-    }
-
-    /**
-     * Validate invitation code
-     * Invite code has to be present at `vm.invitationCode`
-     */
-    function validateInvitationCode() {
-      return $q(function (resolve, reject) {
-        vm.invitationCodeError = false;
-
-        if (vm.invitationCode) {
-          // Validate code
-          InvitationService.post({
-            invitecode: vm.invitationCode,
-          }).$promise.then(function (data) {
-
-            // UI
-            vm.invitationCodeValid = data.valid;
-            vm.invitationCodeError = !data.valid;
-
-            // Resolve promise
-            resolve();
-
-            // Analytics
-            if (data.valid) {
-              $analytics.eventTrack('invitationCode.valid', {
-                category: 'invitation',
-                label: 'Valid invitation code entered',
-              });
-            } else {
-              $analytics.eventTrack('invitationCode.invalid', {
-                category: 'invitation',
-                label: 'Invalid invitation code entered',
-              });
-            }
-          }, function () {
-            vm.invitationCodeValid = false;
-            vm.invitationCodeError = true;
-
-            // Reject promise
-            reject();
-
-            messageCenterService.add('danger', 'Something went wrong, try again.');
-            $analytics.eventTrack('invitationCode.failed', {
-              category: 'invitation',
-              label: 'Failed to validate invitation code',
             });
-          });
-        } else {
-          // No invite code available, just resolve promise
+          } else {
+            // No tribe to join, just continue
+            updateUser(newUser.data);
+            vm.isLoading = false;
+            vm.step = 2;
+          }
+        },
+        function (error) { // On error function
+          vm.isLoading = false;
+          const errorMessage = error.data && error.data.message ? error.data.message : 'Something went wrong while signing you up. Try again!';
+          messageCenterService.add('danger', errorMessage);
+        },
+      );
+  }
+
+  /**
+   * Validate invitation code
+   * Invite code has to be present at `vm.invitationCode`
+   */
+  function validateInvitationCode() {
+    return $q(function (resolve, reject) {
+      vm.invitationCodeError = false;
+
+      if (vm.invitationCode) {
+        // Validate code
+        InvitationService.post({
+          invitecode: vm.invitationCode,
+        }).$promise.then(function (data) {
+
+          // UI
+          vm.invitationCodeValid = data.valid;
+          vm.invitationCodeError = !data.valid;
+
+          // Resolve promise
           resolve();
-        }
-      });
-    }
 
-    /**
-     * Initialize waiting list
-     * @link https://maitreapp.co
-     */
-    function initWaitingList() {
+          // Analytics
+          if (data.valid) {
+            $analytics.eventTrack('invitationCode.valid', {
+              category: 'invitation',
+              label: 'Valid invitation code entered',
+            });
+          } else {
+            $analytics.eventTrack('invitationCode.invalid', {
+              category: 'invitation',
+              label: 'Invalid invitation code entered',
+            });
+          }
+        }, function () {
+          vm.invitationCodeValid = false;
+          vm.invitationCodeError = true;
 
-      // Don't proceed if no invitations enabled,
-      // or no Maitre id available
-      // or if valid invite code was already given
-      if (!appSettings.invitationsEnabled ||
-          !appSettings.maitreId ||
-          vm.invitationCodeValid) {
-        return;
-      }
+          // Reject promise
+          reject();
 
-      // Either store `mwr` URL parameter to localStorage
-      // or pick it up from localStorage and put it back to URL
-      // `mwr` is a Maitre invite parameter
-      if (locker.supported()) {
-        const mwrLockerKey = 'waitinglist.mwr';
-        // If `mwr` attribute is in the URL...
-        if ($stateParams.mwr) {
-          // ...store it in local storage
-          locker.put(mwrLockerKey, $stateParams.mwr);
-          $analytics.eventTrack('waitinglist.enabled', {
-            category: 'waitinglist',
-            label: 'Waiting list invitation code enabled',
-          });
-        // If previously stored `mwr` is available in locker...
-        } else if (locker.get(mwrLockerKey)) {
-          // ...put it back to the URL
-          // This route has `reloadOnSearch:false` configured so it won't
-          // reload the view
-          // See modules/users/client/config/users.client.routes.js
-          $location.search('mwr', locker.get(mwrLockerKey));
-          vm.waitinglistInvitation = true;
-          $analytics.eventTrack('waitinglist.re-enabled', {
-            category: 'waitinglist',
-            label: 'Waiting list invitation code re-enabled',
-          });
-        }
-      }
-
-      vm.isWaitingListEnabled = true;
-
-      // If page was opened via waiting list invitation,
-      // scroll to the right place on page
-      if (vm.waitinglistInvitation) {
-        $location.hash('waitinglist');
-      }
-
-      // Maitre configuration
-      // @link http://support.maitreapp.co/article/56-configuration
-      $window.Maitre = {
-        uuid: appSettings.maitreId,
-
-        // Show/hide name field in the form.
-        require_name: false,
-
-        // When "test_mode" is set to true,
-        // neither views nor registrations will be saved.
-        test_mode: Boolean($window.env !== 'production'),
-
-        // `true`: show list of waiting up users
-        // `false`: show number of waiting users
-        require_leaderboard: false,
-      };
-
-      // Initialize Maitre app by appending script to the page
-      // Expects an element with `data-maitre` be present in DOM
-      // https://api.jquery.com/jQuery.getScript/
-      jQuery.getScript('https://maitreapp.co/widget.js')
-        .fail(function () {
-          // If loading the script fails, hide waiting list feature
-          vm.isWaitingListEnabled = false;
-
-          // Send event to analytics
-          $analytics.eventTrack('waitinglist.failed', {
-            category: 'waitinglist',
-            label: 'Waiting list script failed to load.',
+          messageCenterService.add('danger', 'Something went wrong, try again.');
+          $analytics.eventTrack('invitationCode.failed', {
+            category: 'invitation',
+            label: 'Failed to validate invitation code',
           });
         });
-
-    }
-
-    /**
-     * Assign the response to the global user model
-     *
-     * @param user {object} User object to be put to Authentication
-     * @todo move this to Authentication service
-     */
-    function updateUser(user) {
-      Authentication.user = user;
-      $rootScope.$broadcast('userUpdated');
-    }
-
-    /**
-     * Open rules modal
-     */
-    function openRules($event) {
-      if ($event) {
-        $event.preventDefault();
+      } else {
+        // No invite code available, just resolve promise
+        resolve();
       }
+    });
+  }
 
-      // Open modal
-      $uibModal.open({
-        templateUrl: rulesModalTemplateUrl,
-      });
+  /**
+   * Initialize waiting list
+   * @link https://maitreapp.co
+   */
+  function initWaitingList() {
 
-      // Record event to analytics
-      $analytics.eventTrack('signup.rules.open', {
-        category: 'signup',
-        label: 'Open rules from signup form',
-      });
+    // Don't proceed if no invitations enabled,
+    // or no Maitre id available
+    // or if valid invite code was already given
+    if (!appSettings.invitationsEnabled ||
+        !appSettings.maitreId ||
+        vm.invitationCodeValid) {
+      return;
     }
+
+    // Either store `mwr` URL parameter to localStorage
+    // or pick it up from localStorage and put it back to URL
+    // `mwr` is a Maitre invite parameter
+    if (locker.supported()) {
+      const mwrLockerKey = 'waitinglist.mwr';
+      // If `mwr` attribute is in the URL...
+      if ($stateParams.mwr) {
+        // ...store it in local storage
+        locker.put(mwrLockerKey, $stateParams.mwr);
+        $analytics.eventTrack('waitinglist.enabled', {
+          category: 'waitinglist',
+          label: 'Waiting list invitation code enabled',
+        });
+      // If previously stored `mwr` is available in locker...
+      } else if (locker.get(mwrLockerKey)) {
+        // ...put it back to the URL
+        // This route has `reloadOnSearch:false` configured so it won't
+        // reload the view
+        // See modules/users/client/config/users.client.routes.js
+        $location.search('mwr', locker.get(mwrLockerKey));
+        vm.waitinglistInvitation = true;
+        $analytics.eventTrack('waitinglist.re-enabled', {
+          category: 'waitinglist',
+          label: 'Waiting list invitation code re-enabled',
+        });
+      }
+    }
+
+    vm.isWaitingListEnabled = true;
+
+    // If page was opened via waiting list invitation,
+    // scroll to the right place on page
+    if (vm.waitinglistInvitation) {
+      $location.hash('waitinglist');
+    }
+
+    // Maitre configuration
+    // @link http://support.maitreapp.co/article/56-configuration
+    $window.Maitre = {
+      uuid: appSettings.maitreId,
+
+      // Show/hide name field in the form.
+      require_name: false,
+
+      // When "test_mode" is set to true,
+      // neither views nor registrations will be saved.
+      test_mode: Boolean($window.env !== 'production'),
+
+      // `true`: show list of waiting up users
+      // `false`: show number of waiting users
+      require_leaderboard: false,
+    };
+
+    // Initialize Maitre app by appending script to the page
+    // Expects an element with `data-maitre` be present in DOM
+    // https://api.jquery.com/jQuery.getScript/
+    jQuery.getScript('https://maitreapp.co/widget.js')
+      .fail(function () {
+        // If loading the script fails, hide waiting list feature
+        vm.isWaitingListEnabled = false;
+
+        // Send event to analytics
+        $analytics.eventTrack('waitinglist.failed', {
+          category: 'waitinglist',
+          label: 'Waiting list script failed to load.',
+        });
+      });
 
   }
-}(jQuery));
+
+  /**
+   * Assign the response to the global user model
+   *
+   * @param user {object} User object to be put to Authentication
+   * @todo move this to Authentication service
+   */
+  function updateUser(user) {
+    Authentication.user = user;
+    $rootScope.$broadcast('userUpdated');
+  }
+
+  /**
+   * Open rules modal
+   */
+  function openRules($event) {
+    if ($event) {
+      $event.preventDefault();
+    }
+
+    // Open modal
+    $uibModal.open({
+      templateUrl: rulesModalTemplateUrl,
+    });
+
+    // Record event to analytics
+    $analytics.eventTrack('signup.rules.open', {
+      category: 'signup',
+      label: 'Open rules from signup form',
+    });
+  }
+
+}

--- a/modules/users/client/directives/tr-avatar.client.directive.js
+++ b/modules/users/client/directives/tr-avatar.client.directive.js
@@ -1,140 +1,138 @@
-(function () {
-  /**
-   * @ngdoc directive
-   *
-   * @name trustroots:trAvatar
-   *
-   * @param {object} user User object
-   * @param {int} size Size of the image <img>. Supported values are 2048, 1024, 512, 256, 128, 64, 36, 32, 24 and 16. See avatar.less for details. Defaults to 256.
-   * @param {string} source Leave empty to use user's selected source. Values "none", "facebook", "local", "gravatar".
-   * @param {boolean} link Link to user's profile. Defaults to true.
-   *
-   * @description
-   *
-   * Use this directive to produce user's avatar
-   *
-   * @example
-   *
-   * <pre>
-   * Basic:
-   * <div tr-avatar data-user="user" size="36"></div>
-   *
-   * Advanced:
-   * <div tr-avatar data-user="user" link="false" source="local" size="36"></div>
-   * </pre>
-   */
-  angular.module('users').directive('trAvatar', ['$location',
-    function ($location) {
+/**
+ * @ngdoc directive
+ *
+ * @name trustroots:trAvatar
+ *
+ * @param {object} user User object
+ * @param {int} size Size of the image <img>. Supported values are 2048, 1024, 512, 256, 128, 64, 36, 32, 24 and 16. See avatar.less for details. Defaults to 256.
+ * @param {string} source Leave empty to use user's selected source. Values "none", "facebook", "local", "gravatar".
+ * @param {boolean} link Link to user's profile. Defaults to true.
+ *
+ * @description
+ *
+ * Use this directive to produce user's avatar
+ *
+ * @example
+ *
+ * <pre>
+ * Basic:
+ * <div tr-avatar data-user="user" size="36"></div>
+ *
+ * Advanced:
+ * <div tr-avatar data-user="user" link="false" source="local" size="36"></div>
+ * </pre>
+ */
+angular.module('users').directive('trAvatar', ['$location',
+  function ($location) {
 
-      // Options
-      const defaultSize = 256;
-      const defaultAvatar = '/img/avatar.png';
+    // Options
+    const defaultSize = 256;
+    const defaultAvatar = '/img/avatar.png';
 
-      return {
-        template:
-          '<div ng-switch="link" ng-cloak>' +
-          '  <img class="avatar avatar-{{ size }} avatar-{{ source }}" ' +
-          '       alt=""' +
-          '       aria-hidden="true"' +
-          '       ng-switch-when="false"' +
-          '       ng-src="{{ avatar }}"' +
-          '       draggable="false">' +
-          '  <a ng-switch-when="true"' +
-          '     ui-sref="profile.about({username: user.username})"' +
-          '     aria-label="Open user profile for {{ ::user.displayName }}">' +
-          '    <img class="avatar avatar-{{ size }} avatar-{{ source }}"' +
-          '         alt=""' +
-          '         aria-hidden="true"' +
-          '         ng-class="avatar-{{ size }}"' +
-          '         ng-src="{{ avatar }}"' +
-          '         draggable="false"></a>' +
-          '</div>',
-        restrict: 'A',
-        scope: {
-          user: '=user',
-        },
-        controller: ['$scope', function ($scope) {
+    return {
+      template:
+        '<div ng-switch="link" ng-cloak>' +
+        '  <img class="avatar avatar-{{ size }} avatar-{{ source }}" ' +
+        '       alt=""' +
+        '       aria-hidden="true"' +
+        '       ng-switch-when="false"' +
+        '       ng-src="{{ avatar }}"' +
+        '       draggable="false">' +
+        '  <a ng-switch-when="true"' +
+        '     ui-sref="profile.about({username: user.username})"' +
+        '     aria-label="Open user profile for {{ ::user.displayName }}">' +
+        '    <img class="avatar avatar-{{ size }} avatar-{{ source }}"' +
+        '         alt=""' +
+        '         aria-hidden="true"' +
+        '         ng-class="avatar-{{ size }}"' +
+        '         ng-src="{{ avatar }}"' +
+        '         draggable="false"></a>' +
+        '</div>',
+      restrict: 'A',
+      scope: {
+        user: '=user',
+      },
+      controller: ['$scope', function ($scope) {
 
-          $scope.avatar = defaultAvatar;
-          $scope.size = defaultSize;
+        $scope.avatar = defaultAvatar;
+        $scope.size = defaultSize;
 
-          function determineSource() {
+        function determineSource() {
 
-            // Determine source for avatar
-            if ($scope.fixedSource) {
-              $scope.source = $scope.fixedSource;
-            } else if ($scope.user && $scope.user.avatarSource) {
-              $scope.source = $scope.user.avatarSource;
-            } else {
-              $scope.source = 'none';
-            }
-
-            // Avatar via FB
-            // @link https://developers.facebook.com/docs/graph-api/reference/user/picture/
-            if ($scope.source === 'facebook') {
-              if ($scope.user &&
-                  $scope.user.additionalProvidersData &&
-                  $scope.user.additionalProvidersData.facebook &&
-                  $scope.user.additionalProvidersData.facebook.id) {
-                $scope.avatar = $location.protocol() + '://graph.facebook.com/' + $scope.user.additionalProvidersData.facebook.id + '/picture/?width=' + ($scope.size || defaultSize) + '&height=' + ($scope.size || defaultSize);
-              } else {
-                $scope.avatar = defaultAvatar;
-              }
-            // Avatar via Gravatar
-            // @link https://en.gravatar.com/site/implement/images/
-            } else if ($scope.source === 'gravatar') {
-              if ($scope.user.emailHash) {
-                $scope.avatar = $location.protocol() + '://gravatar.com/avatar/' + $scope.user.emailHash + '?s=' + ($scope.size || defaultSize);
-
-                // This fallback image won't work via localhost since Gravatar fallback is required to be online.
-                $scope.avatar += '&d=' + encodeURIComponent($location.protocol() + '://' + $location.host() + ':' + $location.port() + defaultAvatar);
-              } else {
-                $scope.avatar = defaultAvatar;
-              }
-            // Locally uploaded avatar
-            } else if ($scope.source === 'local') {
-              if ($scope.user.avatarUploaded && $scope.user && $scope.user._id) {
-                // Cache buster
-                const timestamp = $scope.user.updated ? new Date($scope.user.updated).getTime() : '';
-
-                // 32 is the smallest and 2048 biggest file size we're generating.
-                const fileSize = ($scope.size < 32) ? 32 : $scope.size;
-
-                $scope.avatar = '/uploads-profile/' + $scope.user._id + '/avatar/' + fileSize + '.jpg?' + timestamp;
-              } else {
-                $scope.avatar = defaultAvatar;
-              }
-            // Dummy avatar
-            } else {
-              $scope.avatar = defaultAvatar + '?none';
-            }
-          } // determineSource()
-
-          $scope.$watch('user.avatarSource', function () {
-            determineSource();
-          });
-
-          $scope.$watch('user.updated', function () {
-            determineSource();
-          });
-
-        }],
-        link: function (scope, element, attr) {
-
-          // Make sure source won't change dynamicly when user changes
-          if (attr.source) {
-            scope.source = attr.source;
-            scope.fixedSource = attr.source;
+          // Determine source for avatar
+          if ($scope.fixedSource) {
+            $scope.source = $scope.fixedSource;
+          } else if ($scope.user && $scope.user.avatarSource) {
+            $scope.source = $scope.user.avatarSource;
+          } else {
+            $scope.source = 'none';
           }
 
-          // Options
-          scope.size = attr.size || defaultSize;
+          // Avatar via FB
+          // @link https://developers.facebook.com/docs/graph-api/reference/user/picture/
+          if ($scope.source === 'facebook') {
+            if ($scope.user &&
+                $scope.user.additionalProvidersData &&
+                $scope.user.additionalProvidersData.facebook &&
+                $scope.user.additionalProvidersData.facebook.id) {
+              $scope.avatar = $location.protocol() + '://graph.facebook.com/' + $scope.user.additionalProvidersData.facebook.id + '/picture/?width=' + ($scope.size || defaultSize) + '&height=' + ($scope.size || defaultSize);
+            } else {
+              $scope.avatar = defaultAvatar;
+            }
+          // Avatar via Gravatar
+          // @link https://en.gravatar.com/site/implement/images/
+          } else if ($scope.source === 'gravatar') {
+            if ($scope.user.emailHash) {
+              $scope.avatar = $location.protocol() + '://gravatar.com/avatar/' + $scope.user.emailHash + '?s=' + ($scope.size || defaultSize);
 
-          // By default show the link
-          scope.link = attr.link !== 'false';
+              // This fallback image won't work via localhost since Gravatar fallback is required to be online.
+              $scope.avatar += '&d=' + encodeURIComponent($location.protocol() + '://' + $location.host() + ':' + $location.port() + defaultAvatar);
+            } else {
+              $scope.avatar = defaultAvatar;
+            }
+          // Locally uploaded avatar
+          } else if ($scope.source === 'local') {
+            if ($scope.user.avatarUploaded && $scope.user && $scope.user._id) {
+              // Cache buster
+              const timestamp = $scope.user.updated ? new Date($scope.user.updated).getTime() : '';
 
-        },
-      };
-    },
-  ]);
-}());
+              // 32 is the smallest and 2048 biggest file size we're generating.
+              const fileSize = ($scope.size < 32) ? 32 : $scope.size;
+
+              $scope.avatar = '/uploads-profile/' + $scope.user._id + '/avatar/' + fileSize + '.jpg?' + timestamp;
+            } else {
+              $scope.avatar = defaultAvatar;
+            }
+          // Dummy avatar
+          } else {
+            $scope.avatar = defaultAvatar + '?none';
+          }
+        } // determineSource()
+
+        $scope.$watch('user.avatarSource', function () {
+          determineSource();
+        });
+
+        $scope.$watch('user.updated', function () {
+          determineSource();
+        });
+
+      }],
+      link: function (scope, element, attr) {
+
+        // Make sure source won't change dynamicly when user changes
+        if (attr.source) {
+          scope.source = attr.source;
+          scope.fixedSource = attr.source;
+        }
+
+        // Options
+        scope.size = attr.size || defaultSize;
+
+        // By default show the link
+        scope.link = attr.link !== 'false';
+
+      },
+    };
+  },
+]);

--- a/modules/users/client/directives/tr-confirm-password.client.directive.js
+++ b/modules/users/client/directives/tr-confirm-password.client.directive.js
@@ -1,36 +1,34 @@
-(function () {
-  /**
-   * Directive to validate password matches to password in another field
-   *
-   * Usage:
-   * <input type="password" name="password1" ng-model="password">
-   *
-   * <input type="password" name="password2" tr-confirm-password="password">
-   *
-   *
-   */
-  angular
-    .module('users')
-    .directive('trConfirmPassword', trConfirmPasswordDirective);
+/**
+ * Directive to validate password matches to password in another field
+ *
+ * Usage:
+ * <input type="password" name="password1" ng-model="password">
+ *
+ * <input type="password" name="password2" tr-confirm-password="password">
+ *
+ *
+ */
+angular
+  .module('users')
+  .directive('trConfirmPassword', trConfirmPasswordDirective);
 
-  /* @ngInject */
-  function trConfirmPasswordDirective() {
-    return {
-      restrict: 'A',
-      require: 'ngModel',
-      scope: {
-        comparisonValue: '=trConfirmPassword',
-      },
-      link: function (scope, element, attributes, ngModel) {
+/* @ngInject */
+function trConfirmPasswordDirective() {
+  return {
+    restrict: 'A',
+    require: 'ngModel',
+    scope: {
+      comparisonValue: '=trConfirmPassword',
+    },
+    link: function (scope, element, attributes, ngModel) {
 
-        ngModel.$validators.confirmPassword = function (modelValue) {
-          return modelValue === scope.comparisonValue;
-        };
+      ngModel.$validators.confirmPassword = function (modelValue) {
+        return modelValue === scope.comparisonValue;
+      };
 
-        scope.$watch('comparisonValue', function () {
-          ngModel.$validate();
-        });
-      },
-    };
-  }
-}());
+      scope.$watch('comparisonValue', function () {
+        ngModel.$validate();
+      });
+    },
+  };
+}

--- a/modules/users/client/directives/tr-memberships-list.client.directive.js
+++ b/modules/users/client/directives/tr-memberships-list.client.directive.js
@@ -1,32 +1,30 @@
 import templateUrl from '@/modules/users/client/views/directives/tr-memberships-list.client.view.html';
 
-(function () {
-  /**
-   * Simple list of tribes user is member of
-   */
-  angular
-    .module('users')
-    .directive('trMembershipsList', trMembershipsListDirective);
+/**
+ * Simple list of tribes user is member of
+ */
+angular
+  .module('users')
+  .directive('trMembershipsList', trMembershipsListDirective);
 
-  /* @ngInject */
-  function trMembershipsListDirective() {
-    return {
-      templateUrl,
-      restrict: 'A',
-      replace: true,
-      scope: {
-        memberships: '=trMembershipsList',
-        isOwnProfile: '=',
-      },
-      controller: trMembershipsListController,
+/* @ngInject */
+function trMembershipsListDirective() {
+  return {
+    templateUrl,
+    restrict: 'A',
+    replace: true,
+    scope: {
+      memberships: '=trMembershipsList',
+      isOwnProfile: '=',
+    },
+    controller: trMembershipsListController,
 
-    };
-  }
+  };
+}
 
-  function trMembershipsListController($scope) {
-    $scope.tribeListLimit = 5;
-    $scope.toggle = function () {
-      $scope.tribeListLimit = undefined;
-    };
-  }
-}());
+function trMembershipsListController($scope) {
+  $scope.tribeListLimit = 5;
+  $scope.toggle = function () {
+    $scope.tribeListLimit = undefined;
+  };
+}

--- a/modules/users/client/directives/tr-monkeybox.client.directive.js
+++ b/modules/users/client/directives/tr-monkeybox.client.directive.js
@@ -1,27 +1,25 @@
 import templateUrl from '@/modules/users/client/views/directives/tr-monkeybox.client.view.html';
 
-(function () {
-  /**
-   * Monkeybox directive to show a simple profile info box
-   */
-  angular
-    .module('users')
-    .directive('trMonkeybox', trMonkeyboxDirective);
+/**
+ * Monkeybox directive to show a simple profile info box
+ */
+angular
+  .module('users')
+  .directive('trMonkeybox', trMonkeyboxDirective);
 
-  /* @ngInject */
-  function trMonkeyboxDirective() {
-    return {
-      templateUrl,
-      restrict: 'A',
-      replace: true,
-      scope: {
-        profile: '=',
-      },
-      controller: ['$scope', 'Languages', function ($scope, Languages) {
+/* @ngInject */
+function trMonkeyboxDirective() {
+  return {
+    templateUrl,
+    restrict: 'A',
+    replace: true,
+    scope: {
+      profile: '=',
+    },
+    controller: ['$scope', 'Languages', function ($scope, Languages) {
 
-        $scope.languageNames = Languages.get('object');
+      $scope.languageNames = Languages.get('object');
 
-      }],
-    };
-  }
-}());
+    }],
+  };
+}

--- a/modules/users/client/directives/tr-validate-username.client.directive.js
+++ b/modules/users/client/directives/tr-validate-username.client.directive.js
@@ -1,70 +1,68 @@
-(function () {
-  /**
-   * Directive to validate usernames (and check for availability)
-   *
-   * Usage:
-   * ```
-   * <input tr-validate-username>
-   * ```
-   *
-   * Or to avoid validating specific string (like user's previous username):
-   * ```
-   * <input tr-validate-username="{{::username}}">
-   * ```
-   */
-  angular
-    .module('users')
-    .directive('trValidateUsername', trValidateUsernameDirective);
+/**
+ * Directive to validate usernames (and check for availability)
+ *
+ * Usage:
+ * ```
+ * <input tr-validate-username>
+ * ```
+ *
+ * Or to avoid validating specific string (like user's previous username):
+ * ```
+ * <input tr-validate-username="{{::username}}">
+ * ```
+ */
+angular
+  .module('users')
+  .directive('trValidateUsername', trValidateUsernameDirective);
 
-  /* @ngInject */
-  function trValidateUsernameDirective($q, $timeout, SignupValidation) {
+/* @ngInject */
+function trValidateUsernameDirective($q, $timeout, SignupValidation) {
 
-    let delayedUsernameValidation;
+  let delayedUsernameValidation;
 
-    return {
-      restrict: 'A',
-      require: 'ngModel',
-      link: function (scope, elem, attr, ngModel) {
-        const minlength = angular.isDefined(attr.minlength) ? attr.minlength : 1;
+  return {
+    restrict: 'A',
+    require: 'ngModel',
+    link: function (scope, elem, attr, ngModel) {
+      const minlength = angular.isDefined(attr.minlength) ? attr.minlength : 1;
 
-        ngModel.$asyncValidators.username = function (modelValue) {
-          return $q(function (resolve, reject) {
+      ngModel.$asyncValidators.username = function (modelValue) {
+        return $q(function (resolve, reject) {
 
-            ngModel.$setValidity('username', true);
+          ngModel.$setValidity('username', true);
 
-            if (modelValue && modelValue.length >= minlength) {
-              if (delayedUsernameValidation) {
-                $timeout.cancel(delayedUsernameValidation);
+          if (modelValue && modelValue.length >= minlength) {
+            if (delayedUsernameValidation) {
+              $timeout.cancel(delayedUsernameValidation);
+            }
+
+            delayedUsernameValidation = $timeout(function () {
+              delayedUsernameValidation = false;
+
+              // If current value is the same as initial input value, don't do anything
+              if (attr.trValidateUsername && modelValue === attr.trValidateUsername) {
+                return resolve();
               }
 
-              delayedUsernameValidation = $timeout(function () {
-                delayedUsernameValidation = false;
+              SignupValidation
+                .post({ username: modelValue })
+                .$promise
+                .then(function (results) {
+                  if (results && !results.valid) {
+                    // Got result and it's negative
+                    reject();
+                  } else {
+                    // Either result was positive or we couldn't receive any
+                    // response, but regard networks errors as false negatives.
+                    // Otherwise we'd flag everything invalid
+                    resolve();
+                  }
+                });
+            }, 1000);
+          }
+        });
+      };
 
-                // If current value is the same as initial input value, don't do anything
-                if (attr.trValidateUsername && modelValue === attr.trValidateUsername) {
-                  return resolve();
-                }
-
-                SignupValidation
-                  .post({ username: modelValue })
-                  .$promise
-                  .then(function (results) {
-                    if (results && !results.valid) {
-                      // Got result and it's negative
-                      reject();
-                    } else {
-                      // Either result was positive or we couldn't receive any
-                      // response, but regard networks errors as false negatives.
-                      // Otherwise we'd flag everything invalid
-                      resolve();
-                    }
-                  });
-              }, 1000);
-            }
-          });
-        };
-
-      },
-    };
-  }
-}());
+    },
+  };
+}

--- a/modules/users/client/services/authentication.client.service.js
+++ b/modules/users/client/services/authentication.client.service.js
@@ -1,14 +1,12 @@
-(function () {
-  // Authentication service for user variables
-  angular
-    .module('users')
-    .factory('Authentication', Authentication);
+// Authentication service for user variables
+angular
+  .module('users')
+  .factory('Authentication', Authentication);
 
-  /* @ngInject */
-  function Authentication($window) {
-    const auth = {
-      user: $window.user || null,
-    };
-    return auth;
-  }
-}());
+/* @ngInject */
+function Authentication($window) {
+  const auth = {
+    user: $window.user || null,
+  };
+  return auth;
+}

--- a/modules/users/client/services/invitation.client.service.js
+++ b/modules/users/client/services/invitation.client.service.js
@@ -1,19 +1,17 @@
-(function () {
-  angular
-    .module('users')
-    .factory('InvitationService', InvitationService);
+angular
+  .module('users')
+  .factory('InvitationService', InvitationService);
 
-  /* @ngInject */
-  function InvitationService($resource) {
-    return $resource('/api/users/invitecode/:invitecode', {
-      invitecode: '@invitecode',
-    }, {
-      get: {
-        method: 'GET',
-      },
-      post: {
-        method: 'POST',
-      },
-    });
-  }
-}());
+/* @ngInject */
+function InvitationService($resource) {
+  return $resource('/api/users/invitecode/:invitecode', {
+    invitecode: '@invitecode',
+  }, {
+    get: {
+      method: 'GET',
+    },
+    post: {
+      method: 'POST',
+    },
+  });
+}

--- a/modules/users/client/services/signup-validation.client.service.js
+++ b/modules/users/client/services/signup-validation.client.service.js
@@ -1,15 +1,13 @@
-(function () {
-  // SignupValidation service used for communicating with the signup validation REST endpoint
-  angular
-    .module('users')
-    .factory('SignupValidation', SignupValidationFactory);
+// SignupValidation service used for communicating with the signup validation REST endpoint
+angular
+  .module('users')
+  .factory('SignupValidation', SignupValidationFactory);
 
-  /* @ngInject */
-  function SignupValidationFactory($resource) {
-    return $resource('/api/auth/signup/validate', {}, {
-      post: {
-        method: 'POST',
-      },
-    });
-  }
-}());
+/* @ngInject */
+function SignupValidationFactory($resource) {
+  return $resource('/api/auth/signup/validate', {}, {
+    post: {
+      method: 'POST',
+    },
+  });
+}

--- a/modules/users/client/services/users-memberships.client.service.js
+++ b/modules/users/client/services/users-memberships.client.service.js
@@ -1,22 +1,20 @@
-(function () {
-  angular
-    .module('users')
-    .factory('UserMembershipsService', UserMembershipsService);
+angular
+  .module('users')
+  .factory('UserMembershipsService', UserMembershipsService);
 
-  /* @ngInject */
-  function UserMembershipsService($resource) {
-    return $resource('/api/users/memberships/:tribeId?', {
-      tribeId: '@tribeId',
-    }, {
-      post: {
-        method: 'POST',
-      },
-      delete: {
-        method: 'DELETE',
-      },
-      get: {
-        method: 'GET',
-      },
-    });
-  }
-}());
+/* @ngInject */
+function UserMembershipsService($resource) {
+  return $resource('/api/users/memberships/:tribeId?', {
+    tribeId: '@tribeId',
+  }, {
+    post: {
+      method: 'POST',
+    },
+    delete: {
+      method: 'DELETE',
+    },
+    get: {
+      method: 'GET',
+    },
+  });
+}

--- a/modules/users/client/services/users-mini.client.service.js
+++ b/modules/users/client/services/users-mini.client.service.js
@@ -1,17 +1,15 @@
-(function () {
-  // Used to receive basic info to show avatars etc...
-  angular
-    .module('users')
-    .factory('UsersMini', UsersMiniFactory);
+// Used to receive basic info to show avatars etc...
+angular
+  .module('users')
+  .factory('UsersMini', UsersMiniFactory);
 
-  /* @ngInject */
-  function UsersMiniFactory($resource) {
-    return $resource('/api/users/mini/:userId', {
-      userId: '@id',
-    }, {
-      get: {
-        method: 'GET',
-      },
-    });
-  }
-}());
+/* @ngInject */
+function UsersMiniFactory($resource) {
+  return $resource('/api/users/mini/:userId', {
+    userId: '@id',
+  }, {
+    get: {
+      method: 'GET',
+    },
+  });
+}

--- a/modules/users/client/services/users-profile.client.service.js
+++ b/modules/users/client/services/users-profile.client.service.js
@@ -1,16 +1,14 @@
-(function () {
-  angular
-    .module('users')
-    .factory('UserProfilesService', UserProfilesService);
+angular
+  .module('users')
+  .factory('UserProfilesService', UserProfilesService);
 
-  /* @ngInject */
-  function UserProfilesService($resource) {
-    return $resource('/api/users/:username', {
-      username: '@username',
-    }, {
-      get: {
-        method: 'GET',
-      },
-    });
-  }
-}());
+/* @ngInject */
+function UserProfilesService($resource) {
+  return $resource('/api/users/:username', {
+    username: '@username',
+  }, {
+    get: {
+      method: 'GET',
+    },
+  });
+}

--- a/modules/users/client/services/users.client.service.js
+++ b/modules/users/client/services/users.client.service.js
@@ -1,37 +1,35 @@
-(function () {
-  // Users service used for communicating with the users REST endpoint
-  angular
-    .module('users')
-    .factory('Users', UsersFactory);
+// Users service used for communicating with the users REST endpoint
+angular
+  .module('users')
+  .factory('Users', UsersFactory);
 
-  /* @ngInject */
-  function UsersFactory($resource) {
-    const Users = $resource('/api/users', {}, {
-      update: {
-        method: 'PUT',
-      },
-      get: {
-        method: 'GET',
-      },
-      delete: {
-        method: 'DELETE',
-      },
-      deleteConfirm: {
-        method: 'DELETE',
-        url: '/api/users/remove/:token',
-      },
-    });
+/* @ngInject */
+function UsersFactory($resource) {
+  const Users = $resource('/api/users', {}, {
+    update: {
+      method: 'PUT',
+    },
+    get: {
+      method: 'GET',
+    },
+    delete: {
+      method: 'DELETE',
+    },
+    deleteConfirm: {
+      method: 'DELETE',
+      url: '/api/users/remove/:token',
+    },
+  });
 
-    angular.extend(Users, {
-      deleteWithToken: function (token) {
-        return this.deleteConfirm({
-          'token': token, // api expects token as a parameter (i.e. /:token)
-        }, {
-          'token': token,
-        }).$promise;
-      },
-    });
+  angular.extend(Users, {
+    deleteWithToken: function (token) {
+      return this.deleteConfirm({
+        'token': token, // api expects token as a parameter (i.e. /:token)
+      }, {
+        'token': token,
+      }).$promise;
+    },
+  });
 
-    return Users;
-  }
-}());
+  return Users;
+}

--- a/modules/users/tests/client/authentication.client.controller.tests.js
+++ b/modules/users/tests/client/authentication.client.controller.tests.js
@@ -2,107 +2,105 @@ import '@/modules/users/client/users.client.module';
 import '@/modules/search/client/search.client.module';
 import AppConfig from '@/modules/core/client/app/config';
 
-(function () {
-  // Authentication controller Spec
-  describe('AuthenticationController', function () {
-    // Initialize global variables
-    let AuthenticationController;
-    let $httpBackend;
-    let $state;
-    let Authentication;
+// Authentication controller Spec
+describe('AuthenticationController', function () {
+  // Initialize global variables
+  let AuthenticationController;
+  let $httpBackend;
+  let $state;
+  let Authentication;
 
-    // Load the main application module
-    beforeEach(angular.mock.module(AppConfig.appModuleName));
+  // Load the main application module
+  beforeEach(angular.mock.module(AppConfig.appModuleName));
 
-    describe('Logged out user', function () {
+  describe('Logged out user', function () {
 
-      let $scope;
-      const appSettings = {
-        flashTimeout: 0,
-      };
+    let $scope;
+    const appSettings = {
+      flashTimeout: 0,
+    };
 
-      // The injector ignores leading and trailing underscores here (i.e. _$httpBackend_).
-      // This allows us to inject a service but then attach it to a variable
-      // with the same name as the service.
-      beforeEach(inject(function ($controller, $injector, $rootScope, _$httpBackend_, _$state_, _Authentication_) {
-        // Set a new global $scope
-        $scope = $rootScope.$new();
+    // The injector ignores leading and trailing underscores here (i.e. _$httpBackend_).
+    // This allows us to inject a service but then attach it to a variable
+    // with the same name as the service.
+    beforeEach(inject(function ($controller, $injector, $rootScope, _$httpBackend_, _$state_, _Authentication_) {
+      // Set a new global $scope
+      $scope = $rootScope.$new();
 
-        // Point global variables to injected services
-        $httpBackend = _$httpBackend_;
-        $state = _$state_;
-        Authentication = _Authentication_;
+      // Point global variables to injected services
+      $httpBackend = _$httpBackend_;
+      $state = _$state_;
+      Authentication = _Authentication_;
 
-        // Initialize the Authentication controller
-        AuthenticationController = $controller('AuthenticationController', {
-          $scope: $scope,
-          appSettings: appSettings,
-        });
-
-        $scope.vm = AuthenticationController;
-      }));
-
-      describe('AuthenticationController.signin()', function () {
-        it('should login with a correct user and password', function () {
-
-          // Test expected GET request
-          $httpBackend.when('POST', '/api/auth/signin').respond(200, 'Fred');
-          $httpBackend.when('GET', '/modules/pages/views/home.client.view.html').respond(200, '');
-          $httpBackend.when('GET', '/modules/search/views/search.client.view.html').respond(200, '');
-          $httpBackend.when('GET', '/modules/search/views/search-map.client.view.html').respond(200, '');
-          $httpBackend.when('GET', '/modules/search/views/search-sidebar.client.view.html').respond(200, '');
-
-          AuthenticationController.signin();
-          $httpBackend.flush();
-
-          // Test $scope value
-          expect(Authentication.user).toEqual('Fred');
-        });
-
-        it('should fail to log in with nothing', function () {
-
-          // Test expected POST request
-          $httpBackend.expectPOST('/api/auth/signin').respond(400, {
-            'message': 'Missing credentials',
-          });
-          $httpBackend.when('GET', '/modules/pages/views/home.client.view.html').respond(200, '');
-          $httpBackend.when('GET', '/modules/search/views/search.client.view.html').respond(200, '');
-
-          AuthenticationController.signin();
-          $httpBackend.flush();
-          $scope.$digest();
-
-          // Test $scope value
-          expect(Authentication.user).toBeNull();
-        });
-
+      // Initialize the Authentication controller
+      AuthenticationController = $controller('AuthenticationController', {
+        $scope: $scope,
+        appSettings: appSettings,
       });
 
-      describe('Logged in user', function () {
-        beforeEach(inject(function ($controller, $rootScope, _$state_, _Authentication_) {
-          $scope = $rootScope.$new();
+      $scope.vm = AuthenticationController;
+    }));
 
-          $state = _$state_;
-          $state.go = jasmine.createSpy().and.returnValue(true);
+    describe('AuthenticationController.signin()', function () {
+      it('should login with a correct user and password', function () {
 
-          // Mock logged in user
-          _Authentication_.user = {
-            username: 'test',
-            roles: ['user'],
-          };
+        // Test expected GET request
+        $httpBackend.when('POST', '/api/auth/signin').respond(200, 'Fred');
+        $httpBackend.when('GET', '/modules/pages/views/home.client.view.html').respond(200, '');
+        $httpBackend.when('GET', '/modules/search/views/search.client.view.html').respond(200, '');
+        $httpBackend.when('GET', '/modules/search/views/search-map.client.view.html').respond(200, '');
+        $httpBackend.when('GET', '/modules/search/views/search-sidebar.client.view.html').respond(200, '');
 
-          AuthenticationController = $controller('AuthenticationController', {
-            $scope: $scope,
-            appSettings: appSettings,
-          });
-        }));
+        AuthenticationController.signin();
+        $httpBackend.flush();
 
-        it('should be redirected to home', function () {
-          expect($state.go).toHaveBeenCalledWith('search.map');
+        // Test $scope value
+        expect(Authentication.user).toEqual('Fred');
+      });
+
+      it('should fail to log in with nothing', function () {
+
+        // Test expected POST request
+        $httpBackend.expectPOST('/api/auth/signin').respond(400, {
+          'message': 'Missing credentials',
         });
+        $httpBackend.when('GET', '/modules/pages/views/home.client.view.html').respond(200, '');
+        $httpBackend.when('GET', '/modules/search/views/search.client.view.html').respond(200, '');
+
+        AuthenticationController.signin();
+        $httpBackend.flush();
+        $scope.$digest();
+
+        // Test $scope value
+        expect(Authentication.user).toBeNull();
       });
 
     });
 
+    describe('Logged in user', function () {
+      beforeEach(inject(function ($controller, $rootScope, _$state_, _Authentication_) {
+        $scope = $rootScope.$new();
+
+        $state = _$state_;
+        $state.go = jasmine.createSpy().and.returnValue(true);
+
+        // Mock logged in user
+        _Authentication_.user = {
+          username: 'test',
+          roles: ['user'],
+        };
+
+        AuthenticationController = $controller('AuthenticationController', {
+          $scope: $scope,
+          appSettings: appSettings,
+        });
+      }));
+
+      it('should be redirected to home', function () {
+        expect($state.go).toHaveBeenCalledWith('search.map');
+      });
+    });
+
   });
-}());
+
+});

--- a/modules/users/tests/client/password-forgot.client.controller.tests.js
+++ b/modules/users/tests/client/password-forgot.client.controller.tests.js
@@ -2,113 +2,111 @@ import '@/modules/users/client/users.client.module';
 import '@/modules/search/client/search.client.module';
 import AppConfig from '@/modules/core/client/app/config';
 
-(function () {
-  // Authentication controller Spec
-  describe('ForgotPasswordController', function () {
-    // Initialize global variables
-    let $scope;
-    let $httpBackend;
-    let $location;
-    let $window;
-    let Authentication;
+// Authentication controller Spec
+describe('ForgotPasswordController', function () {
+  // Initialize global variables
+  let $scope;
+  let $httpBackend;
+  let $location;
+  let $window;
+  let Authentication;
 
-    // Load the main application module
-    beforeEach(angular.mock.module(AppConfig.appModuleName));
+  // Load the main application module
+  beforeEach(angular.mock.module(AppConfig.appModuleName));
 
-    describe('Logged out user', function () {
-      beforeEach(inject(function ($controller, $rootScope, _$window_, _$httpBackend_, _$location_, _Authentication_) {
-        // Set a new global $scope
-        $scope = $rootScope.$new();
+  describe('Logged out user', function () {
+    beforeEach(inject(function ($controller, $rootScope, _$window_, _$httpBackend_, _$location_, _Authentication_) {
+      // Set a new global $scope
+      $scope = $rootScope.$new();
 
-        // Point global variables to injected services
-        $httpBackend = _$httpBackend_;
-        $location = _$location_;
-        $location.path = jasmine.createSpy().and.returnValue(true);
-        $window = _$window_;
-        $window.user = null;
-        Authentication = _Authentication_;
+      // Point global variables to injected services
+      $httpBackend = _$httpBackend_;
+      $location = _$location_;
+      $location.path = jasmine.createSpy().and.returnValue(true);
+      $window = _$window_;
+      $window.user = null;
+      Authentication = _Authentication_;
 
-        // Initialize the Authentication controller
-        $controller('ForgotPasswordController as vm', {
-          $scope: $scope,
-        });
-      }));
+      // Initialize the Authentication controller
+      $controller('ForgotPasswordController as vm', {
+        $scope: $scope,
+      });
+    }));
 
-      it('should not redirect to home', function () {
-        expect($location.path).not.toHaveBeenCalledWith('/');
+    it('should not redirect to home', function () {
+      expect($location.path).not.toHaveBeenCalledWith('/');
+    });
+
+    describe('askForPasswordReset', function () {
+      const credentials = {
+        username: 'test',
+        password: 'test',
+      };
+      beforeEach(function () {
+        // Test expected GET request
+        $httpBackend.when('GET', '/modules/users/views/password/reset-password-success.client.view.html').respond(200, '');
+        $scope.vm.credentials = credentials;
+        Authentication.user = null;
       });
 
-      describe('askForPasswordReset', function () {
-        const credentials = {
-          username: 'test',
-          password: 'test',
-        };
+      it('should clear $scope.vm.success and $scope.vm.error', function () {
+
+        $scope.vm.success = 'test';
+        $scope.vm.error = 'test';
+        $scope.vm.askForPasswordReset();
+
+        expect($scope.vm.success).toBeNull();
+        expect($scope.vm.error).toBeNull();
+      });
+
+      describe('POST error', function () {
+        const errorMessage = 'No account with that username has been found';
         beforeEach(function () {
+
           // Test expected GET request
           $httpBackend.when('GET', '/modules/users/views/password/reset-password-success.client.view.html').respond(200, '');
-          $scope.vm.credentials = credentials;
+          $httpBackend.when('POST', '/api/auth/forgot', credentials).respond(400, {
+            'message': errorMessage,
+          });
+
           Authentication.user = null;
-        });
-
-        it('should clear $scope.vm.success and $scope.vm.error', function () {
-
-          $scope.vm.success = 'test';
-          $scope.vm.error = 'test';
           $scope.vm.askForPasswordReset();
-
-          expect($scope.vm.success).toBeNull();
-          expect($scope.vm.error).toBeNull();
+          $httpBackend.flush();
         });
 
-        describe('POST error', function () {
-          const errorMessage = 'No account with that username has been found';
-          beforeEach(function () {
-
-            // Test expected GET request
-            $httpBackend.when('GET', '/modules/users/views/password/reset-password-success.client.view.html').respond(200, '');
-            $httpBackend.when('POST', '/api/auth/forgot', credentials).respond(400, {
-              'message': errorMessage,
-            });
-
-            Authentication.user = null;
-            $scope.vm.askForPasswordReset();
-            $httpBackend.flush();
-          });
-
-          it('should not clear form', function () {
-            expect($scope.vm.credentials).not.toBeNull();
-          });
-
-          it('should set error to response message', function () {
-            expect($scope.vm.error).toBe(errorMessage);
-          });
+        it('should not clear form', function () {
+          expect($scope.vm.credentials).not.toBeNull();
         });
 
-        describe('POST success', function () {
-          const successMessage = 'An email has been sent to the provided email with further instructions.';
-          beforeEach(function () {
-
-            // Test expected requests
-            $httpBackend.when('GET', '/modules/users/views/password/reset-password-success.client.view.html').respond(200, '');
-            $httpBackend.when('POST', '/api/auth/forgot', credentials).respond({
-              'message': successMessage,
-            });
-
-            Authentication.user = null;
-            $scope.vm.askForPasswordReset();
-            $httpBackend.flush();
-          });
-
-          it('should clear form', function () {
-            expect($scope.vm.credentials).toBeNull();
-          });
-
-          it('should set success to response message', function () {
-            expect($scope.vm.success).toBe(successMessage);
-          });
+        it('should set error to response message', function () {
+          expect($scope.vm.error).toBe(errorMessage);
         });
       });
 
+      describe('POST success', function () {
+        const successMessage = 'An email has been sent to the provided email with further instructions.';
+        beforeEach(function () {
+
+          // Test expected requests
+          $httpBackend.when('GET', '/modules/users/views/password/reset-password-success.client.view.html').respond(200, '');
+          $httpBackend.when('POST', '/api/auth/forgot', credentials).respond({
+            'message': successMessage,
+          });
+
+          Authentication.user = null;
+          $scope.vm.askForPasswordReset();
+          $httpBackend.flush();
+        });
+
+        it('should clear form', function () {
+          expect($scope.vm.credentials).toBeNull();
+        });
+
+        it('should set success to response message', function () {
+          expect($scope.vm.success).toBe(successMessage);
+        });
+      });
     });
+
   });
-}());
+});

--- a/modules/users/tests/client/password-reset.client.controller.tests.js
+++ b/modules/users/tests/client/password-reset.client.controller.tests.js
@@ -2,107 +2,105 @@ import '@/modules/users/client/users.client.module';
 import '@/modules/search/client/search.client.module';
 import AppConfig from '@/modules/core/client/app/config';
 
-(function () {
-  // Authentication controller Spec
-  describe('ResetPasswordController', function () {
-    // Initialize global variables
-    let $scope;
-    let $httpBackend;
-    let $stateParams;
-    let $location;
-    let $window;
-    let Authentication;
+// Authentication controller Spec
+describe('ResetPasswordController', function () {
+  // Initialize global variables
+  let $scope;
+  let $httpBackend;
+  let $stateParams;
+  let $location;
+  let $window;
+  let Authentication;
 
-    // Load the main application module
-    beforeEach(angular.mock.module(AppConfig.appModuleName));
+  // Load the main application module
+  beforeEach(angular.mock.module(AppConfig.appModuleName));
 
-    describe('Logged out user', function () {
-      beforeEach(inject(function ($controller, $rootScope, _$window_, _$stateParams_, _$httpBackend_, _$location_, _Authentication_) {
-        // Set a new global $scope
-        $scope = $rootScope.$new();
+  describe('Logged out user', function () {
+    beforeEach(inject(function ($controller, $rootScope, _$window_, _$stateParams_, _$httpBackend_, _$location_, _Authentication_) {
+      // Set a new global $scope
+      $scope = $rootScope.$new();
 
-        // Point global variables to injected services
-        $stateParams = _$stateParams_;
-        $httpBackend = _$httpBackend_;
-        $location = _$location_;
-        $location.path = jasmine.createSpy().and.returnValue(true);
-        $window = _$window_;
-        $window.user = null;
-        Authentication = _Authentication_;
+      // Point global variables to injected services
+      $stateParams = _$stateParams_;
+      $httpBackend = _$httpBackend_;
+      $location = _$location_;
+      $location.path = jasmine.createSpy().and.returnValue(true);
+      $window = _$window_;
+      $window.user = null;
+      Authentication = _Authentication_;
+
+      Authentication.user = null;
+
+      // Initialize the Authentication controller
+      $controller('ResetPasswordController as vm', {
+        $scope: $scope,
+      });
+    }));
+
+    it('should not redirect to home', function () {
+      expect($location.path).not.toHaveBeenCalledWith('/');
+    });
+
+    describe('resetUserPassword', function () {
+      const token = 'testToken';
+      const passwordDetails = {
+        password: 'test',
+      };
+      beforeEach(function () {
+
+        // Test expected GET request
+        $httpBackend.when('GET', '/modules/users/views/password/reset-password-success.client.view.html').respond(200, '');
 
         Authentication.user = null;
-
-        // Initialize the Authentication controller
-        $controller('ResetPasswordController as vm', {
-          $scope: $scope,
-        });
-      }));
-
-      it('should not redirect to home', function () {
-        expect($location.path).not.toHaveBeenCalledWith('/');
+        $stateParams.token = token;
+        $scope.vm.passwordDetails = passwordDetails;
       });
 
-      describe('resetUserPassword', function () {
-        const token = 'testToken';
-        const passwordDetails = {
-          password: 'test',
+      it('should clear $scope.vm.success and $scope.vm.error', function () {
+        $scope.vm.error = 'test';
+        $scope.vm.resetUserPassword();
+        expect($scope.vm.error).toBeNull();
+      });
+
+      it('POST error should set $scope.vm.error to response message', function () {
+        const errorMessage = 'Passwords do not match';
+        $httpBackend.when('POST', '/api/auth/reset/' + token, passwordDetails).respond(400, {
+          'message': errorMessage,
+        });
+
+        $scope.vm.resetUserPassword();
+        $httpBackend.flush();
+
+        expect($scope.vm.error).toBe(errorMessage);
+      });
+
+      describe('POST success', function () {
+        const user = {
+          username: 'test',
         };
         beforeEach(function () {
 
-          // Test expected GET request
+          // Test expected requests
           $httpBackend.when('GET', '/modules/users/views/password/reset-password-success.client.view.html').respond(200, '');
+          $httpBackend.when('POST', '/api/auth/reset/' + token, passwordDetails).respond(user);
 
           Authentication.user = null;
-          $stateParams.token = token;
-          $scope.vm.passwordDetails = passwordDetails;
-        });
-
-        it('should clear $scope.vm.success and $scope.vm.error', function () {
-          $scope.vm.error = 'test';
-          $scope.vm.resetUserPassword();
-          expect($scope.vm.error).toBeNull();
-        });
-
-        it('POST error should set $scope.vm.error to response message', function () {
-          const errorMessage = 'Passwords do not match';
-          $httpBackend.when('POST', '/api/auth/reset/' + token, passwordDetails).respond(400, {
-            'message': errorMessage,
-          });
-
           $scope.vm.resetUserPassword();
           $httpBackend.flush();
-
-          expect($scope.vm.error).toBe(errorMessage);
         });
 
-        describe('POST success', function () {
-          const user = {
-            username: 'test',
-          };
-          beforeEach(function () {
+        it('should clear password form', function () {
+          expect($scope.vm.passwordDetails).toBeNull();
+        });
 
-            // Test expected requests
-            $httpBackend.when('GET', '/modules/users/views/password/reset-password-success.client.view.html').respond(200, '');
-            $httpBackend.when('POST', '/api/auth/reset/' + token, passwordDetails).respond(user);
+        it('should attach user profile', function () {
+          expect(Authentication.user).toEqual(user);
+        });
 
-            Authentication.user = null;
-            $scope.vm.resetUserPassword();
-            $httpBackend.flush();
-          });
-
-          it('should clear password form', function () {
-            expect($scope.vm.passwordDetails).toBeNull();
-          });
-
-          it('should attach user profile', function () {
-            expect(Authentication.user).toEqual(user);
-          });
-
-          it('should redirect to password reset success view', function () {
-            expect($location.path).toHaveBeenCalledWith('/password/reset/success');
-          });
+        it('should redirect to password reset success view', function () {
+          expect($location.path).toHaveBeenCalledWith('/password/reset/success');
         });
       });
     });
   });
-}());
+});

--- a/modules/users/tests/client/profile-edit-account.client.controller.tests.js
+++ b/modules/users/tests/client/profile-edit-account.client.controller.tests.js
@@ -2,127 +2,125 @@ import '@/modules/users/client/users.client.module';
 import '@/modules/search/client/search.client.module';
 import AppConfig from '@/modules/core/client/app/config';
 
-(function () {
-  describe('ProfileEditAccountController', function () {
+describe('ProfileEditAccountController', function () {
 
-    let ProfileEditAccountController;
-    let $httpBackend;
-    let messageCenterService;
-    let Authentication;
+  let ProfileEditAccountController;
+  let $httpBackend;
+  let messageCenterService;
+  let Authentication;
 
-    const user = {
-      _id: 'user',
-      displayName: 'User',
-      emailTemporary: 'foo@foo.com',
-    };
+  const user = {
+    _id: 'user',
+    displayName: 'User',
+    emailTemporary: 'foo@foo.com',
+  };
 
-    // Load the main application module
-    beforeEach(angular.mock.module(AppConfig.appModuleName));
+  // Load the main application module
+  beforeEach(angular.mock.module(AppConfig.appModuleName));
 
-    beforeEach(inject(function (
-      _$httpBackend_,
-      _Authentication_,
-      _messageCenterService_,
-    ) {
-      $httpBackend = _$httpBackend_;
-      Authentication = _Authentication_;
+  beforeEach(inject(function (
+    _$httpBackend_,
+    _Authentication_,
+    _messageCenterService_,
+  ) {
+    $httpBackend = _$httpBackend_;
+    Authentication = _Authentication_;
 
-      messageCenterService = _messageCenterService_;
-      spyOn(messageCenterService, 'add').and.callThrough();
-    }));
+    messageCenterService = _messageCenterService_;
+    spyOn(messageCenterService, 'add').and.callThrough();
+  }));
 
-    afterEach(function () {
-      $httpBackend.verifyNoOutstandingExpectation();
-      $httpBackend.verifyNoOutstandingRequest();
+  afterEach(function () {
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+  });
+
+  describe('Logged in user', function () {
+
+    beforeEach(function (done) {
+      inject(function ($controller, $rootScope) {
+        Authentication.user = user;
+        ProfileEditAccountController = $controller('ProfileEditAccountController', {
+          messageCenterService: messageCenterService,
+          $scope: $rootScope.$new(),
+          push: {}, // this ends up trying to load firebaseMessaging service otherwise
+        });
+        done();
+      });
     });
 
-    describe('Logged in user', function () {
+    describe('change email address', function () {
 
-      beforeEach(function (done) {
-        inject(function ($controller, $rootScope) {
-          Authentication.user = user;
-          ProfileEditAccountController = $controller('ProfileEditAccountController', {
-            messageCenterService: messageCenterService,
-            $scope: $rootScope.$new(),
-            push: {}, // this ends up trying to load firebaseMessaging service otherwise
-          });
-          done();
-        });
+      it('can update email address', function () {
+        ProfileEditAccountController.user.emailTemporary = 'new@email.com';
+        const expectedPutData = {
+          _id: 'user',
+          displayName: 'User',
+          emailTemporary: 'new@email.com',
+        };
+        $httpBackend.expect('PUT', '/api/users', expectedPutData).respond(200);
+        ProfileEditAccountController.updateUserEmail();
+        $httpBackend.flush();
+        expect(messageCenterService.add).toHaveBeenCalledWith(
+          'success',
+          'Check your email for further instructions.',
+        );
       });
 
-      describe('change email address', function () {
-
-        it('can update email address', function () {
-          ProfileEditAccountController.user.emailTemporary = 'new@email.com';
-          const expectedPutData = {
-            _id: 'user',
-            displayName: 'User',
-            emailTemporary: 'new@email.com',
-          };
-          $httpBackend.expect('PUT', '/api/users', expectedPutData).respond(200);
-          ProfileEditAccountController.updateUserEmail();
-          $httpBackend.flush();
-          expect(messageCenterService.add).toHaveBeenCalledWith(
-            'success',
-            'Check your email for further instructions.',
-          );
-        });
-
-        it('can show an error message during failure', function () {
-          ProfileEditAccountController.user.emailTemporary = 'new@email.com';
-          $httpBackend.expect('PUT', '/api/users').respond(500);
-          ProfileEditAccountController.updateUserEmail();
-          $httpBackend.flush();
-          expect(ProfileEditAccountController.emailError).toEqual('Something went wrong.');
-        });
-
-        it('can show a custom error message during failure', function () {
-          ProfileEditAccountController.user.emailTemporary = 'new@email.com';
-          $httpBackend.expect('PUT', '/api/users').respond(400, { message: 'custom error' });
-          ProfileEditAccountController.updateUserEmail();
-          $httpBackend.flush();
-          expect(ProfileEditAccountController.emailError).toEqual('custom error');
-        });
-
+      it('can show an error message during failure', function () {
+        ProfileEditAccountController.user.emailTemporary = 'new@email.com';
+        $httpBackend.expect('PUT', '/api/users').respond(500);
+        ProfileEditAccountController.updateUserEmail();
+        $httpBackend.flush();
+        expect(ProfileEditAccountController.emailError).toEqual('Something went wrong.');
       });
 
-      describe('resend email confirmation', function () {
+      it('can show a custom error message during failure', function () {
+        ProfileEditAccountController.user.emailTemporary = 'new@email.com';
+        $httpBackend.expect('PUT', '/api/users').respond(400, { message: 'custom error' });
+        ProfileEditAccountController.updateUserEmail();
+        $httpBackend.flush();
+        expect(ProfileEditAccountController.emailError).toEqual('custom error');
+      });
 
-        it('can resend email', function () {
-          $httpBackend.expect('POST', '/api/auth/resend-confirmation').respond(200);
-          ProfileEditAccountController.resendUserEmailConfirm();
-          $httpBackend.flush();
-          expect(messageCenterService.add).toHaveBeenCalledWith(
-            'success',
-            'Confirmation email resent.',
-          );
+    });
+
+    describe('resend email confirmation', function () {
+
+      it('can resend email', function () {
+        $httpBackend.expect('POST', '/api/auth/resend-confirmation').respond(200);
+        ProfileEditAccountController.resendUserEmailConfirm();
+        $httpBackend.flush();
+        expect(messageCenterService.add).toHaveBeenCalledWith(
+          'success',
+          'Confirmation email resent.',
+        );
+      });
+
+      it('can show an error message during failure', function () {
+        $httpBackend.expect('POST', '/api/auth/resend-confirmation').respond(500);
+        ProfileEditAccountController.resendUserEmailConfirm();
+        $httpBackend.flush();
+        expect(messageCenterService.add).toHaveBeenCalledWith(
+          'danger',
+          'Error: Something went wrong.',
+        );
+      });
+
+      it('can show an custom error message during failure', function () {
+        $httpBackend.expect('POST', '/api/auth/resend-confirmation').respond(400, {
+          message: 'my custom error',
         });
-
-        it('can show an error message during failure', function () {
-          $httpBackend.expect('POST', '/api/auth/resend-confirmation').respond(500);
-          ProfileEditAccountController.resendUserEmailConfirm();
-          $httpBackend.flush();
-          expect(messageCenterService.add).toHaveBeenCalledWith(
-            'danger',
-            'Error: Something went wrong.',
-          );
-        });
-
-        it('can show an custom error message during failure', function () {
-          $httpBackend.expect('POST', '/api/auth/resend-confirmation').respond(400, {
-            message: 'my custom error',
-          });
-          ProfileEditAccountController.resendUserEmailConfirm();
-          $httpBackend.flush();
-          expect(messageCenterService.add).toHaveBeenCalledWith(
-            'danger',
-            'Error: my custom error',
-          );
-        });
-
+        ProfileEditAccountController.resendUserEmailConfirm();
+        $httpBackend.flush();
+        expect(messageCenterService.add).toHaveBeenCalledWith(
+          'danger',
+          'Error: my custom error',
+        );
       });
 
     });
 
   });
-}());
+
+});


### PR DESCRIPTION
Now we are in npm/webpack world we don't need these to give us scope

#### Proposed Changes

I wanted to get rid of the all the angular-era IIFE's (you know, `(function(){ /* code goes here */ })()` that wraps everything) as they are no longer needed we are in webpack (each file is it's own scope).

I wrote a jscodeshift script to do it (see https://gist.github.com/nicksellen/cbe11ad0ca9073ce762c02c897e67d1c), I was thinking we can just keep it as a standalone script (not in repo), make one BIG change PR to change everything, but then people can run the script in their branches to minimise big change.

Whaddya think?

#### Testing Instructions

* site should work as before!

To run the script:

```
npm install -g jscodeshift
curl https://gist.githubusercontent.com/nicksellen/cbe11ad0ca9073ce762c02c897e67d1c/raw/cf137f497d2d891d42c02cc6260e13f46f8f6d9f/transform.js > /tmp/transform.js
jscodeshift --no-babel -t /tmp/transform.js modules
```

Fixes #
