### PR TITLE
Fix/accidental assignment

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,7 +42,7 @@ const defaultRules = {
   'prefer-const': 2,
   'arrow-spacing': [2, { before: true, after: true }],
   'require-atomic-updates': 0,
-  'import/first': 2
+  'import/first': 2,
 };
 
 module.exports = {
@@ -190,7 +190,8 @@ module.exports = {
         sourceType: 'module'
       },
       rules: {
-        'react/no-access-state-in-setstate': 2
+        'react/no-access-state-in-setstate': 2,
+        'no-multi-assign': 2,
       }
     },
 

--- a/modules/core/client/components/LanguageSwitchPresentational.js
+++ b/modules/core/client/components/LanguageSwitchPresentational.js
@@ -57,7 +57,10 @@ export function LanguageSwitchSelect({ currentLanguageCode, onChangeLanguage }) 
   );
 }
 
-LanguageSwitchSelect.propTypes = LanguageSwitchDropdown.propTypes = {
+const propTypes = {
   currentLanguageCode: PropTypes.string,
   onChangeLanguage: PropTypes.func,
 };
+
+LanguageSwitchSelect.propTypes = propTypes;
+LanguageSwitchDropdown.propTypes = propTypes;

--- a/modules/messages/client/components/InboxThread.js
+++ b/modules/messages/client/components/InboxThread.js
@@ -9,7 +9,7 @@ import { userType } from '@/modules/users/client/users.prop-types';
 export default function InboxThread({ user, thread }) {
   const { t } = useTranslation('messages');
   const otherUser = findOtherUser(user, thread);
-  const haveReplied = thread.userFrom._id = user._id;
+  const haveReplied = thread.userFrom._id === user._id;
   return <li className="list-group-item threadlist-thread">
     <a href={`/messages/${otherUser.username}`}>
       <div className="media">

--- a/modules/messages/tests/client/components/Inbox.component.tests.js
+++ b/modules/messages/tests/client/components/Inbox.component.tests.js
@@ -37,6 +37,25 @@ describe('<Inbox>', () => {
     });
   });
 
+  it('shows that I have replied if the last message is from me', async () => {
+    const threads = generateThreads(1, { userFrom: me });
+    api.fetchThreads.mockResolvedValue({ threads });
+    const { container, findByRole } = render(<Inbox user={me}/>);
+    await findByRole('listitem');
+    const icon = container.querySelector('.icon-reply');
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveAttribute('title', 'You replied');
+  });
+
+  it('does not show that I have replied if the last message is from them', async () => {
+    const threads = generateThreads(1, { userTo: me });
+    api.fetchThreads.mockResolvedValue({ threads });
+    const { container, findByRole } = render(<Inbox user={me}/>);
+    await findByRole('listitem');
+    const icon = container.querySelector('.icon-reply');
+    expect(icon).not.toBeInTheDocument();
+  });
+
   it('shows a read more button if there are more results', async () => {
     api.fetchThreads.mockResolvedValue({ threads, nextParams: { foo: 'bar' } });
     const { findByRole } = render(<Inbox user={me}/>);

--- a/testutils/client/data.client.testutil.js
+++ b/testutils/client/data.client.testutil.js
@@ -8,11 +8,14 @@ import {
 
 export { generateClientUser };
 
-export function generateThreads(count) {
-  return range(count).map(generateThread);
+export function generateThreads(count, { userFrom, userTo } = {}) {
+  return range(count).map(() => generateThread({ userFrom, userTo }));
 }
 
-function generateThread() {
+function generateThread({
+  userFrom = generateClientUser(),
+  userTo = generateClientUser(),
+} = {}) {
   return {
     _id: generateMongoId(),
     read: true,
@@ -20,7 +23,7 @@ function generateThread() {
     message: {
       excerpt: faker.lorem.sentence(),
     },
-    userFrom: generateClientUser(),
-    userTo: generateClientUser(),
+    userFrom,
+    userTo,
   };
 }


### PR DESCRIPTION
#### Proposed Changes

* there was a bug where I used assignment operator instead of equality
* I fixed the error (`=` -> `===`)
* I added a test that would fail with the same error we had in production
* I added an eslint rule ([no-multi-assign](https://eslint.org/docs/rules/no-multi-assign)) that prevents that kind of thing

#### Testing Instructions

* you should be able to run the tests and view messages :)
