### PR TITLE
Profiles: hide profiles with 'shadowban' role

### DIFF
--- a/modules/users/server/controllers/users.authentication.server.controller.js
+++ b/modules/users/server/controllers/users.authentication.server.controller.js
@@ -259,7 +259,7 @@ exports.signin = function (req, res, next) {
     }
 
     // Don't let suspended users sign in
-    if (_.isArray(user.roles) && user.roles.indexOf('suspended') > -1) {
+    if (user.roles.includes('suspended')) {
       // Log the failure to signin
       log('error', 'User signin failed. #3tfgbg-2', {
         reason: 'Suspended user',

--- a/modules/users/tests/server/user-signup.server.routes.tests.js
+++ b/modules/users/tests/server/user-signup.server.routes.tests.js
@@ -114,9 +114,7 @@ describe('User signup and authentication CRUD tests', function () {
         should.not.exist(signupRes.body.emailToken);
         should.not.exist(signupRes.body.password);
         should.not.exist(signupRes.body.salt);
-        // Assert we have just the default 'user' role
-        signupRes.body.roles.should.be.instanceof(Array).and.have.lengthOf(1);
-        signupRes.body.roles.indexOf('user').should.equal(0);
+        should.not.exist(signupRes.body.roles);
 
         jobs.length.should.equal(1);
         jobs[0].type.should.equal('send email');
@@ -124,6 +122,27 @@ describe('User signup and authentication CRUD tests', function () {
         jobs[0].data.to.address.should.equal(_unConfirmedUser.email);
 
         done();
+      });
+  });
+
+  it('should be able to register a new user but not inject additional roles', function (done) {
+    _unConfirmedUser.username = 'Register_New_User';
+    _unConfirmedUser.email = 'register_new_user_@example.org';
+    _unConfirmedUser.roles = ['user', 'admin'];
+
+    agent.post('/api/auth/signup')
+      .send(_unConfirmedUser)
+      .expect(200)
+      .end(function (err, signupRes) {
+        should.not.exist(err);
+        should.not.exist(signupRes.body.roles);
+
+        User.findById(signupRes.body._id, function (err, userFindRes) {
+          should.not.exist(err);
+          userFindRes.roles.should.be.instanceof(Array).and.have.lengthOf(1);
+          userFindRes.roles.indexOf('user').should.equal(0);
+          done();
+        });
       });
   });
 


### PR DESCRIPTION
Split out from bigger draft PR #1178 

#### Proposed Changes

* Adds extra protection by filtering out suspended users.
* Adds a new "shadowban" role which is like suspended, but works slightly differently.

#### Testing Instructions

- Create two users and log in different browser windows (e.g. use incognito). Confirm emails to both users (e.g. via http://localhost:1080 or switching `public` value to `true` in their profiles).

- Add `shadowban` to another user's `roles` array in the `users` DB

- Confirm that shadowban user can look at their own profile and other people's profiles

- Confirm that other users don't see shadow users profile

- Confirm that as a regular user, you still see regular user profiles

- Confirm that adding `suspended` role to user stops you from being able to login


