### PR TITLE
User removal: don't let suspended users remove themself

### DIFF
--- a/modules/users/server/controllers/users.profile.server.controller.js
+++ b/modules/users/server/controllers/users.profile.server.controller.js
@@ -396,6 +396,13 @@ exports.initializeRemoveProfile = function (req, res) {
     });
   }
 
+  // Don't let suspended or shadowbanned users remove themself, ask them to get in touch with support instead.
+  if (req.user.roles.includes('suspended') || req.user.roles.includes('shadowban')) {
+    return res.status(403).send({
+      message: 'Oops! Something went wrong. Please get in touch with support at trustroots.org/support',
+    });
+  }
+
   async.waterfall([
 
     // Generate random token

--- a/modules/users/server/models/user.server.model.js
+++ b/modules/users/server/models/user.server.model.js
@@ -218,7 +218,7 @@ const UserSchema = new Schema({
   roles: {
     type: [{
       type: String,
-      enum: ['user', 'admin', 'suspended'],
+      enum: ['user', 'admin', 'suspended', 'shadowban'],
     }],
     default: ['user'],
   },

--- a/modules/users/tests/server/user-removal.server.routes.tests.js
+++ b/modules/users/tests/server/user-removal.server.routes.tests.js
@@ -311,6 +311,32 @@ describe('User removal CRUD tests', function () {
     });
   });
 
+  it('should not able to initiate removing profile with role "shadowban"', function (done) {
+    userA.roles = ['user', 'shadowban'];
+
+    userA.save(function (err) {
+      should.not.exist(err);
+
+      agent.post('/api/auth/signin')
+        .send(credentialsA)
+        .expect(200)
+        .end(function (signinErr) {
+          should.not.exist(signinErr);
+
+          agent.del('/api/users')
+            .expect(403)
+            .end(function (deleteErr, deleteRes) {
+              should.not.exist(deleteErr);
+
+              deleteRes.body.message.should.equal('Oops! Something went wrong. Please get in touch with support at trustroots.org/support');
+              jobs.length.should.equal(0);
+
+              done();
+            });
+        });
+    });
+  });
+
   it('should not be able to confirm removing profile when not signed in', function (done) {
 
     userA.removeProfileExpires = Date.now() + (24 * 3600000);


### PR DESCRIPTION
Split out from bigger draft PR #1178 

#### Proposed Changes

* Adds a new "shadowban" role which is like suspended, but works slightly differently.
* Doesn't let shadowbanned users remove themself.

#### Testing Instructions

- Create two users and log in different browser windows (e.g. use incognito). Confirm emails to both users (e.g. via http://localhost:1080 or switching `public` value to `true` in their profiles).

- Add `shadowban` to another user's `roles` array in the `users` DB

- Confirm that shadowban user cannot remove themself, while a regular user can

   ![Screenshot 2020-01-18 at 17 11 42](https://user-images.githubusercontent.com/87168/72666172-64069300-3a18-11ea-983b-485e6181594d.png)

