### PR TITLE
Remove contact info for shadowbanned users

### DIFF
--- a/modules/core/server/services/text.server.service.js
+++ b/modules/core/server/services/text.server.service.js
@@ -203,3 +203,34 @@ exports.plainText = function (content, cleanWhitespace) {
 
   return content;
 };
+
+/**
+ * Strip all phone numbers, email addresses and links from the text.
+ *
+ * @link https://github.com/gregjacobs/Autolinker.js#custom-replacement-function
+ *
+ * @param {String} content - Content
+ * @returns {String}
+ */
+exports.stripContactDetails = function (content) {
+  // Don't bother with empty strings
+  if (!content) {
+    return '';
+  }
+
+  return Autolinker.link(content, {
+    replaceFn: function (match) {
+      switch (match.getType()) {
+        case 'url':
+        case 'email':
+        case 'phone' :
+          // This will hide the email/url/phone completely from the content
+          return '';
+        default:
+          // Let Autolinker perform its normal anchor tag replacement in
+          // other cases like `mention` or `hashtag`
+          return true;
+      }
+    },
+  });
+};


### PR DESCRIPTION
Part of https://github.com/Trustroots/trustroots/issues/1184


WIP: needs tests.

#### Proposed Changes

* Filter out contact details from profile and offer descriptions when user with `shadowban` role is looking at them.

#### Testing Instructions

- Create two users and log in different browser windows (e.g. use incognito). Confirm emails to both users (e.g. via http://localhost:1080 or switching `public` value to `true` in their profiles).

- Add `shadowban` to another user's `roles` array in the `users` DB

- Write some phone numbers, emails, and URLs in the profile description of a regular user. Regular uers see those just fine, but shadowbanned user won't:
 
     <img src="https://user-images.githubusercontent.com/87168/72666800-4805f000-3a1e-11ea-9f53-a6916c301def.png" alt="" width="350">
    <img width="350" alt="Screenshot 2020-01-18 at 18 10 26" src="https://user-images.githubusercontent.com/87168/72666793-44726900-3a1e-11ea-94b9-b542ce126dd4.png">

