### PR TITLE
Do not send notifications to/from shadowbanned users

### DIFF
--- a/modules/messages/server/jobs/message-unread.server.job.js
+++ b/modules/messages/server/jobs/message-unread.server.job.js
@@ -228,7 +228,10 @@ function sendUnreadMessageReminders(reminder, callback) {
         // Remember to add these values also userNotFound object (see below)
         if (userIds.length > 0) {
           User.find(
-            { _id: { $in: userIds } },
+            {
+              _id: { $in: userIds },
+              roles: { $nin: ['suspended', 'shadowban'] },
+            },
             [
               // Fields to get for each user:
               'email',

--- a/modules/messages/tests/server/jobs/message-unread.server.job.tests.js
+++ b/modules/messages/tests/server/jobs/message-unread.server.job.tests.js
@@ -2,7 +2,7 @@
  * Module dependencies.
  */
 const path = require('path');
-// should = require('should'),
+const should = require('should');
 const moment = require('moment');
 const sinon = require('sinon');
 const testutils = require(path.resolve('./testutils/server/server.testutil'));
@@ -44,6 +44,7 @@ describe('Job: message unread', function() {
       username: 'userfrom',
       password: 'M3@n.jsI$Aw3$0m4',
       provider: 'local',
+      roles: ['user'],
     };
 
     userFrom = new User(_userFrom);
@@ -66,6 +67,7 @@ describe('Job: message unread', function() {
       username: 'userto',
       password: 'M3@n.jsI$Aw3$0m4',
       provider: 'local',
+      roles: ['user'],
     };
 
     userTo = new User(_userTo);
@@ -508,6 +510,30 @@ describe('Job: message unread', function() {
             jobs.length.should.equal(1);
 
             return done();
+          });
+        });
+      });
+    });
+
+    ['suspended', 'shadowban'].forEach(function(role) {
+      it(`Don't send notifications from users with role "${role}".`, function(done) {
+        message.created = moment().subtract(
+          moment.duration({ minutes: 10, seconds: 1 }),
+        );
+        message.save(function(err) {
+          should.not.exist(err);
+
+          userFrom.roles = ['user', role];
+          userFrom.save(function(err) {
+            should.not.exist(err);
+
+            messageUnreadJobHandler({}, function(err) {
+              should.not.exist(err);
+
+              jobs.length.should.equal(0);
+
+              return done();
+            });
           });
         });
       });


### PR DESCRIPTION
Part of https://github.com/Trustroots/trustroots/issues/1184

#### Proposed Changes

* Do not send notifications to shadowbanner users
* Do not send notifications about messages from shadowbanner users; this was pretty confusing as we don't show up their messages in people's inboxes either, but we'd still send the message notification.

#### Testing Instructions

- Create two users and log in different browser windows (e.g. use incognito). Confirm emails to both users (e.g. via http://localhost:1080 or switching `public` value to `true` in their profiles).

- Add `shadowban` to another user's `roles` array in the `users` DB

- Send message from the banned user, and to the banned user

- Send also a message between two regular users

- Make sure not to read messages via web interface; notifications are sent only for messages that are unread.

- Using maildev (http://localhost:1080/), see that no notifications are sent to/from banned user
