### PR TITLE
Shadow ban: hide messages

### DIFF
--- a/modules/messages/server/controllers/messages.server.controller.js
+++ b/modules/messages/server/controllers/messages.server.controller.js
@@ -220,11 +220,17 @@ exports.send = function (req, res) {
 
   async.waterfall([
 
-    // Check receiver
+    // Check that receiving user is legitimate:
+    // - Has to be confirmed their email (hence be public)
+    // - Not suspended profile
     function (done) {
-      User.findById(req.body.userTo, 'public').exec(function (err, receiver) {
+      User.findOne({
+        _id: req.body.userTo,
+        public: true,
+        roles: { $nin: [ 'suspended', 'shadowban' ] },
+      }).exec(function (err, receiver) {
         // If we were unable to find the receiver, return the error and stop here
-        if (err || !receiver || !receiver.public) {
+        if (err || !receiver) {
           return res.status(404).send({
             message: 'Member you are writing to does not exist.',
           });

--- a/modules/messages/tests/server/message.server.routes.tests.js
+++ b/modules/messages/tests/server/message.server.routes.tests.js
@@ -7,6 +7,7 @@ const moment = require('moment');
 const mongoose = require('mongoose');
 const User = mongoose.model('User');
 const Message = mongoose.model('Message');
+const MessageStat = mongoose.model('MessageStat');
 const Thread = mongoose.model('Thread');
 const config = require(path.resolve('./config/config'));
 const express = require(path.resolve('./config/lib/express'));
@@ -211,7 +212,7 @@ describe('Message CRUD tests', function () {
           // Save a new message
           agent.post('/api/messages')
             .send(message)
-            .expect(403)
+            .expect(404)
             .end(done);
         });
     });
@@ -1037,7 +1038,9 @@ describe('Message CRUD tests', function () {
     // Uggggly pyramid revenge!
     User.deleteMany().exec(function () {
       Message.deleteMany().exec(function () {
-        Thread.deleteMany().exec(done);
+        Thread.deleteMany().exec(function () {
+          MessageStat.deleteMany().exec(done);
+        });
       });
     });
   });

--- a/modules/messages/tests/server/message.server.routes.tests.js
+++ b/modules/messages/tests/server/message.server.routes.tests.js
@@ -160,7 +160,6 @@ describe('Message CRUD tests', function () {
       });
   });
 
-  /*
   it('should be able to send and read messages when with role "shadowban"', function (done) {
     userFrom.roles = ['user', 'shadowban'];
 
@@ -250,7 +249,6 @@ describe('Message CRUD tests', function () {
         });
     });
   });
-  */
 
   it('should be able to send basic correctly formatted html in an message', function (done) {
     agent.post('/api/auth/signin')

--- a/modules/messages/tests/server/message.server.routes.tests.js
+++ b/modules/messages/tests/server/message.server.routes.tests.js
@@ -110,11 +110,12 @@ describe('Message CRUD tests', function () {
       });
   });
 
-  it('should be able to send an message if logged in', function (done) {
+  it('should be able to send and read messages if logged in', function (done) {
     agent.post('/api/auth/signin')
       .send(credentials)
       .expect(200)
       .end(function (signinErr, signinRes) {
+        console.log('Sign-in:', signinErr, signinRes.body); //eslint-disable-line
         // Handle signin error
         if (signinErr) return done(signinErr);
 
@@ -131,6 +132,7 @@ describe('Message CRUD tests', function () {
 
             // Get a list of messages
             agent.get('/api/messages/' + userToId)
+              .expect(200)
               .end(function (messagesGetErr, messagesGetRes) {
                 // Handle message get error
                 if (messagesGetErr) return done(messagesGetErr);
@@ -157,6 +159,98 @@ describe('Message CRUD tests', function () {
           });
       });
   });
+
+  /*
+  it('should be able to send and read messages when with role "shadowban"', function (done) {
+    userFrom.roles = ['user', 'shadowban'];
+
+    userFrom.save(function (saveErr) {
+      should.not.exist(saveErr);
+
+      agent.post('/api/auth/signin')
+        .send(credentials)
+        .expect(200)
+        .end(function (signinErr) {
+          should.not.exist(signinErr);
+
+          // Save a new message
+          agent.post('/api/messages')
+            .send(message)
+            .expect(200)
+            .end(function (messageSaveErr) {
+              should.not.exist(messageSaveErr);
+
+              // Get a list of messages
+              agent.get('/api/messages/' + userToId)
+                .expect(200)
+                .end(function (messagesGetErr, messagesGetRes) {
+                  should.not.exist(messagesGetErr);
+
+                  // Confirm message is on the list
+                  if (!messagesGetRes.body[0] || !messagesGetRes.body[0].content) {
+                    return done(new Error('Message list empty.'));
+                  }
+
+                  done();
+                });
+            });
+        });
+    });
+  });
+
+  it('should not be able to send messages to user with role "shadowban"', function (done) {
+    userTo.roles = ['user', 'shadowban'];
+
+    userTo.save(function (saveErr) {
+      should.not.exist(saveErr);
+
+      agent.post('/api/auth/signin')
+        .send(credentials)
+        .expect(200)
+        .end(function (signinErr) {
+          should.not.exist(signinErr);
+
+          // Save a new message
+          agent.post('/api/messages')
+            .send(message)
+            .expect(403)
+            .end(function (messageSaveErr, messageSaveRes) {
+              console.log('---->',messageSaveRes.body);//eslint-disable-line
+              should.exist(messageSaveErr);
+              done();
+            });
+        });
+    });
+  });
+
+
+  it('should not be able to send messages to, and read messages from user with role "shadowban"', function (done) {
+    userTo.roles = ['user', 'shadowban'];
+
+    userTo.save(function (saveErr) {
+      should.not.exist(saveErr);
+
+      agent.post('/api/auth/signin')
+        .send(credentials)
+        .expect(200)
+        .end(function (signinErr) {
+          should.not.exist(signinErr);
+
+          // Get a list of messages
+          agent.get('/api/messages/' + userToId)
+            .expect(403)
+            .end(function (messagesGetErr, messagesGetRes) {
+              should.not.exist(messagesGetErr);
+
+              // messagesGetRes.body.length.should.equal(0); //eslint-disable-line
+              console.log('---->',messagesGetRes.body);//eslint-disable-line
+
+              done();
+            });
+        });
+    });
+  });
+  */
 
   it('should be able to send basic correctly formatted html in an message', function (done) {
     agent.post('/api/auth/signin')

--- a/modules/messages/tests/server/message.server.routes.tests.js
+++ b/modules/messages/tests/server/message.server.routes.tests.js
@@ -212,17 +212,13 @@ describe('Message CRUD tests', function () {
           agent.post('/api/messages')
             .send(message)
             .expect(403)
-            .end(function (messageSaveErr, messageSaveRes) {
-              console.log('---->',messageSaveRes.body);//eslint-disable-line
-              should.exist(messageSaveErr);
-              done();
-            });
+            .end(done);
         });
     });
   });
 
 
-  it('should not be able to send messages to, and read messages from user with role "shadowban"', function (done) {
+  it('should not be able to read messages from user with role "shadowban"', function (done) {
     userTo.roles = ['user', 'shadowban'];
 
     userTo.save(function (saveErr) {
@@ -236,15 +232,8 @@ describe('Message CRUD tests', function () {
 
           // Get a list of messages
           agent.get('/api/messages/' + userToId)
-            .expect(403)
-            .end(function (messagesGetErr, messagesGetRes) {
-              should.not.exist(messagesGetErr);
-
-              // messagesGetRes.body.length.should.equal(0); //eslint-disable-line
-              console.log('---->',messagesGetRes.body);//eslint-disable-line
-
-              done();
-            });
+            .expect(404)
+            .end(done);
         });
     });
   });

--- a/modules/messages/tests/server/message.server.routes.tests.js
+++ b/modules/messages/tests/server/message.server.routes.tests.js
@@ -115,7 +115,6 @@ describe('Message CRUD tests', function () {
       .send(credentials)
       .expect(200)
       .end(function (signinErr, signinRes) {
-        console.log('Sign-in:', signinErr, signinRes.body); //eslint-disable-line
         // Handle signin error
         if (signinErr) return done(signinErr);
 


### PR DESCRIPTION
Split out from bigger draft PR #1178

#### Proposed Changes

* Don't show messages from shadowbanned user to regular user

Not in this PR and should be handled in follow-up PRs:
* Notifications still go through (https://github.com/Trustroots/trustroots/pull/1182)
* Message thread is visible in the inbox
* Unread message count might stay visible (pre-existing https://github.com/Trustroots/trustroots/issues/596) 


#### Testing Instructions

- Create two users and log in different browser windows (e.g. use incognito). Confirm emails to both users (e.g. via http://localhost:1080 or switching `public` value to `true` in their profiles).

- Add `shadowban` to another user's `roles` array in the `users` DB

- Confirm that the shadow-banned user can send messages to a regular user and see those messages in their inbox and message thread

- Confirm that regular user sees the message in their inbox and gets notification (via http://localhost:1080/#/) (both aspects to be hidden in separate PR):
    <img width="1076" alt="Screenshot 2020-01-19 at 15 14 46" src="https://user-images.githubusercontent.com/87168/72681730-0ed98880-3acf-11ea-87a4-3ce34986003d.png">

- Confirm that regular user cannot open the thread or reply to it:
   In this PR you'll see just loading spinner as the user does resolve but message thread doesn't, and we don't have handling for this on the frontend:
   
    <img width="1164" alt="Screenshot 2020-01-19 at 15 13 51" src="https://user-images.githubusercontent.com/87168/72681711-e6ea2500-3ace-11ea-8937-f02d4debfd48.png">

    If you cherry-pick commit from hiding profiles PR (https://github.com/Trustroots/trustroots/pull/1179), you can see how thread never even loads.
    ```
    git cherry-pick 6cab8940443b3242b86327a602f909799176389b
    ````
    <img width="1197" alt="Screenshot 2020-01-19 at 15 15 39" src="https://user-images.githubusercontent.com/87168/72681724-05502080-3acf-11ea-8375-c2a060986600.png">

- If you open message thread _before_ the other user has `shadowban` role, you can try sending them a message after adding the shadowban role and without refreshing the page. You should see this error:
    ![image](https://user-images.githubusercontent.com/87168/72682091-57467580-3ad2-11ea-8e8b-117b01bcb7d2.png)

- Should work even with various combinations of `public: false/true` state of users.

- Confirm that you can still send and see messages to/from other regular users
