### PR TITLE
Add `moderator` role

### DIFF
--- a/modules/messages/server/controllers/messages.server.controller.js
+++ b/modules/messages/server/controllers/messages.server.controller.js
@@ -218,6 +218,14 @@ exports.send = function (req, res) {
     });
   }
 
+  // Only moderator and admin roles can send messages to banned users. For others they stay hidden.
+  const publicityLimit = req.user.roles.includes('moderator') || req.user.roles.includes('admin')
+    ? {}
+    : {
+      public: true,
+      roles: { $nin: ['suspended', 'shadowban'] },
+    };
+
   async.waterfall([
 
     // Check that receiving user is legitimate:
@@ -226,8 +234,7 @@ exports.send = function (req, res) {
     function (done) {
       User.findOne({
         _id: req.body.userTo,
-        public: true,
-        roles: { $nin: [ 'suspended', 'shadowban' ] },
+        ...publicityLimit,
       }).exec(function (err, receiver) {
         // If we were unable to find the receiver, return the error and stop here
         if (err || !receiver) {
@@ -436,6 +443,14 @@ exports.threadByUser = function (req, res, next, userId) {
     });
   }
 
+  // Only moderator and admin roles can read messages from banned users. For others they stay hidden.
+  const publicityLimit = req.user.roles.includes('moderator') || req.user.roles.includes('admin')
+    ? {}
+    : {
+      public: true,
+      roles: { $nin: ['suspended', 'shadowban'] },
+    };
+
   async.waterfall([
     // Check that other user is legitimate:
     // - Has to be confirmed their email (hence be public)
@@ -443,8 +458,7 @@ exports.threadByUser = function (req, res, next, userId) {
     function (done) {
       User.findOne({
         _id: userId,
-        public: true,
-        roles: { $nin: [ 'suspended', 'shadowban' ] },
+        ...publicityLimit,
       }).exec(function (err, receiver) {
         // If we were unable to find the receiver, return the error and stop here
         if (err || !receiver) {

--- a/modules/messages/tests/server/message-stat-integration.server.service.tests.js
+++ b/modules/messages/tests/server/message-stat-integration.server.service.tests.js
@@ -47,6 +47,7 @@ describe('Integration of the MessageStat service', function () {
       username: 'username1',
       password: 'password123',
       provider: 'local',
+      roles: ['user'],
       public: true,
       description: _.repeat('.', config.profileMinimumLength),
     });
@@ -59,6 +60,7 @@ describe('Integration of the MessageStat service', function () {
       username: 'username2',
       password: 'password123',
       provider: 'local',
+      roles: ['user'],
       public: true,
     });
 
@@ -98,6 +100,7 @@ describe('Integration of the MessageStat service', function () {
       const req = {
         user: {
           _id: user1._id,
+          roles: ['user'],
         },
         body: {
           userTo: String(user2._id),

--- a/modules/messages/tests/server/message-to-stats-integration.server.service.tests.js
+++ b/modules/messages/tests/server/message-to-stats-integration.server.service.tests.js
@@ -51,6 +51,7 @@ describe('Message to Stats API server service Integration Test', function () {
       password: 'password123',
       provider: 'local',
       public: true,
+      roles: ['user'],
       description: _.repeat('.', config.profileMinimumLength),
     });
 
@@ -63,6 +64,7 @@ describe('Message to Stats API server service Integration Test', function () {
       password: 'password123',
       provider: 'local',
       public: true,
+      roles: ['user'],
     });
 
     // save those users to mongoDB
@@ -106,6 +108,7 @@ describe('Message to Stats API server service Integration Test', function () {
       const req = {
         user: {
           _id: user1._id,
+          roles: ['user'],
         },
         body: {
           userTo: String(user2._id),

--- a/modules/messages/tests/server/message.server.routes.tests.js
+++ b/modules/messages/tests/server/message.server.routes.tests.js
@@ -53,6 +53,7 @@ describe('Message CRUD tests', function () {
       username: credentials.username,
       password: credentials.password,
       provider: 'local',
+      roles: ['user'],
       description: _.repeat('.', config.profileMinimumLength),
       public: true,
     });
@@ -65,6 +66,7 @@ describe('Message CRUD tests', function () {
       username: 'username2',
       password: 'password123',
       provider: 'local',
+      roles: ['user'],
       description: _.repeat('.', config.profileMinimumLength),
       public: true,
     });
@@ -218,6 +220,107 @@ describe('Message CRUD tests', function () {
     });
   });
 
+  it('should be able to read messages from user with role "shadowban" when with role "admin"', function (done) {
+    userTo.roles = ['user', 'shadowban'];
+    userFrom.roles = ['user', 'admin'];
+
+    userFrom.save(function (saveErr) {
+      should.not.exist(saveErr);
+
+      userTo.save(function (saveErr) {
+        should.not.exist(saveErr);
+
+        agent.post('/api/auth/signin')
+          .send(credentials)
+          .expect(200)
+          .end(function (signinErr) {
+            should.not.exist(signinErr);
+
+            // Get a list of messages
+            agent.get('/api/messages/' + userToId)
+              .expect(200)
+              .end(done);
+          });
+      });
+    });
+  });
+
+  it('should be able to send messages to user with role "shadowban" when with role "admin"', function (done) {
+    userTo.roles = ['user', 'shadowban'];
+    userFrom.roles = ['user', 'admin'];
+
+    userFrom.save(function (saveErr) {
+      should.not.exist(saveErr);
+
+      userTo.save(function (saveErr) {
+        should.not.exist(saveErr);
+
+        agent.post('/api/auth/signin')
+          .send(credentials)
+          .expect(200)
+          .end(function (signinErr) {
+            should.not.exist(signinErr);
+
+            // Save a new message
+            agent.post('/api/messages')
+              .send(message)
+              .expect(200)
+              .end(done);
+          });
+      });
+    });
+  });
+
+  it('should be able to read messages from user with role "shadowban" when with role "moderator"', function (done) {
+    userTo.roles = ['user', 'shadowban'];
+    userFrom.roles = ['user', 'moderator'];
+
+    userFrom.save(function (saveErr) {
+      should.not.exist(saveErr);
+
+      userTo.save(function (saveErr) {
+        should.not.exist(saveErr);
+
+        agent.post('/api/auth/signin')
+          .send(credentials)
+          .expect(200)
+          .end(function (signinErr) {
+            should.not.exist(signinErr);
+
+            // Get a list of messages
+            agent.get('/api/messages/' + userToId)
+              .expect(200)
+              .end(done);
+          });
+      });
+    });
+  });
+
+  it('should be able to send messages to user with role "shadowban" when with role "moderator"', function (done) {
+    userTo.roles = ['user', 'shadowban'];
+    userFrom.roles = ['user', 'moderator'];
+
+    userFrom.save(function (saveErr) {
+      should.not.exist(saveErr);
+
+      userTo.save(function (saveErr) {
+        should.not.exist(saveErr);
+
+        agent.post('/api/auth/signin')
+          .send(credentials)
+          .expect(200)
+          .end(function (signinErr) {
+            should.not.exist(signinErr);
+
+            // Save a new message
+            agent.post('/api/messages')
+              .send(message)
+              .expect(200)
+              .end(done);
+          });
+      });
+    });
+  });
 
   it('should not be able to read messages from user with role "shadowban"', function (done) {
     userTo.roles = ['user', 'shadowban'];

--- a/modules/users/server/controllers/users.profile.server.controller.js
+++ b/modules/users/server/controllers/users.profile.server.controller.js
@@ -705,9 +705,10 @@ exports.userMiniByID = function (req, res, next, userId) {
 
     const isOwnProfile = req.user._id.equals(profile._id);
     const isBannedProfile = profile.roles.includes('suspended') || profile.roles.includes('shadowban');
+    const isAdminOrModerator = req.user.roles.includes('moderator') || req.user.roles.includes('admin');
 
     // Not own profile, and not public, or suspended, or shadowbanned user
-    if (!isOwnProfile && (!profile.public || isBannedProfile)) {
+    if (!isAdminOrModerator && !isOwnProfile && (!profile.public || isBannedProfile)) {
       return res.status(404).send({
         message: errorService.getErrorMessageByKey('not-found'),
       });
@@ -766,9 +767,10 @@ exports.userByUsername = function (req, res, next, username) {
 
           const isOwnProfile = req.user._id.equals(profile._id);
           const isBannedProfile = profile.roles.includes('suspended') || profile.roles.includes('shadowban');
+          const isAdminOrModerator = req.user.roles.includes('moderator') || req.user.roles.includes('admin');
 
           // Not own profile, and not public, or suspended, or shadowbanned user
-          if (!isOwnProfile && (!profile.public || isBannedProfile)) {
+          if (!isAdminOrModerator && !isOwnProfile && (!profile.public || isBannedProfile)) {
             return res.status(404).send({
               message: errorService.getErrorMessageByKey('not-found'),
             });

--- a/modules/users/server/models/user.server.model.js
+++ b/modules/users/server/models/user.server.model.js
@@ -218,7 +218,7 @@ const UserSchema = new Schema({
   roles: {
     type: [{
       type: String,
-      enum: ['user', 'admin', 'suspended', 'shadowban'],
+      enum: ['user', 'admin', 'suspended', 'shadowban', 'moderator'],
     }],
     default: ['user'],
   },

--- a/modules/users/tests/server/user-profile.server.routes.tests.js
+++ b/modules/users/tests/server/user-profile.server.routes.tests.js
@@ -200,6 +200,52 @@ describe('User profile CRUD tests', function () {
     });
   });
 
+  it('should be able to get other users details successfully that have "shadowban" role when with role "moderator"', function (done) {
+    user.roles = ['user', 'moderator'];
+    user2.roles = ['user', 'shadowban'];
+
+    user.save(function (err) {
+      should.not.exist(err);
+      user2.save(function (err) {
+        should.not.exist(err);
+        agent.post('/api/auth/signin')
+          .send(credentials)
+          .expect(200)
+          .end(function (signinErr) {
+            should.not.exist(signinErr);
+
+            // Get their user details
+            agent.get('/api/users/' + user2.username)
+              .expect(200)
+              .end(done);
+          });
+      });
+    });
+  });
+
+  it('should be able to get other users details successfully that have "shadowban" role when with role "admin"', function (done) {
+    user.roles = ['user', 'admin'];
+    user2.roles = ['user', 'shadowban'];
+
+    user.save(function (err) {
+      should.not.exist(err);
+      user2.save(function (err) {
+        should.not.exist(err);
+        agent.post('/api/auth/signin')
+          .send(credentials)
+          .expect(200)
+          .end(function (signinErr) {
+            should.not.exist(signinErr);
+
+            // Get their user details
+            agent.get('/api/users/' + user2.username)
+              .expect(200)
+              .end(done);
+          });
+      });
+    });
+  });
+
   it('should not be able to get any user details of confirmed user if not logged in', function (done) {
     // Get own user details
     agent.get('/api/users/' + user.username)

--- a/modules/users/tests/server/user.server.model.tests.js
+++ b/modules/users/tests/server/user.server.model.tests.js
@@ -331,6 +331,26 @@ describe('User Model Unit Tests:', function () {
       });
     });
 
+    it('should save with "moderator" role', function (done) {
+      const _user = new User(user);
+
+      _user.roles = ['moderator'];
+      _user.save(function (err) {
+        should.not.exist(err);
+        done();
+      });
+    });
+
+    it('should save with "shadowban" role', function (done) {
+      const _user = new User(user);
+
+      _user.roles = ['shadowban'];
+      _user.save(function (err) {
+        should.not.exist(err);
+        done();
+      });
+    });
+
     it('should save with "suspended" role', function (done) {
       const _user = new User(user);
 


### PR DESCRIPTION
#### Proposed Changes

* Adds new `moderator` role
* Grants admins and moderators permission to see suspended or shadowbanned profiles and send them messages.

#### Testing Instructions

- Create two users and log in different browser windows (e.g. use incognito). Confirm emails to both users (e.g. via http://localhost:1080 or switching `public` value to `true` in their profiles).

- Add `shadowban` to another user's `roles` array in the `users` DB and `moderator` or `admin` for another.

- Confirm that without `moderator`/`admin` role you cannot see `shadowban` user or send them messages. With the role you can.


