### PR TITLE
[WIP] Add localization tutorial

### DIFF
--- a/docs/Translating-Getting-Started.md
+++ b/docs/Translating-Getting-Started.md
@@ -1,0 +1,3 @@
+# Getting started with translating
+
+Read our [translation tutorial](i18n.md).

--- a/docs/Volunteering.md
+++ b/docs/Volunteering.md
@@ -15,6 +15,7 @@ Please start by joining our [volunteer chat](Chat.md). You should start by intro
 - [Development](Development-Getting-Started.md).
 - [Design](Design-Getting-Started.md).
 - [Support](Support-Getting-Started.md).
+- [Translating](Translating-Getting-Started.md).
 - [Photography](Photography-Getting-Started.md).
 - [Copywriting & Proofreading](Copywriting-Getting-Started.md).
 - [Social Media](Social-Media-Getting-Started.md).

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,5 +1,7 @@
 # Developer's guide to internationalization
 
+See also our [localization tutorial](l10n.md).
+
 ## Step by step how to internationalize your i18n component
 
 ### 1. Provide `t` function to your component

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,8 @@ title: Trustroots Team Guide
 
 - [Angular Directives](Angular-Directives.md) (deprecated)
 - [App and server Monitoring](Monitoring.md)
-- [i18n](i18n.md)
+- [Internationalization (i18n)](i18n.md)
+- [Localization (l10n)](l10n.md)
 - [Icons](Icons.md)
 - [InfluxDB](InfluxDB.md)
 - [Logging](Logging.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,8 +45,8 @@ title: Trustroots Team Guide
 
 - [Angular Directives](Angular-Directives.md) (deprecated)
 - [App and server Monitoring](Monitoring.md)
-- [Internationalization (i18n)](i18n.md)
-- [Localization (l10n)](l10n.md)
+- [Internationalization - for developers (i18n)](i18n.md)
+- [Localization - for translators (l10n)](l10n.md)
 - [Icons](Icons.md)
 - [InfluxDB](InfluxDB.md)
 - [Logging](Logging.md)

--- a/docs/l10n.md
+++ b/docs/l10n.md
@@ -1,0 +1,55 @@
+# Localization tutorial
+
+Localize (translate) the trustroots. The complicated way.
+
+## Prerequisities
+
+- Install [poedit](https://poedit.net/) on your computer.
+- Install [i18next-gettext-converter](https://github.com/i18next/i18next-gettext-converter)
+  ```sh
+  npm install i18next-conv -g
+  ```
+
+## Extract translation strings (optional)
+
+**TL;DR** Ask your friendly Trustroots developers to do this step for you.
+
+If you have your [Trustroots development environment](https://github.com/Trustroots/trustroots/blob/master/docs/Install.md) set up, run it with `npm start`.
+
+Open the app and select the language you want to translate to. (@TODO how?)
+
+Go to the page which you want to translate. Click around, both when you're signed in and signed out.
+
+All the encountered untranslated strings get extracted to `public/locales/{locale}/{namespace}.json`.
+
+## Convert the translation JSON files to PO (gettext) format
+
+```sh
+i18next-conv -l {locale} -s public/locales/{locale}/{namespace}.json -t {path/to/}{namespace}.po
+```
+
+So for example when we convert volunteering.json in Finnish (fi), we need to run
+
+```sh
+i18next-conv -l fi -s public/locales/fi/volunteering.json -t temporary_folder/volunteering.po
+```
+
+## Translate
+
+Open the exported .po file with poedit and enjoy the translating. Save your work.
+
+## Convert the PO files back to JSON
+
+```sh
+i18next-conv -l fi -s temporary_folder/volunteering.po -t public/locales/fi/volunteering.json
+```
+
+## Commit your translation in JSON format to trustroots repository
+
+If you don't know how to do this step, send your translated JSON files to trustroots developers who will do it.
+
+## @TODO
+
+- automate
+  - automate the extraction. A headless browser can be instructed to click around the app automatically.
+  - automate the conversion from JSON to PO and vice-versa. Share the PO files with translators who don't need to worry about any of this complexity. They just translate the PO files with poedit.

--- a/docs/l10n.md
+++ b/docs/l10n.md
@@ -1,55 +1,39 @@
-# Localization tutorial
+# Translating Trustroots (localization)
 
-Localize (translate) the trustroots. The complicated way.
+Thank you for your interest in translating Trustroots! :tada:
 
-## Prerequisities
+You'll learn how to start translating here.
 
-- Install [poedit](https://poedit.net/) on your computer.
-- Install [i18next-gettext-converter](https://github.com/i18next/i18next-gettext-converter)
-  ```sh
-  npm install i18next-conv -g
-  ```
+## Tools
 
-## Extract translation strings (optional)
+There are a few tools available which you can use:
 
-**TL;DR** Ask your friendly Trustroots developers to do this step for you.
+- [Poedit](https://poedit.net/) is a free and open-source translation tool. You can [install it](https://poedit.net/download) on Windows, Mac and Unix. It supports gettext (.po) format.
+- [Transifex](https://www.transifex.com/) is an online translation platform. It is free for [Open Source projects](https://docs.transifex.com/projects/open-source-project). Trustroots currently doesn't have an account. It supports [gettext](https://docs.transifex.com/formats/gettext) (.po) format.
+- [Locize](https://locize.com/) is a paid translation platform for i18next format. We don't have an account and probably don't need it.
+- A text editor of your preference (not preferred)
+- _Share your favourite tool!_
 
-If you have your [Trustroots development environment](https://github.com/Trustroots/trustroots/blob/master/docs/Install.md) set up, run it with `npm start`.
+## How to start
 
-Open the app and select the language you want to translate to. (@TODO how?)
+Tell us which language you'd like to translate to and we'll make sure the translation files are available and up-to-date. You can also [see the translation files and locales](https://github.com/Trustroots/trustroots/tree/master/public/locales).
 
-Go to the page which you want to translate. Click around, both when you're signed in and signed out.
-
-All the encountered untranslated strings get extracted to `public/locales/{locale}/{namespace}.json`.
-
-## Convert the translation JSON files to PO (gettext) format
-
-```sh
-i18next-conv -l {locale} -s public/locales/{locale}/{namespace}.json -t {path/to/}{namespace}.po
-```
-
-So for example when we convert volunteering.json in Finnish (fi), we need to run
-
-```sh
-i18next-conv -l fi -s public/locales/fi/volunteering.json -t temporary_folder/volunteering.po
-```
+_If you know how to use [git](https://git-scm.com/), clone this repository and go to [./public/locales](https://github.com/Trustroots/trustroots/tree/master/public/locales). Otherwise we'll provide the translation files to you._
 
 ## Translate
 
-Open the exported .po file with poedit and enjoy the translating. Save your work.
+Open the `.po` files with [Poedit](https://poedit.net/) and enjoy the translating. Save your work.
 
-## Convert the PO files back to JSON
+Alternatively, you can edit the `.json` files with your text editor.
 
-```sh
-i18next-conv -l fi -s temporary_folder/volunteering.po -t public/locales/fi/volunteering.json
-```
+## Share
 
-## Commit your translation in JSON format to trustroots repository
+Send us your work and we'll publish it in your name.
 
-If you don't know how to do this step, send your translated JSON files to trustroots developers who will do it.
+Alternatively, if you know how to use [git](https://git-scm.com/), create a pull request with your work. We'll review and merge it as soon as possible.
 
-## @TODO
+## Stay tuned
 
-- automate
-  - automate the extraction. A headless browser can be instructed to click around the app automatically.
-  - automate the conversion from JSON to PO and vice-versa. Share the PO files with translators who don't need to worry about any of this complexity. They just translate the PO files with poedit.
+There will be new translations coming. We'd love if you stay with us and help!
+
+:heart:


### PR DESCRIPTION
_Update: Currently we seem to converge into using [weblate](https://hosted.weblate.org/projects/trustroots/). This tutorial will need to be rewritten, when the setup settles._

#### Proposed Changes

A tutorial for translating Trustroots. It will be valid when #1291 and #1289 get finished and merged. All the burden of extracting and converting translation files should lay on developers.

#### Testing Instructions

* Read the [tutorial](https://github.com/Trustroots/trustroots/blob/docs/localization/docs/l10n.md), try it out and propose improvements
* A feedback from non-technical perspective very welcome! Is it understandable? Does it sound reasonably easy to start translating?