### PR TITLE
Only return threads with both userFrom and userTo

### DIFF
--- a/modules/messages/server/controllers/messages.server.controller.js
+++ b/modules/messages/server/controllers/messages.server.controller.js
@@ -98,8 +98,6 @@ function sanitizeThreads(threads, authenticatedUserId) {
       thread.read = true;
     }
 
-    threadsCleaned.push(thread);
-
     // If users weren't populated, they were removed.
     // Don't return thread at all at this point.
     //
@@ -107,9 +105,9 @@ function sanitizeThreads(threads, authenticatedUserId) {
     // Return thread but with placeholder user and old user's ID
     // With ID we could fetch the message thread — now all we could
     // show is this line at inbox but not actual messages
-    // if (thread.userTo && thread.userFrom) {
-    //   threadsCleaned.push(thread);
-    // }
+    if (thread.userTo && thread.userFrom) {
+      threadsCleaned.push(thread);
+    }
   });
 
   return threadsCleaned;


### PR DESCRIPTION
#### Proposed Changes

With the new react-based inbox view (https://github.com/Trustroots/trustroots/pull/1171) we are more strict with whether to display threads where the user has been deleted.

Previously the angular code would accept having a missing user (https://github.com/Trustroots/trustroots/pull/1171/files#diff-9fdee58b34092f27c2455b5699fd4c65L67-L69), it's not clear to me what the template would have done, I suspect a silent error, but still display _something_. It can't have worked very well, as the URL for a thread contains the `username` field, so if it is null, there is no `username`.

In the new react version it's a hard error, and the user cannot view their inbox, see [slack conversation](https://trustroots.slack.com/archives/C0A3Q15SS/p1580985654015400) for reports of users not being able to access their inbox.

The [server code](https://github.com/Trustroots/trustroots/blob/3dfb08815cb17d2643c01ada2f1c986e8f33a65a/modules/messages/server/controllers/messages.server.controller.js#L103-L112) has a TODO about handling this better and more consistently/modules/messages/server/controllers/messages.server.controller.js#L103-L112), but this has not been implemented.

The proper fix is to decide what _should_ be the case for messages with deleted users, then implement that, in the meantime, we need to not break the inbox.

This fix makes the _server_ not send threads that are missing a `userTo`, or `userFrom` field, given we have no viable way to display these (as I said above, the URL uses the `username` which is unavailable when `null`).

It is not a great fix, as the pagination limit will be inconsistent, but I couldn't easily see how to modify the mongo query to do it at that level (we use the mongoose `populate` feature, but I don't think we can filter on this, maybe we can using mongos `$lookup` alternative for _joins_, but I couldn't see how to do this immediately, and I think we need a quick fix so users can read their messages. Forgive me.

#### Testing Instructions

* run your trustroots local dev environment (with seeded content)
* login as one of your users
* look at the messages inbox view
* find a thread, and then delete the user for that thread
* you should still be able to view your inbox (the thread with that user will not be displayed)
