### PR TITLE
Schedule Renovate run only on weekends

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "assignees": ["nicksellen", "simison"],
   "extends": ["config:base"],
+  "schedule": "every weekend",
   "ignorePaths": ["scripts/mass-email/package.json"],
   "packageRules": [
     {


### PR DESCRIPTION
#### Proposed Changes

* Run Renovate only on weekends

https://docs.renovatebot.com/presets-schedule/#scheduleweekends

* Other limitations that are useful? Better if this runs only on Fridays, ready for merging on weekends and not taking CI capacity when everyone is already busy coding on weekends?

#### Testing Instructions

*  Renovate will validate this and show up in Github tests section
    <img width="422" alt="image" src="https://user-images.githubusercontent.com/87168/74543810-bae78580-4f4e-11ea-8d4b-3602423caaf5.png">
