### PR TITLE
Renovate: group related packages into one

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,15 @@
   "packageRules": [
     {
       "packageNames": [
+        "babel-eslint",
+        "gulp-eslint"
+      ],
+      "packagePatterns": [
+        "^eslint"
+      ]
+    },
+    {
+      "packageNames": [
         "angular",
         "angular-animate",
         "angular-aria",

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,36 @@
       ]
     },
     {
+      "packagePatterns": [
+        "^passport"
+      ]
+    },
+    {
+      "packageNames": [
+        "@pmmmwh/react-refresh-webpack-plugin"
+      ],
+      "packagePatterns": [
+        "^webpack"
+      ]
+    },
+    {
+      "packageNames": [
+        "react-leaflet",
+        "ui-leaflet"
+      ],
+      "packagePatterns": [
+        "^leaflet"
+      ]
+    },
+    {
+      "packageNames": [
+        "react-i18next"
+      ],
+      "packagePatterns": [
+        "^i18next"
+      ]
+    },
+    {
       "packageNames": [
         "angular",
         "angular-animate",


### PR DESCRIPTION
Groups related packages in Renovate into one PR. Will reduce noise.

- leaflet
- eslint
- webpack
- i18next
- passport


From https://docs.renovatebot.com/presets-packages/#packageseslint