### PR TITLE
Optimize renovate.json for less CI and notifications noise

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,45 +3,26 @@
   "extends": ["config:base"],
   "schedule": "every weekend",
   "ignorePaths": ["scripts/mass-email/package.json"],
+  "masterIssue": true,
   "packageRules": [
     {
-      "packageNames": [
-        "babel-eslint",
-        "gulp-eslint"
-      ],
-      "packagePatterns": [
-        "^eslint"
-      ]
+      "packageNames": ["babel-eslint", "gulp-eslint"],
+      "packagePatterns": ["^eslint"]
     },
     {
-      "packagePatterns": [
-        "^passport"
-      ]
+      "packagePatterns": ["^passport"]
     },
     {
-      "packageNames": [
-        "@pmmmwh/react-refresh-webpack-plugin"
-      ],
-      "packagePatterns": [
-        "^webpack"
-      ]
+      "packageNames": ["@pmmmwh/react-refresh-webpack-plugin"],
+      "packagePatterns": ["^webpack"]
     },
     {
-      "packageNames": [
-        "react-leaflet",
-        "ui-leaflet"
-      ],
-      "packagePatterns": [
-        "^leaflet"
-      ]
+      "packageNames": ["react-leaflet", "ui-leaflet"],
+      "packagePatterns": ["^leaflet"]
     },
     {
-      "packageNames": [
-        "react-i18next"
-      ],
-      "packagePatterns": [
-        "^i18next"
-      ]
+      "packageNames": ["react-i18next"],
+      "packagePatterns": ["^i18next"]
     },
     {
       "packageNames": [
@@ -75,6 +56,8 @@
       "sourceUrlPrefixes": ["https://github.com/facebook/react"]
     }
   ],
+  "rebaseConflictedPrs": false,
+  "rebaseStalePrs": false,
   "supportPolicy": "lts_latest",
   "travis": {
     "enabled": true

--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,17 @@
 {
-  "assignees": ["nicksellen", "simison"],
   "extends": ["config:base"],
   "schedule": "every weekend",
   "ignorePaths": ["scripts/mass-email/package.json"],
   "masterIssue": true,
+  "vulnerabilityAlerts": {
+    "labels": ["security"],
+    "assignees": ["nicksellen", "simison"]
+  },
   "packageRules": [
+    {
+      "depTypeList": ["devDependencies"],
+      "prPriority": -1
+    },
     {
       "packageNames": ["babel-eslint", "gulp-eslint"],
       "packagePatterns": ["^eslint"]


### PR DESCRIPTION
#### Proposed Changes

Update renovate config with:
* Don't assign reviewers unless it's a security update ([docs](https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts))
* Create & keep up to date renovate master issue ([docs](https://docs.renovatebot.com/configuration-options/#masterissueapproval))
* Set devDependencies lower priority ([docs](https://docs.renovatebot.com/configuration-options/#prpriority))
* Don't auto-rebase stale PRs ([docs](https://docs.renovatebot.com/configuration-options/#rebasestaleprs))
* Do not rebase conflicted PRs ([docs](https://docs.renovatebot.com/configuration-options/#rebaseconflictedprs))
* Some unrelated Prettier whitespace updates in `packageRules`

We'll need to ask Renovate rebase manually or do it ourselves, but it won't anymore cause extraneous CI cycles and notifications for all the open Renovate PRs when we merge another one.

#### Testing Instructions

* Renovate bot check at Github list shows up green.