### PR TITLE
Support listening on a file descriptor

### DIFF
--- a/config/env/default.js
+++ b/config/env/default.js
@@ -48,6 +48,7 @@ module.exports = {
   uploadDir: './public/uploads-profile',
   port: 3000,
   host: 'localhost',
+  fd: null, // listen on a file descriptor (instead of host/port)
   https: false,
   sessionSecret: 'MEAN',
   sessionCollection: 'sessions',

--- a/config/lib/app.js
+++ b/config/lib/app.js
@@ -26,8 +26,15 @@ module.exports.start = function start(callback) {
   const _this = this;
 
   _this.init(function(app, db, config) {
-    // Start the app by listening on <port> at <host>
-    app.listen(config.port, config.host, function() {
+    const listenArgs = [];
+    if (config.fd) {
+      // Start the app by listening on a file descriptor (useful for systemd socket activation)
+      listenArgs.push({ fd: config.fd });
+    } else {
+      // Start the app by listening on <port> at <host>
+      listenArgs.push(config.port, config.host);
+    }
+    app.listen(...listenArgs, function() {
       // Check in case mailer config is still set to default values (a common problem)
       if (
         config.mailer.service &&
@@ -51,7 +58,11 @@ module.exports.start = function start(callback) {
         ),
       );
       console.log(chalk.green('HTTPS:\t\t\t' + (config.https ? 'on' : 'off')));
-      console.log(chalk.green('Port:\t\t\t' + config.port));
+      if (config.fd) {
+        console.log(chalk.green('File Descriptor:\t' + config.fd));
+      } else {
+        console.log(chalk.green('Port:\t\t\t' + config.port));
+      }
       console.log(chalk.green('Image processor:\t' + config.imageProcessor));
       console.log(
         chalk.green(


### PR DESCRIPTION
#### Proposed Changes

* extra optional configuration option (`fd`) to support listening on a file descriptor
* if set, replaces use of `host` / `port` options
* if not set, no difference to before
* useful for using with systemd socket activation (set `fd: 3`, see https://www.freedesktop.org/software/systemd/man/sd_listen_fds.html), which can be used for zero down time deploys

#### Testing Instructions

* ... can verify it still works under normal conditions
* probably too fiddly to explain how to actually use the new option here... configuration will be in https://github.com/trustroots/trustroots-debops at some point
