### PR TITLE
Fix push messaging config

### DIFF
--- a/config/webpack/entries/pushMessagingServiceWorker.js
+++ b/config/webpack/entries/pushMessagingServiceWorker.js
@@ -1,4 +1,4 @@
-/* global FCM_SENDER_ID */
+/* global FCM_SENDER_ID,importScripts */
 
 /**
  *  This will not rebuild on change, so if you're doing development you might want to rebuild it manually:
@@ -11,6 +11,8 @@
 
 import firebase from 'firebase/app';
 import 'firebase/messaging';
+
+importScripts('/config/sw.js');
 
 firebase.initializeApp({
   messagingSenderId: FCM_SENDER_ID,

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -143,7 +143,6 @@ module.exports = merge(shims, {
       }),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
-      FCM_SENDER_ID: JSON.stringify(config.fcm.senderId),
     }),
     isDevelopment &&
       new ReactRefreshWebpackPlugin({

--- a/config/webpack/webpack.push-messaging-sw.config.js
+++ b/config/webpack/webpack.push-messaging-sw.config.js
@@ -1,9 +1,6 @@
-const webpack = require('webpack');
 const { join } = require('path');
 
 const basedir = join(__dirname, '../..');
-
-const config = require('../config');
 
 const isProduction = process.env.NODE_ENV === 'production';
 
@@ -29,10 +26,4 @@ module.exports = {
       },
     ],
   },
-  plugins: [
-    new webpack.DefinePlugin({
-      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
-      FCM_SENDER_ID: JSON.stringify(config.fcm.senderId),
-    }),
-  ],
 };


### PR DESCRIPTION
When adding some fcm config for dev2.trustroots.org I noticed it didn't work. Then I noticed it didn't work on production either.

![tr-push-error](https://user-images.githubusercontent.com/31616/76153841-7cb72f00-60d2-11ea-898e-17970393001a.png)

In the switch to use webpack I changed it to get the FCM_SENDER_ID through webpack... _but_ webpack build time is not a good place to rely on having configuration available (evidently).

#### Proposed Changes

The `/config/sw.js` endpoint already exists and sets a global FCM_SENDER_ID variable and was used before, so I just reverted to using this method.

I tried it locally and could observe the error with the old way, and this change fixing it such that I could receive push messages.

#### Testing Instructions

* add some fcm config to your local setup
* try enabling it!
* you should receive a push notification (to tell you that you have enabled push notifications)

(also just to note, changes to the service worker are _not_ automatically rebuilt, you need to run `npm run webpack:service-worker` if you change something).