### PR TITLE
Use babel-plugin-i18next-extract to extract translations

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -25,7 +25,7 @@ module.exports = {
   ]),
   env: {
     production: {
-      plugins: compact([
+      plugins: [
         [
           // extraction of the i18next translation strings
           'i18next-extract',
@@ -38,7 +38,7 @@ module.exports = {
             discardOldKeys: true,
           },
         ],
-      ]),
+      ],
     },
   },
 };

--- a/babel.config.js
+++ b/babel.config.js
@@ -22,16 +22,23 @@ module.exports = {
     '@babel/plugin-proposal-optional-chaining',
     'angularjs-annotate',
     isDevelopment && 'react-refresh/babel',
-    [
-      'i18next-extract',
-      {
-        nsSeparator: false,
-        locales: locales.map(locale => locale.code),
-        keySeparator: false,
-        outputPath: 'public/locales/{{locale}}/{{ns}}.json',
-        keyAsDefaultValue: ['en'],
-        discardOldKeys: true,
-      },
-    ],
   ]),
+  env: {
+    production: {
+      plugins: compact([
+        [
+          // extraction of the i18next translation strings
+          'i18next-extract',
+          {
+            nsSeparator: false,
+            locales: locales.map(locale => locale.code),
+            keySeparator: false,
+            outputPath: 'public/locales/{{locale}}/{{ns}}.json',
+            keyAsDefaultValue: ['en'],
+            discardOldKeys: true,
+          },
+        ],
+      ]),
+    },
+  },
 };

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,6 @@
 const compact = require('lodash/compact');
+const path = require('path');
+const locales = require(path.resolve('./config/shared/locales'));
 
 const isDevelopment = process.env.NODE_ENV === 'development';
 
@@ -20,5 +22,16 @@ module.exports = {
     '@babel/plugin-proposal-optional-chaining',
     'angularjs-annotate',
     isDevelopment && 'react-refresh/babel',
+    [
+      'i18next-extract',
+      {
+        nsSeparator: false,
+        locales: locales.map(locale => locale.code),
+        keySeparator: false,
+        outputPath: 'public/locales/{{locale}}/{{ns}}.json',
+        keyAsDefaultValue: ['en'],
+        discardOldKeys: true,
+      },
+    ],
   ]),
 };

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -53,7 +53,9 @@ export function MyComponent() {
 
 ### 4. Enjoy!
 
-Somebody still needs to specify the translations in `/public/locales/{lng}/myDefaultNamespace.json`:
+Run `npm run build`. Your extracted translation files should appear in `/public/locales/{locale}/{namespace}.json`.
+
+Somebody still needs to translate them.
 
 ```json
 {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6279,6 +6279,17 @@
         "object.assign": "^4.1.0"
       }
     },
+    "babel-plugin-i18next-extract": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-i18next-extract/-/babel-plugin-i18next-extract-0.6.1.tgz",
+      "integrity": "sha512-cvFZG6GaS53BaC3ILuY2sHV4bx2FoJrcLzqU3hNQodc3PnEFKv+EFj84C2+7ES7jSsFPwsCPBmALlIygLWyh4w==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.4.5",
+        "i18next": "^19.0.0",
+        "json-stable-stringify": "^1.0.1"
+      }
+    },
     "babel-plugin-istanbul": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -196,6 +196,7 @@
     "babel-eslint": "10.1.0",
     "babel-loader": "8.0.6",
     "babel-plugin-angularjs-annotate": "0.10.0",
+    "babel-plugin-i18next-extract": "0.6.1",
     "concurrently": "5.1.0",
     "css-loader": "3.4.2",
     "eslint": "6.8.0",


### PR DESCRIPTION
#### Proposed Changes

Configuration to extract translations with [babel-plugin-i18next-extract](https://github.com/gilbsgilbs/babel-plugin-i18next-extract)

This will make #1288 #1056 outdated.

~To work properly, we'll need to migrate all `withTranslation` to `useTranslation`. Otherwise the namespace is not recognized. #1292~ _done_

#### Usage

```sh
npm run build
```

#### Testing Instructions

- `git switch i18next-extract`
- `npm run build`
- new files in `./public/locales/{locale}` should appear. All strings should be sorted to their namespaces, so [translation.json](https://github.com/Trustroots/trustroots/blob/master/public/locales/en/translation.json) (i.e. fallback namespace) should not get updated.
- (optional) add a new locale to `./config/shared/locales.json`, run the build and see that a folder for the new locale with translation files gets generated. (`./public/locales/{newLocale}`)

#### Follow up
- ~close #1288~ _done_
- remove the endpoint for saving missing translations added in #1056 (#1312)
- extract the translations