### PR TITLE
Fix i18n extraction bugs

### DIFF
--- a/modules/contacts/client/components/ContactPresentational.js
+++ b/modules/contacts/client/components/ContactPresentational.js
@@ -25,7 +25,7 @@ export default function ContactPresentational({
         <div>
           <i className="icon-fw icon-building text-muted"></i>
           <small>
-            <Trans locationLiving={locationLiving}>
+            <Trans ns="contact" locationLiving={locationLiving}>
               Lives in{' '}
               <a href={`/search?location=${locationLiving}`}>
                 {{ locationLiving }}
@@ -38,7 +38,7 @@ export default function ContactPresentational({
         <div>
           <i className="icon-fw icon-home text-muted"></i>
           <small>
-            <Trans locationFrom={locationFrom}>
+            <Trans ns="contact" locationFrom={locationFrom}>
               From{' '}
               <a href={`/search?location=${locationFrom}`}>
                 {{ locationFrom }}

--- a/modules/references/client/components/create-reference/Info.js
+++ b/modules/references/client/components/create-reference/Info.js
@@ -55,11 +55,9 @@ export function LoadingInfo() {
  * @param {User} userTo
  */
 export function DuplicateInfo({ userTo }) {
-  useTranslation('reference');
-
   return (
     <div role="alert" className="alert alert-warning">
-      <Trans>
+      <Trans ns="reference">
         You&apos;ve already given a reference to <UserLink user={userTo} />.
       </Trans>
     </div>
@@ -81,7 +79,7 @@ export function SubmittedInfo({ isReported, isPublic, userFrom, userTo }) {
   const isPublicMessage = isPublic ? (
     <>
       <div>
-        <Trans>
+        <Trans ns="reference">
           <a href={`/profile/${userTo.username}/references`}>Your reference</a>{' '}
           for <UserLink user={userTo} /> is public now.
         </Trans>
@@ -94,7 +92,7 @@ export function SubmittedInfo({ isReported, isPublic, userFrom, userTo }) {
     </>
   ) : (
     <div>
-      <Trans daysToReply={daysToReply}>
+      <Trans ns="reference" daysToReply={daysToReply}>
         Your reference will become public when <UserLink user={userTo} /> gives
         you a reference back, or in {{ daysToReply }} days.
       </Trans>
@@ -107,7 +105,7 @@ export function SubmittedInfo({ isReported, isPublic, userFrom, userTo }) {
       <div>{isPublicMessage}</div>
       {isReported && (
         <div>
-          <Trans>
+          <Trans ns="reference">
             Also, <UserLink user={userTo} /> was reported.
           </Trans>
         </div>

--- a/modules/tribes/client/components/JoinButton.js
+++ b/modules/tribes/client/components/JoinButton.js
@@ -9,8 +9,6 @@ import * as api from '../api/tribes.api';
 function JoinButtonPresentational({
   isMember,
   isLoading,
-  joinLabel = 'Join',
-  joinedLabel = 'Joined',
   tribe,
   isLoggedIn,
   onToggle,
@@ -19,8 +17,8 @@ function JoinButtonPresentational({
 
   const ariaLabel = isMember
     ? t('Leave Tribe')
-    : t(`${joinLabel} ({{label}})`, { label: tribe.label });
-  const buttonLabel = isMember ? t(joinedLabel) : t(joinLabel);
+    : t('Join ({{label}})', { label: tribe.label });
+  const buttonLabel = isMember ? t('Joined') : t('Join');
 
   // a button to be shown when user is signed out
   if (!isLoggedIn) {
@@ -70,8 +68,6 @@ JoinButtonPresentational.propTypes = {
   isMember: PropTypes.bool.isRequired,
   isLoading: PropTypes.bool,
   isLoggedIn: PropTypes.bool.isRequired,
-  joinLabel: PropTypes.string,
-  joinedLabel: PropTypes.string,
   tribe: PropTypes.object.isRequired,
   onToggle: PropTypes.func,
 };

--- a/modules/users/client/components/Activate.js
+++ b/modules/users/client/components/Activate.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-
 import '@/config/client/i18n';
 
 export default function Activate() {

--- a/modules/users/client/components/Activate.js
+++ b/modules/users/client/components/Activate.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
-import { Trans } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
 import '@/config/client/i18n';
 
@@ -23,7 +22,7 @@ export default function Activate() {
           </em>
         </p>
         <p>
-          <Trans t={t}>
+          <Trans t={t} ns="users">
             If you didn&apos;t receive the message, check your spam folder or
             resend it via
             <a href="/profile/edit/account">email settings</a>.

--- a/modules/users/client/components/ProfileViewBasics.js
+++ b/modules/users/client/components/ProfileViewBasics.js
@@ -49,6 +49,7 @@ export default function ProfileViewBasics({ profile }) {
     return t('Online long ago');
   };
 
+  // i18next-extract-disable-next-line
   const getLanguage = code => t(languages[code], { ns: 'languages' });
 
   /*
@@ -89,7 +90,7 @@ export default function ProfileViewBasics({ profile }) {
   const renderLocationLiving = locationLiving => (
     <div className="profile-sidebar-section">
       <i className="icon-fw icon-building text-muted" />
-      <Trans>
+      <Trans ns="user-profile">
         Lives in{' '}
         <a href={`/search?location=${locationLiving}`}>{{ locationLiving }}</a>
       </Trans>
@@ -99,7 +100,7 @@ export default function ProfileViewBasics({ profile }) {
   const renderLocationFrom = locationFrom => (
     <div className="profile-sidebar-section">
       <i className="icon-fw icon-home text-muted"></i>
-      <Trans>
+      <Trans ns="user-profile">
         From <a href={`/search?location=${locationFrom}`}>{{ locationFrom }}</a>
       </Trans>
     </div>


### PR DESCRIPTION
#### Proposed Changes

There were a few bugs which caused extractions to be exported to wrong translation files, e.g. namespace was not recognized. Now they're fixed.

#### Testing Instructions

Just see that the app works. Or trust that these changes don't affect it. :)

_Please note: The following will work only after #1291 is merged. Let's do it as part of that PR:_

Extract the translations (`npm run build`) and see that none get extracted to a default namespace `public/locales/en/translations.json`. Also see that extraction passes without errors.

