### PR TITLE
Disable runtime extraction of translations

### DIFF
--- a/config/client/i18n.js
+++ b/config/client/i18n.js
@@ -88,8 +88,6 @@ i18n
     // allow keys to be phrases having `:`, `.`
     nsSeparator: false,
     keySeparator: false, // we do not use keys in form messages.welcome
-    saveMissing: process.env.NODE_ENV === 'development', // send not translated keys to endpoint
-    saveMissingTo: 'current',
     returnEmptyString: false,
     interpolation: {
       escapeValue: false, // react already safes from xss
@@ -106,7 +104,6 @@ i18n
     backend: {
       addPath: '/api/locales/{{lng}}/{{ns}}',
     },
-    saveMissingPlurals: true,
     whitelist: locales.map(({ code }) => code),
     // debug: true, // show missing translation keys in console.log
   });


### PR DESCRIPTION
#### Proposed Changes

Don't save missing translations on runtime. (disable in the config)

##### Why

I get annoyed when the translations are extracted and mess with my workflow.
#1291 method is superior to #1056, so when it gets merged, we'll remove the #1056 completely.

#### Testing Instructions (optional)

* `git switch dont-save-missing-translations`
* run the dev app
* browse it
* See that the translations don't get extracted at runtime
