### PR TITLE
Eslint: no-duplicate-imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,7 @@ const rules = {
   'new-cap': [2, { newIsCapExceptions: ['acl.memoryBackend', 'acl'] }],
   'no-caller': 2,
   'no-console': 2,
+  'no-duplicate-imports': 2,
   'no-multi-spaces': 2,
   'no-process-exit': 2,
   'no-spaced-func': 2,

--- a/modules/support/client/config/support.client.routes.js
+++ b/modules/support/client/config/support.client.routes.js
@@ -1,5 +1,4 @@
 import supportTemplateUrl from '@/modules/support/client/views/support.client.view.html';
-import contactTemplateUrl from '@/modules/support/client/views/support.client.view.html';
 
 angular.module('support').config(SupportRoutes);
 
@@ -19,7 +18,7 @@ function SupportRoutes($stateProvider) {
     // Deprecated (02-2016):
     .state('contact', {
       url: '/contact',
-      templateUrl: contactTemplateUrl,
+      templateUrl: supportTemplateUrl,
       requiresAuth: false,
       controller: 'SupportController',
       controllerAs: 'support',

--- a/modules/tribes/tests/client/components/TribesPage.component.tests.js
+++ b/modules/tribes/tests/client/components/TribesPage.component.tests.js
@@ -1,5 +1,10 @@
 import React from 'react';
-import { render, fireEvent, waitForElement, within } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  waitForElement,
+  within,
+} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import '@/config/client/i18n';
 import {

--- a/modules/tribes/tests/client/components/TribesPage.component.tests.js
+++ b/modules/tribes/tests/client/components/TribesPage.component.tests.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { within } from '@testing-library/react';
-import { render, fireEvent, waitForElement } from '@testing-library/react';
+import { render, fireEvent, waitForElement, within } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import '@/config/client/i18n';
 import {


### PR DESCRIPTION
Came up via https://github.com/Trustroots/trustroots/pull/1156#discussion_r392700524

#### Proposed Changes

* Enable [`no-duplicate-imports`](https://eslint.org/docs/rules/no-duplicate-imports) Eslint rule.

#### Testing Instructions

* `npm run lint` passing (in CI)
* This won't work without lint error:
```js
import { get } from 'lodash';
import { set } from 'lodash';
```
