### PR TITLE
Add admin threads tool

### DIFF
--- a/modules/admin/client/api/threads.api.js
+++ b/modules/admin/client/api/threads.api.js
@@ -1,0 +1,6 @@
+import axios from 'axios';
+
+export async function getThreads(userId) {
+  const { data } = await axios.post('/api/admin/threads', { userId });
+  return data;
+}

--- a/modules/admin/client/api/threads.api.js
+++ b/modules/admin/client/api/threads.api.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-export async function getThreads(userId) {
-  const { data } = await axios.post('/api/admin/threads', { userId });
+export async function getThreads({ userId = '', username = '' }) {
+  const { data } = await axios.post('/api/admin/threads', { userId, username });
   return data;
 }

--- a/modules/admin/client/components/AdminHeader.component.js
+++ b/modules/admin/client/components/AdminHeader.component.js
@@ -40,6 +40,9 @@ export default function AdminHeader() {
             <li className={classnames({ active: path === '/admin/messages' })}>
               <a href="/admin/messages">Messages</a>
             </li>
+            <li className={classnames({ active: path === '/admin/threads' })}>
+              <a href="/admin/threads">Threads</a>
+            </li>
             <li
               className={classnames({
                 active: path === '/admin/acquisition-stories',

--- a/modules/admin/client/components/AdminMessages.component.js
+++ b/modules/admin/client/components/AdminMessages.component.js
@@ -117,7 +117,7 @@ export default class AdminMessages extends Component {
           ) : (
             <p>
               <br />
-              <em className="text-muted">Choose two members...</em>
+              <em className="text-muted">Choose two members…</em>
             </p>
           )}
         </div>

--- a/modules/admin/client/components/AdminMessages.component.js
+++ b/modules/admin/client/components/AdminMessages.component.js
@@ -11,6 +11,7 @@ import UserLink from './UserLink.component';
 const MONGO_OBJECT_ID_LENGTH = 24;
 
 export default function AdminMessages() {
+  // @TODO: replace with useLocation of react-router or similar.
   const urlParams = new URLSearchParams(window.location.search);
   const urlUserId1 = urlParams.get('userId1');
   const urlUserId2 = urlParams.get('userId2');

--- a/modules/admin/client/components/AdminMessages.component.js
+++ b/modules/admin/client/components/AdminMessages.component.js
@@ -91,7 +91,7 @@ export default function AdminMessages() {
           </p>
         )}
 
-        {queried && messages.length ? (
+        {queried && messages.length > 0 && (
           <>
             <h3>
               Messaging between <UserLink user={messages[0].userFrom} />
@@ -116,7 +116,8 @@ export default function AdminMessages() {
               );
             })}
           </>
-        ) : (
+        )}
+        {queried && messages.length === 0 && (
           <div className="alert alert-info">
             <em>Nothing found…</em>
           </div>

--- a/modules/admin/client/components/AdminMessages.component.js
+++ b/modules/admin/client/components/AdminMessages.component.js
@@ -1,5 +1,5 @@
 // External dependencies
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 
 // Internal dependencies
 import { getMessages } from '../api/messages.api';
@@ -10,120 +10,120 @@ import UserLink from './UserLink.component';
 // Mongo ObjectId is always 24 chars long
 const MONGO_OBJECT_ID_LENGTH = 24;
 
-export default class AdminMessages extends Component {
-  constructor(props) {
-    super(props);
-    this.onUserChange = this.onUserChange.bind(this);
-    this.onSubmit = this.onSubmit.bind(this);
-    this.state = {
-      messages: [],
-      user1: '',
-      user2: '',
-    };
-  }
+export default function AdminMessages() {
+  const urlParams = new URLSearchParams(window.location.search);
+  const urlUserId1 = urlParams.get('userId1');
+  const urlUserId2 = urlParams.get('userId2');
+  const initialUserId1 =
+    urlUserId1 && urlUserId1.length === MONGO_OBJECT_ID_LENGTH
+      ? urlUserId1
+      : '';
+  const initialUserId2 =
+    urlUserId2 && urlUserId2.length === MONGO_OBJECT_ID_LENGTH
+      ? urlUserId2
+      : '';
 
-  onUserChange(event) {
-    const { name, value } = event.target;
-    this.setState({
-      [name]: value,
-    });
-  }
+  const [queried, setQueried] = useState(false);
+  const [messages, setMessages] = useState([]);
+  const [userId1, setUserId1] = useState(initialUserId1);
+  const [userId2, setUserId2] = useState(initialUserId2);
 
-  async onSubmit(event) {
-    if (event) {
-      event.preventDefault();
-    }
-    const { user1, user2 } = this.state;
+  async function onSubmit(event) {
+    event.preventDefault();
     if (
-      user1 &&
-      user2 &&
-      user1.length === MONGO_OBJECT_ID_LENGTH &&
-      user2.length === MONGO_OBJECT_ID_LENGTH
+      userId1 &&
+      userId2 &&
+      userId1.length === MONGO_OBJECT_ID_LENGTH &&
+      userId2.length === MONGO_OBJECT_ID_LENGTH
     ) {
-      const messages = await getMessages(user1, user2);
-      this.setState({ messages });
+      const messages = await getMessages(userId1, userId2);
+      setMessages(messages);
+      setQueried(true);
     }
   }
 
-  render() {
-    const { messages, user1, user2 } = this.state;
+  return (
+    <>
+      <AdminHeader />
+      <div className="container">
+        <h2>Messages</h2>
 
-    return (
-      <>
-        <AdminHeader />
-        <div className="container">
-          <h2>Messages</h2>
+        <form className="form-inline" onSubmit={event => onSubmit(event)}>
+          <input
+            aria-label="Member 1 ID"
+            className="form-control input-lg"
+            maxLength={MONGO_OBJECT_ID_LENGTH}
+            name="userId1"
+            onChange={({ target: { value } }) => setUserId1(value)}
+            placeholder="Member 1 ID"
+            size={MONGO_OBJECT_ID_LENGTH + 2}
+            type="text"
+            value={userId1}
+          />
+          <input
+            aria-label="Member 2 ID"
+            className="form-control input-lg"
+            maxLength={MONGO_OBJECT_ID_LENGTH}
+            name="userId2"
+            onChange={({ target: { value } }) => setUserId2(value)}
+            placeholder="Member 2 ID"
+            size={MONGO_OBJECT_ID_LENGTH + 2}
+            type="text"
+            value={userId2}
+          />
+          <button
+            className="btn btn-lg btn-default"
+            disabled={
+              userId1.length !== MONGO_OBJECT_ID_LENGTH &&
+              userId2.length !== MONGO_OBJECT_ID_LENGTH
+            }
+            type="submit"
+          >
+            Read
+          </button>
+        </form>
 
-          <form className="form-inline" onSubmit={this.onSubmit}>
-            <input
-              aria-label="Member 1 ID"
-              className="form-control input-lg"
-              maxLength={MONGO_OBJECT_ID_LENGTH}
-              name="user1"
-              onChange={this.onUserChange}
-              placeholder="Member 1 ID"
-              size={MONGO_OBJECT_ID_LENGTH + 2}
-              type="text"
-              value={user1}
-            />
-            <input
-              aria-label="Member 2 ID"
-              className="form-control input-lg"
-              maxLength={MONGO_OBJECT_ID_LENGTH}
-              name="user2"
-              onChange={this.onUserChange}
-              placeholder="Member 2 ID"
-              size={MONGO_OBJECT_ID_LENGTH + 2}
-              type="text"
-              value={user2}
-            />
-            <button
-              className="btn btn-lg btn-default"
-              disabled={
-                user1.length !== MONGO_OBJECT_ID_LENGTH &&
-                user2.length !== MONGO_OBJECT_ID_LENGTH
-              }
-              type="submit"
-            >
-              Read
-            </button>
-          </form>
+        {!queried && messages.length === 0 && (
+          <p>
+            <em className="text-muted">
+              {userId1 && userId2 ? 'Press "Read"' : 'Choose two members…'}
+            </em>
+          </p>
+        )}
 
-          {messages.length ? (
-            <>
-              <h3>
-                Messaging between <UserLink user={messages[0].userFrom} />
-                {' & '}
-                <UserLink user={messages[0].userTo} />
-              </h3>
-              {messages.map(message => {
-                const { _id } = message;
-                return (
-                  <div className="panel panel-default" key={_id}>
-                    <div className="panel-body">
-                      {message.content}
-                      <br />
-                      <br />
-                      <UserLink user={message.userFrom} />
-                      <details>
-                        <summary>Message details</summary>
-                        <Json content={message} />
-                      </details>
-                    </div>
+        {queried && messages.length ? (
+          <>
+            <h3>
+              Messaging between <UserLink user={messages[0].userFrom} />
+              {' & '}
+              <UserLink user={messages[0].userTo} />
+            </h3>
+            {messages.map(message => {
+              const { _id } = message;
+              return (
+                <div className="panel panel-default" key={_id}>
+                  <div className="panel-body">
+                    {message.content}
+                    <br />
+                    <br />
+                    <UserLink user={message.userFrom} />
+                    <details>
+                      <summary>Message details</summary>
+                      <Json content={message} />
+                    </details>
                   </div>
-                );
-              })}
-            </>
-          ) : (
-            <p>
-              <br />
-              <em className="text-muted">Choose two members…</em>
-            </p>
-          )}
-        </div>
-      </>
-    );
-  }
+                </div>
+              );
+            })}
+          </>
+        ) : (
+          <div className="alert alert-info">
+            <em>Nothing found…</em>
+          </div>
+        )}
+      </div>
+    </>
+  );
 }
 
 AdminMessages.propTypes = {};

--- a/modules/admin/client/components/AdminThreads.component.js
+++ b/modules/admin/client/components/AdminThreads.component.js
@@ -8,7 +8,6 @@ import Json from './Json.component';
 import UserLink from './UserLink.component';
 import TimeAgo from '@/modules/core/client/components/TimeAgo';
 
-
 // Mongo ObjectId is always 24 chars long
 const MONGO_OBJECT_ID_LENGTH = 24;
 
@@ -58,7 +57,7 @@ export default class AdminThreads extends Component {
       return (
         <p>
           <em className="text-muted">
-            { userId ? 'Press "Query"' : 'Enter member ID…' }
+            {userId ? 'Press "Query"' : 'Enter member ID…'}
           </em>
         </p>
       );
@@ -74,34 +73,30 @@ export default class AdminThreads extends Component {
 
     return (
       <>
-        <h3>
-          Messages from/to them
-        </h3>
-        {
-          threads.map((thread) => {
-            const { _id } = thread;
-            return (
-              <div className="panel panel-default" key={_id}>
-                <div className="panel-body">
-                  <p>
-                    <UserLink user={ thread.userFromProfile[0] } />
-                    { ' → ' }
-                    <UserLink user={ thread.userToProfile[0] } />
-                    { ` (${thread.read ? 'read' : 'unread'})` }
-                  </p>
-                  <p>
-                    <TimeAgo date={thread.updated} />
-                    { ` (${thread.updated})` }
-                  </p>
-                  <details>
-                    <summary>Thread details</summary>
-                    <Json content={thread} />
-                  </details>
-                </div>
+        <h3>Messages from/to them</h3>
+        {threads.map(thread => {
+          const { _id } = thread;
+          return (
+            <div className="panel panel-default" key={_id}>
+              <div className="panel-body">
+                <p>
+                  <UserLink user={thread.userFromProfile[0]} />
+                  {' → '}
+                  <UserLink user={thread.userToProfile[0]} />
+                  {` (${thread.read ? 'read' : 'unread'})`}
+                </p>
+                <p>
+                  <TimeAgo date={thread.updated} />
+                  {` (${thread.updated})`}
+                </p>
+                <details>
+                  <summary>Thread details</summary>
+                  <Json content={thread} />
+                </details>
               </div>
-            );
-          })
-        }
+            </div>
+          );
+        })}
       </>
     );
   }
@@ -114,28 +109,28 @@ export default class AdminThreads extends Component {
         <AdminHeader />
         <div className="container">
           <h2>Threads</h2>
-          <form className="form-inline" onSubmit={ this.onSubmit }>
+          <form className="form-inline" onSubmit={this.onSubmit}>
             <input
               aria-label="Member ID"
               className="form-control input-lg"
-              maxLength={ MONGO_OBJECT_ID_LENGTH }
+              maxLength={MONGO_OBJECT_ID_LENGTH}
               name="userId"
-              onChange={ this.onUserIdChange }
+              onChange={this.onUserIdChange}
               placeholder="Member ID"
-              size={ MONGO_OBJECT_ID_LENGTH + 2 }
+              size={MONGO_OBJECT_ID_LENGTH + 2}
               type="text"
-              value={ userId }
+              value={userId}
             />
             <button
               className="btn btn-lg btn-default"
-              disabled={ userId.length !== MONGO_OBJECT_ID_LENGTH }
+              disabled={userId.length !== MONGO_OBJECT_ID_LENGTH}
               type="submit"
             >
               Query
             </button>
           </form>
           <br />
-          { this.renderResults() }
+          {this.renderResults()}
         </div>
       </>
     );

--- a/modules/admin/client/components/AdminThreads.component.js
+++ b/modules/admin/client/components/AdminThreads.component.js
@@ -1,0 +1,145 @@
+// External dependencies
+import React, { Component } from 'react';
+
+// Internal dependencies
+import { getThreads } from '../api/threads.api';
+import AdminHeader from './AdminHeader.component';
+import Json from './Json.component';
+import UserLink from './UserLink.component';
+import TimeAgo from '@/modules/core/client/components/TimeAgo';
+
+
+// Mongo ObjectId is always 24 chars long
+const MONGO_OBJECT_ID_LENGTH = 24;
+
+export default class AdminThreads extends Component {
+  constructor(props) {
+    super(props);
+    this.onUserIdChange = this.onUserIdChange.bind(this);
+    this.renderResults = this.renderResults.bind(this);
+    this.onSubmit = this.onSubmit.bind(this);
+    this.state = {
+      queried: false,
+      threads: [],
+      userId: '',
+    };
+  }
+
+  componentDidMount() {
+    const urlParams = new URLSearchParams(window.location.search);
+    const userId = urlParams.get('userId');
+
+    if (userId && userId.length === MONGO_OBJECT_ID_LENGTH) {
+      this.setState({ userId });
+    }
+  }
+
+  onUserIdChange(event) {
+    const userId = event.target.value;
+    this.setState({ userId });
+  }
+
+  async onSubmit(event) {
+    if (event) {
+      event.preventDefault();
+    }
+    const { userId } = this.state;
+    // Mongo ObjectId is always 24 chars long
+    if (userId && userId.length === MONGO_OBJECT_ID_LENGTH) {
+      const threads = await getThreads(userId);
+      this.setState({ threads, queried: true });
+    }
+  }
+
+  renderResults() {
+    const { threads, queried, userId } = this.state;
+
+    if (!queried && threads.length === 0) {
+      return (
+        <p>
+          <em className="text-muted">
+            { userId ? 'Press "Query"' : 'Enter member ID…' }
+          </em>
+        </p>
+      );
+    }
+
+    if (queried && threads.length === 0) {
+      return (
+        <div className="alert alert-info">
+          <em>Nothing found…</em>
+        </div>
+      );
+    }
+
+    return (
+      <>
+        <h3>
+          Messages from/to them
+        </h3>
+        {
+          threads.map((thread) => {
+            const { _id } = thread;
+            return (
+              <div className="panel panel-default" key={_id}>
+                <div className="panel-body">
+                  <p>
+                    <UserLink user={ thread.userFromProfile[0] } />
+                    { ' → ' }
+                    <UserLink user={ thread.userToProfile[0] } />
+                    { ` (${thread.read ? 'read' : 'unread'})` }
+                  </p>
+                  <p>
+                    <TimeAgo date={thread.updated} />
+                    { ` (${thread.updated})` }
+                  </p>
+                  <details>
+                    <summary>Thread details</summary>
+                    <Json content={thread} />
+                  </details>
+                </div>
+              </div>
+            );
+          })
+        }
+      </>
+    );
+  }
+
+  render() {
+    const { userId } = this.state;
+
+    return (
+      <>
+        <AdminHeader />
+        <div className="container">
+          <h2>Threads</h2>
+          <form className="form-inline" onSubmit={ this.onSubmit }>
+            <input
+              aria-label="Member ID"
+              className="form-control input-lg"
+              maxLength={ MONGO_OBJECT_ID_LENGTH }
+              name="userId"
+              onChange={ this.onUserIdChange }
+              placeholder="Member ID"
+              size={ MONGO_OBJECT_ID_LENGTH + 2 }
+              type="text"
+              value={ userId }
+            />
+            <button
+              className="btn btn-lg btn-default"
+              disabled={ userId.length !== MONGO_OBJECT_ID_LENGTH }
+              type="submit"
+            >
+              Query
+            </button>
+          </form>
+          <br />
+          { this.renderResults() }
+        </div>
+      </>
+    );
+  }
+}
+
+AdminThreads.propTypes = {};

--- a/modules/admin/client/components/AdminThreads.component.js
+++ b/modules/admin/client/components/AdminThreads.component.js
@@ -13,6 +13,7 @@ import TimeAgo from '@/modules/core/client/components/TimeAgo';
 const MONGO_OBJECT_ID_LENGTH = 24;
 
 export default function AdminThreads() {
+  // @TODO: replace with useLocation of react-router or similar.
   const urlParams = new URLSearchParams(window.location.search);
   const urlUserId = urlParams.get('userId');
   const initialUsername = urlParams.get('username') || '';
@@ -45,7 +46,7 @@ export default function AdminThreads() {
       return (
         <p>
           <em className="text-muted">
-            {userId ? 'Press "Query"' : 'Enter member ID…'}
+            {userId ? 'Press "Query"' : 'Enter member ID or username…'}
           </em>
         </p>
       );
@@ -117,7 +118,7 @@ export default function AdminThreads() {
             size={MONGO_OBJECT_ID_LENGTH + 2}
             type="text"
             value={userId}
-            disabled={username.length}
+            disabled={username.length > 0}
           />
           <em> or </em>
           <input
@@ -129,7 +130,7 @@ export default function AdminThreads() {
             size={20}
             type="text"
             value={username}
-            disabled={userId && userId.length === MONGO_OBJECT_ID_LENGTH}
+            disabled={userId.length > 0}
           />
           <button
             className="btn btn-lg btn-default"

--- a/modules/admin/client/components/AdminThreads.component.js
+++ b/modules/admin/client/components/AdminThreads.component.js
@@ -15,22 +15,28 @@ const MONGO_OBJECT_ID_LENGTH = 24;
 export default function AdminThreads() {
   const urlParams = new URLSearchParams(window.location.search);
   const urlUserId = urlParams.get('userId');
+  const initialUsername = urlParams.get('username') || '';
   const initialUserId =
     urlUserId && urlUserId.length === MONGO_OBJECT_ID_LENGTH ? urlUserId : '';
 
   const [queried, setQueried] = useState(false);
   const [threads, setThreads] = useState([]);
   const [userId, setUserId] = useState(initialUserId);
+  const [username, setUsername] = useState(initialUsername);
 
   async function onSubmit(event) {
-    if (event) {
-      event.preventDefault();
-    }
+    event.preventDefault();
+
     // Mongo ObjectId is always 24 chars long
-    if (userId && userId.length === MONGO_OBJECT_ID_LENGTH) {
-      const threads = await getThreads(userId);
+    if (!username && userId && userId.length !== MONGO_OBJECT_ID_LENGTH) {
+      alert('User ID is wrong length');
+      return;
+    }
+
+    const threads = await getThreads({ userId, username });
+    setQueried(true);
+    if (threads) {
       setThreads(threads);
-      setQueried(true);
     }
   }
 
@@ -111,11 +117,24 @@ export default function AdminThreads() {
             size={MONGO_OBJECT_ID_LENGTH + 2}
             type="text"
             value={userId}
+            disabled={username.length}
+          />
+          <em> or </em>
+          <input
+            aria-label="Username"
+            className="form-control input-lg"
+            name="userId"
+            onChange={({ target: { value } }) => setUsername(value)}
+            placeholder="Username"
+            size={20}
+            type="text"
+            value={username}
+            disabled={userId && userId.length === MONGO_OBJECT_ID_LENGTH}
           />
           <button
             className="btn btn-lg btn-default"
-            disabled={userId.length !== MONGO_OBJECT_ID_LENGTH}
             type="submit"
+            disabled={!username.length && !userId.length}
           >
             Query
           </button>

--- a/modules/admin/client/components/AdminUser.component.js
+++ b/modules/admin/client/components/AdminUser.component.js
@@ -173,7 +173,11 @@ export default class AdminUser extends Component {
                     </li>
                     <li>{user.messageFromCount || 0} sent</li>
                     <li>{user.messageToCount || 0} received</li>
-                    <li>{user.threadCount || 0} threads total</li>
+                    <li>
+                      <a href={`/admin/threads?userId=${user.profile._id}`}>
+                        {user.threadCount || 0} threads total
+                      </a>
+                    </li>
                   </ul>
                   <ul className="list-inline">
                     <li>

--- a/modules/admin/client/config/admin.client.routes.js
+++ b/modules/admin/client/config/admin.client.routes.js
@@ -52,6 +52,19 @@ function AdminRoutes($stateProvider) {
         pageTitle: 'Admin - Messages',
       },
     })
+    .state('admin-threads', {
+      url: '/admin/threads',
+      // `template` is Angular state so
+      // it should be lowercase, with dashes
+      // This is the bridge towards (and from) React
+      template: '<admin-threads></admin-threads>',
+      requiresRole: 'admin',
+      requiresAuth: true,
+      footerHidden: true,
+      data: {
+        pageTitle: 'Admin - Threads',
+      },
+    })
     .state('admin-search-users', {
       url: '/admin/search-users',
       // `template` is Angular state so

--- a/modules/admin/server/controllers/admin.threads.server.controller.js
+++ b/modules/admin/server/controllers/admin.threads.server.controller.js
@@ -3,7 +3,9 @@
  */
 const _ = require('lodash');
 const path = require('path');
-const errorService = require(path.resolve('./modules/core/server/services/error.server.service'));
+const errorService = require(path.resolve(
+  './modules/core/server/services/error.server.service',
+));
 const mongoose = require('mongoose');
 const Thread = mongoose.model('Thread');
 
@@ -20,58 +22,56 @@ exports.getThreads = (req, res) => {
     });
   }
 
-  Thread
-    .aggregate([
-      {
-        // Latest message in thread is either from, or to user
-        $match: { $or: [
+  Thread.aggregate([
+    {
+      // Latest message in thread is either from, or to user
+      $match: {
+        $or: [
           // eslint-disable-next-line new-cap
           { userFrom: mongoose.Types.ObjectId(userId) },
           // eslint-disable-next-line new-cap
           { userTo: mongoose.Types.ObjectId(userId) },
-        ] },
+        ],
       },
-      {
-        $lookup:
-          {
-            from: 'users',
-            localField: 'userTo',
-            foreignField: '_id',
-            as: 'userToProfile',
-          },
+    },
+    {
+      $lookup: {
+        from: 'users',
+        localField: 'userTo',
+        foreignField: '_id',
+        as: 'userToProfile',
       },
-      {
-        $lookup:
-          {
-            from: 'users',
-            localField: 'userFrom',
-            foreignField: '_id',
-            as: 'userFromProfile',
-          },
+    },
+    {
+      $lookup: {
+        from: 'users',
+        localField: 'userFrom',
+        foreignField: '_id',
+        as: 'userFromProfile',
       },
-      {
-        $project: {
-          _id: 1,
-          read: 1,
-          updated: 1,
-          'userToProfile._id': 1,
-          'userToProfile.username': 1,
-          'userToProfile.email': 1,
-          'userFromProfile._id': 1,
-          'userFromProfile.username': 1,
-        },
+    },
+    {
+      $project: {
+        _id: 1,
+        read: 1,
+        updated: 1,
+        'userToProfile._id': 1,
+        'userToProfile.username': 1,
+        'userToProfile.email': 1,
+        'userFromProfile._id': 1,
+        'userFromProfile.username': 1,
       },
-      {
-        $sort: { updated: -1 },
-      },
-    ])
-    .exec((err, threads) => {
-      if (err) {
-        return res.status(400).send({
-          message: errorService.getErrorMessage(err),
-        });
-      }
+    },
+    {
+      $sort: { updated: -1 },
+    },
+  ]).exec((err, threads) => {
+    if (err) {
+      return res.status(400).send({
+        message: errorService.getErrorMessage(err),
+      });
+    }
 
-      return res.send(threads);
-    });
+    return res.send(threads);
+  });
 };

--- a/modules/admin/server/controllers/admin.threads.server.controller.js
+++ b/modules/admin/server/controllers/admin.threads.server.controller.js
@@ -1,0 +1,77 @@
+/**
+ * Module dependencies.
+ */
+const _ = require('lodash');
+const path = require('path');
+const errorService = require(path.resolve('./modules/core/server/services/error.server.service'));
+const mongoose = require('mongoose');
+const Thread = mongoose.model('Thread');
+
+/*
+ * This middleware sends response with an array of found users
+ */
+exports.getThreads = (req, res) => {
+  const userId = _.get(req, ['body', 'userId']);
+
+  // Check that all provided IDs are  valid
+  if (!userId || !mongoose.Types.ObjectId.isValid(userId)) {
+    return res.status(400).send({
+      message: errorService.getErrorMessageByKey('invalid-id'),
+    });
+  }
+
+  Thread
+    .aggregate([
+      {
+        // Latest message in thread is either from, or to user
+        $match: { $or: [
+          // eslint-disable-next-line new-cap
+          { userFrom: mongoose.Types.ObjectId(userId) },
+          // eslint-disable-next-line new-cap
+          { userTo: mongoose.Types.ObjectId(userId) },
+        ] },
+      },
+      {
+        $lookup:
+          {
+            from: 'users',
+            localField: 'userTo',
+            foreignField: '_id',
+            as: 'userToProfile',
+          },
+      },
+      {
+        $lookup:
+          {
+            from: 'users',
+            localField: 'userFrom',
+            foreignField: '_id',
+            as: 'userFromProfile',
+          },
+      },
+      {
+        $project: {
+          _id: 1,
+          read: 1,
+          updated: 1,
+          'userToProfile._id': 1,
+          'userToProfile.username': 1,
+          'userToProfile.email': 1,
+          'userFromProfile._id': 1,
+          'userFromProfile.username': 1,
+        },
+      },
+      {
+        $sort: { updated: -1 },
+      },
+    ])
+    .exec((err, threads) => {
+      if (err) {
+        return res.status(400).send({
+          message: errorService.getErrorMessage(err),
+        });
+      }
+
+      return res.send(threads);
+    });
+};

--- a/modules/admin/server/controllers/admin.threads.server.controller.js
+++ b/modules/admin/server/controllers/admin.threads.server.controller.js
@@ -15,7 +15,7 @@ const Thread = mongoose.model('Thread');
 exports.getThreads = async (req, res) => {
   // See `usernameToUserId` middleware from admin.users.server.controller.js
   // req.userId can get placed in request when `req.body.username` is set.
-  const userId = req.userId || _.get(req, ['body', 'userId']);
+  const userId = req.userIdFromUsername || _.get(req, ['body', 'userId']);
 
   // Check that provided ID is valid
   if (!userId || !mongoose.Types.ObjectId.isValid(userId)) {

--- a/modules/admin/server/controllers/admin.threads.server.controller.js
+++ b/modules/admin/server/controllers/admin.threads.server.controller.js
@@ -12,10 +12,12 @@ const Thread = mongoose.model('Thread');
 /*
  * This middleware sends response with an array of found users
  */
-exports.getThreads = (req, res) => {
-  const userId = _.get(req, ['body', 'userId']);
+exports.getThreads = async (req, res) => {
+  // See `usernameToUserId` middleware from admin.users.server.controller.js
+  // req.userId can get placed in request when `req.body.username` is set.
+  const userId = req.userId || _.get(req, ['body', 'userId']);
 
-  // Check that all provided IDs are  valid
+  // Check that provided ID is valid
   if (!userId || !mongoose.Types.ObjectId.isValid(userId)) {
     return res.status(400).send({
       message: errorService.getErrorMessageByKey('invalid-id'),

--- a/modules/admin/server/controllers/admin.users.server.controller.js
+++ b/modules/admin/server/controllers/admin.users.server.controller.js
@@ -298,3 +298,18 @@ exports.changeRole = async (req, res) => {
     handleAdminApiError(res, err);
   }
 };
+
+exports.usernameToUserId = async (req, res, next) => {
+  const username = _.get(req, ['body', 'username']);
+
+  // Get userID based on provided username
+  if (username) {
+    const user = await User.findOne({ username });
+
+    if (user) {
+      req.userId = user._id;
+    }
+  }
+
+  next();
+};

--- a/modules/admin/server/controllers/admin.users.server.controller.js
+++ b/modules/admin/server/controllers/admin.users.server.controller.js
@@ -307,7 +307,7 @@ exports.usernameToUserId = async (req, res, next) => {
     const user = await User.findOne({ username });
 
     if (user) {
-      req.userId = user._id;
+      req.userIdFromUsername = user._id;
     }
   }
 

--- a/modules/admin/server/policies/admin.server.policy.js
+++ b/modules/admin/server/policies/admin.server.policy.js
@@ -22,6 +22,7 @@ exports.invokeRolesPolicies = () => {
         { resources: '/api/admin/acquisition-stories', permissions: ['post'] },
         { resources: '/api/admin/audit-log', permissions: ['get'] },
         { resources: '/api/admin/messages', permissions: ['post'] },
+        { resources: '/api/admin/threads', permissions: ['post'] },
         { resources: '/api/admin/user', permissions: ['post'] },
         { resources: '/api/admin/user/change-role', permissions: ['post'] },
         { resources: '/api/admin/users', permissions: ['post'] },

--- a/modules/admin/server/routes/admin.server.routes.js
+++ b/modules/admin/server/routes/admin.server.routes.js
@@ -5,6 +5,7 @@ const adminAcquisitionStories = require('../controllers/admin.acquisition-storie
 const adminAuditLog = require('../controllers/admin.audit-log.server.controller');
 const adminMessages = require('../controllers/admin.messages.server.controller');
 const adminPolicy = require('../policies/admin.server.policy');
+const adminThreads = require('../controllers/admin.threads.server.controller');
 const adminUsers = require('../controllers/admin.users.server.controller');
 
 module.exports = app => {
@@ -22,6 +23,11 @@ module.exports = app => {
     .route('/api/admin/messages')
     .all(adminPolicy.isAllowed)
     .post(adminAuditLog.record, adminMessages.getMessages);
+
+  app
+    .route('/api/admin/threads')
+    .all(adminPolicy.isAllowed)
+    .post(adminAuditLog.record, adminThreads.getThreads);
 
   app
     .route('/api/admin/users')

--- a/modules/admin/server/routes/admin.server.routes.js
+++ b/modules/admin/server/routes/admin.server.routes.js
@@ -27,7 +27,11 @@ module.exports = app => {
   app
     .route('/api/admin/threads')
     .all(adminPolicy.isAllowed)
-    .post(adminAuditLog.record, adminThreads.getThreads);
+    .post(
+      adminAuditLog.record,
+      adminUsers.usernameToUserId,
+      adminThreads.getThreads,
+    );
 
   app
     .route('/api/admin/users')

--- a/modules/admin/tests/server/admin.threads.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.threads.server.routes.tests.js
@@ -1,0 +1,173 @@
+const request = require('supertest');
+const path = require('path');
+const mongoose = require('mongoose');
+const Message = mongoose.model('Message');
+const User = mongoose.model('User');
+const express = require(path.resolve('./config/lib/express'));
+require('should');
+
+/**
+ * Globals
+ */
+let app;
+let agent;
+let credentialsAdmin;
+let credentialsRegular;
+let userAdmin;
+let userRegular1;
+let userRegular2;
+let userRegular1Id;
+let userRegular2Id;
+
+describe('Admin Message CRUD tests', () => {
+
+  before((done) => {
+    // Get application
+    app = express.init(mongoose.connection);
+    agent = request.agent(app);
+
+    done();
+  });
+
+  beforeEach(async () => {
+    try {
+      // Create admin credentials
+      credentialsAdmin = {
+        username: 'user-admin',
+        password: 'Password123!',
+      };
+
+      // Create regular user credentials
+      credentialsRegular = {
+        username: 'user-regular1',
+        password: 'Password123!',
+      };
+
+      // Create a new admin user
+      userAdmin = new User({
+        displayName: 'Admin Name',
+        email: 'admin@example.com',
+        firstName: 'Admin',
+        lastName: 'Name',
+        member: [],
+        provider: 'local',
+        public: true,
+        roles: ['user', 'admin'],
+        ...credentialsAdmin,
+      });
+
+      await userAdmin.save();
+
+      // Create a new regular user
+      userRegular1 = new User({
+        displayName: 'Full Name1',
+        email: 'regular1@example.com',
+        firstName: 'Full',
+        lastName: 'Name2',
+        member: [],
+        provider: 'local',
+        public: true,
+        roles: ['user'],
+        ...credentialsRegular,
+      });
+
+      // Create a new regular user
+      userRegular2 = new User({
+        displayName: 'Full Name2',
+        email: 'regular2@example.com',
+        firstName: 'Full',
+        lastName: 'Name2',
+        member: [],
+        provider: 'local',
+        public: true,
+        roles: ['user'],
+        username: 'user-regular2',
+        password: 'Password123!',
+      });
+
+      const { _id: _userRegular1Id } = await userRegular1.save();
+      const { _id: _userRegular2Id } = await userRegular2.save();
+      userRegular1Id = _userRegular1Id;
+      userRegular2Id = _userRegular2Id;
+
+      const message1 = new Message({
+        content: 'test',
+        notificationCount: 0,
+        userFrom: userRegular1Id,
+        userTo: userRegular2Id,
+      });
+
+      const message2 = new Message({
+        content: 'test',
+        notificationCount: 0,
+        userFrom: userRegular2Id,
+        userTo: userRegular1Id,
+      });
+
+      await message1.save();
+      await message2.save();
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err);
+    }
+  });
+
+  describe('Read messages between two users', () => {
+    it('non-authenticated users should not be allowed to read messages', (done) => {
+      agent.post('/api/admin/messages')
+        .send({ 'user1': userRegular1Id, 'user2': userRegular2Id })
+        .expect(403)
+        .end((err, res) => {
+          res.body.message.should.equal('Forbidden.');
+          return done(err);
+        });
+    });
+
+    it('non-admin users should not be allowed to read messages', (done) => {
+      agent.post('/api/auth/signin')
+        .send(credentialsRegular)
+        .expect(200)
+        .end((signinErr) => {
+          if (signinErr) {
+            return done(signinErr);
+          }
+
+          agent.post('/api/admin/messages')
+            .send({ 'user1': userRegular1Id, 'user2': userRegular2Id })
+            .expect(403)
+            .end((err, res) => {
+              res.body.message.should.equal('Forbidden.');
+              return done(err);
+            });
+        });
+    });
+
+    it('admin users should be allowed to read messages', (done) => {
+      agent.post('/api/auth/signin')
+        .send(credentialsAdmin)
+        .expect(200)
+        .end((signinErr) => {
+          if (signinErr) {
+            return done(signinErr);
+          }
+
+          agent.post('/api/admin/messages')
+            .send({ 'user1': userRegular1Id, 'user2': userRegular2Id })
+            .expect(200)
+            .end((err, res) => {
+              res.body.length.should.equal(2);
+              res.body[0].userFrom.username.should.equal('user-regular1');
+              res.body[0].userTo.username.should.equal('user-regular2');
+              return done(err);
+            });
+        });
+    });
+
+  });
+
+  afterEach((done) => {
+    User.deleteMany().exec(() => {
+      Message.deleteMany().exec(done);
+    });
+  });
+});

--- a/modules/admin/tests/server/admin.threads.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.threads.server.routes.tests.js
@@ -55,10 +55,11 @@ describe('Admin Thread CRUD tests', () => {
     await message2.save();
   });
 
-  describe('Read user\'s threads', () => {
-    it('non-authenticated users should not be allowed to read threads', (done) => {
-      agent.post('/api/admin/threads')
-        .send({ 'userId': _users[1]._id })
+  describe("Read user's threads", () => {
+    it('non-authenticated users should not be allowed to read threads', done => {
+      agent
+        .post('/api/admin/threads')
+        .send({ userId: _users[1]._id })
         .expect(403)
         .end((err, res) => {
           res.body.message.should.equal('Forbidden.');
@@ -74,8 +75,9 @@ describe('Admin Thread CRUD tests', () => {
       it('non-admin users should not be allowed to read threads', async () => {
         await utils.signIn(credentialsRegular, agent);
 
-        const { body } = await agent.post('/api/admin/threads')
-          .send({ 'userId': _users[1]._id })
+        const { body } = await agent
+          .post('/api/admin/threads')
+          .send({ userId: _users[1]._id })
           .expect(403);
 
         body.message.should.equal('Forbidden.');
@@ -84,8 +86,9 @@ describe('Admin Thread CRUD tests', () => {
       it('admin users should be allowed to read threads', async () => {
         await utils.signIn(credentialsAdmin, agent);
 
-        const { body } = await agent.post('/api/admin/threads')
-          .send({ 'userId': _users[1]._id })
+        const { body } = await agent
+          .post('/api/admin/threads')
+          .send({ userId: _users[1]._id })
           .expect(200);
 
         // body.length.should.equal(2);

--- a/modules/admin/tests/server/admin.threads.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.threads.server.routes.tests.js
@@ -1,121 +1,64 @@
 const request = require('supertest');
 const path = require('path');
 const mongoose = require('mongoose');
-const Message = mongoose.model('Message');
-const User = mongoose.model('User');
+const Thread = mongoose.model('Thread');
 const express = require(path.resolve('./config/lib/express'));
+const utils = require(path.resolve('./testutils/server/data.server.testutil'));
 require('should');
 
 /**
  * Globals
  */
-let app;
-let agent;
-let credentialsAdmin;
-let credentialsRegular;
-let userAdmin;
-let userRegular1;
-let userRegular2;
 let userRegular1Id;
 let userRegular2Id;
 
-describe('Admin Message CRUD tests', () => {
+describe('Admin Thread CRUD tests', () => {
+  // Get application
+  const app = express.init(mongoose.connection);
+  const agent = request.agent(app);
 
-  before((done) => {
-    // Get application
-    app = express.init(mongoose.connection);
-    agent = request.agent(app);
+  const _users = utils.generateUsers(3);
+  _users[0].roles = ['user', 'admin'];
 
-    done();
-  });
+  const credentialsAdmin = {
+    username: _users[0].username,
+    password: _users[0].password,
+  };
+
+  const credentialsRegular = {
+    username: _users[1].username,
+    password: _users[1].password,
+  };
 
   beforeEach(async () => {
-    try {
-      // Create admin credentials
-      credentialsAdmin = {
-        username: 'user-admin',
-        password: 'Password123!',
-      };
-
-      // Create regular user credentials
-      credentialsRegular = {
-        username: 'user-regular1',
-        password: 'Password123!',
-      };
-
-      // Create a new admin user
-      userAdmin = new User({
-        displayName: 'Admin Name',
-        email: 'admin@example.com',
-        firstName: 'Admin',
-        lastName: 'Name',
-        member: [],
-        provider: 'local',
-        public: true,
-        roles: ['user', 'admin'],
-        ...credentialsAdmin,
-      });
-
-      await userAdmin.save();
-
-      // Create a new regular user
-      userRegular1 = new User({
-        displayName: 'Full Name1',
-        email: 'regular1@example.com',
-        firstName: 'Full',
-        lastName: 'Name2',
-        member: [],
-        provider: 'local',
-        public: true,
-        roles: ['user'],
-        ...credentialsRegular,
-      });
-
-      // Create a new regular user
-      userRegular2 = new User({
-        displayName: 'Full Name2',
-        email: 'regular2@example.com',
-        firstName: 'Full',
-        lastName: 'Name2',
-        member: [],
-        provider: 'local',
-        public: true,
-        roles: ['user'],
-        username: 'user-regular2',
-        password: 'Password123!',
-      });
-
-      const { _id: _userRegular1Id } = await userRegular1.save();
-      const { _id: _userRegular2Id } = await userRegular2.save();
-      userRegular1Id = _userRegular1Id;
-      userRegular2Id = _userRegular2Id;
-
-      const message1 = new Message({
-        content: 'test',
-        notificationCount: 0,
-        userFrom: userRegular1Id,
-        userTo: userRegular2Id,
-      });
-
-      const message2 = new Message({
-        content: 'test',
-        notificationCount: 0,
-        userFrom: userRegular2Id,
-        userTo: userRegular1Id,
-      });
-
-      await message1.save();
-      await message2.save();
-    } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error(err);
-    }
+    await utils.saveUsers(_users);
   });
 
-  describe('Read messages between two users', () => {
-    it('non-authenticated users should not be allowed to read messages', (done) => {
-      agent.post('/api/admin/messages')
-        .send({ 'user1': userRegular1Id, 'user2': userRegular2Id })
+  afterEach(utils.clearDatabase);
+
+  beforeEach(async () => {
+    const message1 = new Thread({
+      content: 'test',
+      notificationCount: 0,
+      userFrom: userRegular1Id,
+      userTo: userRegular2Id,
+    });
+
+    const message2 = new Thread({
+      content: 'test',
+      notificationCount: 0,
+      userFrom: userRegular2Id,
+      userTo: userRegular1Id,
+    });
+
+    await message1.save();
+    await message2.save();
+  });
+
+  describe('Read user\'s threads', () => {
+    it('non-authenticated users should not be allowed to read threads', (done) => {
+      agent.post('/api/admin/threads')
+        .send({ 'userId': _users[1]._id })
         .expect(403)
         .end((err, res) => {
           res.body.message.should.equal('Forbidden.');
@@ -123,51 +66,32 @@ describe('Admin Message CRUD tests', () => {
         });
     });
 
-    it('non-admin users should not be allowed to read messages', (done) => {
-      agent.post('/api/auth/signin')
-        .send(credentialsRegular)
-        .expect(200)
-        .end((signinErr) => {
-          if (signinErr) {
-            return done(signinErr);
-          }
+    describe('As authenticated user...', () => {
+      afterEach(async () => {
+        await utils.signOut(agent);
+      });
 
-          agent.post('/api/admin/messages')
-            .send({ 'user1': userRegular1Id, 'user2': userRegular2Id })
-            .expect(403)
-            .end((err, res) => {
-              res.body.message.should.equal('Forbidden.');
-              return done(err);
-            });
-        });
-    });
+      it('non-admin users should not be allowed to read threads', async () => {
+        await utils.signIn(credentialsRegular, agent);
 
-    it('admin users should be allowed to read messages', (done) => {
-      agent.post('/api/auth/signin')
-        .send(credentialsAdmin)
-        .expect(200)
-        .end((signinErr) => {
-          if (signinErr) {
-            return done(signinErr);
-          }
+        const { body } = await agent.post('/api/admin/threads')
+          .send({ 'userId': _users[1]._id })
+          .expect(403);
 
-          agent.post('/api/admin/messages')
-            .send({ 'user1': userRegular1Id, 'user2': userRegular2Id })
-            .expect(200)
-            .end((err, res) => {
-              res.body.length.should.equal(2);
-              res.body[0].userFrom.username.should.equal('user-regular1');
-              res.body[0].userTo.username.should.equal('user-regular2');
-              return done(err);
-            });
-        });
-    });
+        body.message.should.equal('Forbidden.');
+      });
 
-  });
+      it('admin users should be allowed to read threads', async () => {
+        await utils.signIn(credentialsAdmin, agent);
 
-  afterEach((done) => {
-    User.deleteMany().exec(() => {
-      Message.deleteMany().exec(done);
+        const { body } = await agent.post('/api/admin/threads')
+          .send({ 'userId': _users[1]._id })
+          .expect(200);
+
+        // body.length.should.equal(2);
+        console.log(body); //eslint-disable-line
+        // body[0].userFrom.username.should.equal('user-regular1');
+      });
     });
   });
 });

--- a/modules/admin/tests/server/admin.threads.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.threads.server.routes.tests.js
@@ -92,7 +92,7 @@ describe('Admin Thread CRUD tests', () => {
           .expect(200);
 
         body.length.should.equal(2);
-        body[0].userToProfile[0]._id.should.equal(_usersRaw[2]._id);
+        body[0].userToProfile[0]._id.should.equal(_users[2]._id.toString());
       });
 
       it('admin users should be allowed to read threads by username', async () => {
@@ -104,7 +104,7 @@ describe('Admin Thread CRUD tests', () => {
           .expect(200);
 
         body.length.should.equal(2);
-        body[0].userToProfile[0]._id.should.equal(_usersRaw[1]._id);
+        body[0].userToProfile[0].username.should.equal(_users[2].username);
       });
     });
   });

--- a/modules/admin/tests/server/admin.threads.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.threads.server.routes.tests.js
@@ -6,32 +6,32 @@ const express = require(path.resolve('./config/lib/express'));
 const utils = require(path.resolve('./testutils/server/data.server.testutil'));
 require('should');
 
-/**
- * Globals
- */
-let userRegular1Id;
-let userRegular2Id;
-
 describe('Admin Thread CRUD tests', () => {
   // Get application
   const app = express.init(mongoose.connection);
   const agent = request.agent(app);
 
-  const _users = utils.generateUsers(3);
-  _users[0].roles = ['user', 'admin'];
+  let _users;
+  let userRegular1Id;
+  let userRegular2Id;
+
+  const _usersRaw = utils.generateUsers(3);
+  _usersRaw[0].roles = ['user', 'admin'];
 
   const credentialsAdmin = {
-    username: _users[0].username,
-    password: _users[0].password,
+    username: _usersRaw[0].username,
+    password: _usersRaw[0].password,
   };
 
   const credentialsRegular = {
-    username: _users[1].username,
-    password: _users[1].password,
+    username: _usersRaw[1].username,
+    password: _usersRaw[1].password,
   };
 
   beforeEach(async () => {
-    await utils.saveUsers(_users);
+    _users = await utils.saveUsers(_usersRaw);
+    userRegular1Id = _users[1]._id;
+    userRegular2Id = _users[2]._id;
   });
 
   afterEach(utils.clearDatabase);
@@ -59,7 +59,7 @@ describe('Admin Thread CRUD tests', () => {
     it('non-authenticated users should not be allowed to read threads', done => {
       agent
         .post('/api/admin/threads')
-        .send({ userId: _users[1]._id })
+        .send({ userId: userRegular1Id })
         .expect(403)
         .end((err, res) => {
           res.body.message.should.equal('Forbidden.');
@@ -77,7 +77,7 @@ describe('Admin Thread CRUD tests', () => {
 
         const { body } = await agent
           .post('/api/admin/threads')
-          .send({ userId: _users[1]._id })
+          .send({ userId: userRegular1Id })
           .expect(403);
 
         body.message.should.equal('Forbidden.');
@@ -88,12 +88,10 @@ describe('Admin Thread CRUD tests', () => {
 
         const { body } = await agent
           .post('/api/admin/threads')
-          .send({ userId: _users[1]._id })
+          .send({ userId: userRegular1Id })
           .expect(200);
 
-        // body.length.should.equal(2);
-        console.log(body); //eslint-disable-line
-        // body[0].userFrom.username.should.equal('user-regular1');
+        body.length.should.equal(2);
       });
     });
   });

--- a/modules/admin/tests/server/admin.threads.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.threads.server.routes.tests.js
@@ -92,7 +92,10 @@ describe('Admin Thread CRUD tests', () => {
           .expect(200);
 
         body.length.should.equal(2);
-        body[0].userToProfile[0]._id.should.equal(_users[2]._id.toString());
+        body[0].userToProfile[0]._id.should.equalOneOf([
+          _users[1]._id.toString(),
+          _users[2]._id.toString(),
+        ]);
       });
 
       it('admin users should be allowed to read threads by username', async () => {
@@ -104,7 +107,10 @@ describe('Admin Thread CRUD tests', () => {
           .expect(200);
 
         body.length.should.equal(2);
-        body[0].userToProfile[0].username.should.equal(_users[2].username);
+        body[0].userToProfile[0].username.should.equalOneOf([
+          _users[1].username,
+          _users[2].username,
+        ]);
       });
     });
   });

--- a/modules/admin/tests/server/admin.threads.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.threads.server.routes.tests.js
@@ -83,7 +83,7 @@ describe('Admin Thread CRUD tests', () => {
         body.message.should.equal('Forbidden.');
       });
 
-      it('admin users should be allowed to read threads', async () => {
+      it('admin users should be allowed to read threads by user ID', async () => {
         await utils.signIn(credentialsAdmin, agent);
 
         const { body } = await agent
@@ -92,6 +92,19 @@ describe('Admin Thread CRUD tests', () => {
           .expect(200);
 
         body.length.should.equal(2);
+        body[0].userToProfile[0]._id.should.equal(_usersRaw[2]._id);
+      });
+
+      it('admin users should be allowed to read threads by username', async () => {
+        await utils.signIn(credentialsAdmin, agent);
+
+        const { body } = await agent
+          .post('/api/admin/threads')
+          .send({ username: _usersRaw[1].username })
+          .expect(200);
+
+        body.length.should.equal(2);
+        body[0].userToProfile[0]._id.should.equal(_usersRaw[1]._id);
       });
     });
   });


### PR DESCRIPTION
#### Proposed Changes

* Add "threads" admin security tool

#### Testing Instructions
* With user with `admin` role...
* Open `/admin/threads` with admin user
* Try searching by user ID and username
* No handling erroneous usernames for now but 🤷‍♂ 
* You should be able to click on "read thread" to get to `/admin/messages` with prefilled IDs
