### PR TITLE
Admin search: add date to listing

### DIFF
--- a/modules/admin/client/components/AdminSearchUsers.component.js
+++ b/modules/admin/client/components/AdminSearchUsers.component.js
@@ -138,6 +138,7 @@ export default class AdminSearchUsers extends Component {
                       <th>Name</th>
                       <th>Username</th>
                       <th>Email</th>
+                      <th>Signed up</th>
                       <th>ID</th>
                     </tr>
                   </thead>
@@ -145,6 +146,7 @@ export default class AdminSearchUsers extends Component {
                     {userResults.map(user => {
                       const {
                         _id,
+                        created,
                         displayName,
                         email,
                         emailTemporary,
@@ -193,6 +195,13 @@ export default class AdminSearchUsers extends Component {
                                 />
                               </>
                             )}
+                          </td>
+                          <td>
+                            {new Date(created).toLocaleDateString('en-US', {
+                              year: 'numeric',
+                              month: 'short',
+                              day: 'numeric',
+                            })}
                           </td>
                           <td>
                             <small>

--- a/modules/admin/server/controllers/admin.users.server.controller.js
+++ b/modules/admin/server/controllers/admin.users.server.controller.js
@@ -23,6 +23,7 @@ const SEARCH_STRING_LIMIT = 3;
 // Everything that's needed for `AdminSearchUsers.component.js` and `UserState.component.js`
 const USER_LIST_FIELDS = [
   '_id',
+  'created',
   'displayName',
   'email',
   'emailTemporary',

--- a/modules/admin/tests/server/admin.users.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.users.server.routes.tests.js
@@ -63,6 +63,7 @@ describe('Admin User CRUD tests', () => {
         removeProfileToken: 'test-token',
         resetPasswordToken: 'test-token',
         roles: ['user'],
+        created: new Date(),
         ...credentialsRegular,
       });
 
@@ -139,6 +140,8 @@ describe('Admin User CRUD tests', () => {
 
         should(body.length).equal(2);
 
+        should(body[0].created).should.exist();
+        should(body[1].created).should.exist();
         should(body[0].username).equal('user-admin');
         should(body[1].username).equal('user-regular');
 

--- a/modules/admin/tests/server/admin.users.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.users.server.routes.tests.js
@@ -140,8 +140,8 @@ describe('Admin User CRUD tests', () => {
 
         should(body.length).equal(2);
 
-        should(body[0].created).should.exist();
-        should(body[1].created).should.exist();
+        should.exist(body[0].created);
+        should.exist(body[1].created);
         should(body[0].username).equal('user-admin');
         should(body[1].username).equal('user-regular');
 


### PR DESCRIPTION
#### Proposed Changes

* Adds date to admin search tool results:

![image](https://user-images.githubusercontent.com/87168/76907930-27d49f00-68b0-11ea-80f2-5a649b9bf246.png)


#### Testing Instructions

- Open `/admin`
- Go to search and look up something
- Observe results having date

Fixes https://github.com/Trustroots/trustroots/issues/1308
