### PR TITLE
Map: add style control

### DIFF
--- a/config/env/local.sample.js
+++ b/config/env/local.sample.js
@@ -89,7 +89,8 @@ module.exports = {
       }
     },
     user: 'trustroots',
-    publicKey: 'pk.eyJ1IjoidHJ1c3Ryb290cyIsImEiOiJVWFFGa19BIn0.4e59q4-7e8yvgvcd1jzF4g'
+    publicKey:
+      'pk.eyJ1IjoidHJ1c3Ryb290cyIsImEiOiJjanhydWF3bDkwYnd0M2JtanB2amg1NWVpIn0.a8XP1jMeVFBsScDI3oV1BA',
   }
   */
   /*

--- a/modules/core/client/components/Map/MapIcon.js
+++ b/modules/core/client/components/Map/MapIcon.js
@@ -1,0 +1,34 @@
+// External dependencies
+import PropTypes from 'prop-types';
+import React from 'react';
+
+/**
+ * Map icon
+ * @link https://docs.mapbox.com/playground/static/
+ * @link https://docs.mapbox.com/api/maps/#static-images
+ */
+export default function MapIcon({ mapboxStyle, mapboxToken }) {
+  const image =
+    mapboxStyle && mapboxToken
+      ? `https://api.mapbox.com/styles/v1/mapbox/${mapboxStyle
+          .split('/')
+          .pop()}/static/14.1663,55.6438,5.22,0/128x128@2x?attribution=false&access_token=${mapboxToken}`
+      : // Default image when API isn't available
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNc8mTSfwAHaQMbL4UQfQAAAABJRU5ErkJggg==';
+
+  return (
+    <img
+      className="img-circle"
+      alt=""
+      aria-hidden="true"
+      width="24"
+      height="24"
+      src={image}
+    />
+  );
+}
+
+MapIcon.propTypes = {
+  mapboxStyle: PropTypes.string,
+  mapboxToken: PropTypes.string,
+};

--- a/modules/core/client/components/Map/MapStyleControl.js
+++ b/modules/core/client/components/Map/MapStyleControl.js
@@ -1,0 +1,74 @@
+// External dependencies
+import { useTranslation } from 'react-i18next';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+// Internal dependencies
+import {
+  MAPBOX_TOKEN,
+  MAP_STYLE_MAPBOX_STREETS,
+  MAP_STYLE_MAPBOX_SATELLITE,
+  MAP_STYLE_MAPBOX_OUTDOORS,
+  MAP_STYLE_OSM,
+} from './constants';
+
+/**
+ * The main LanguageSwitch component.
+ * @param {'dropdown'|'select'} presentation - should we show dropdown (header), or select (account) selector?
+ * @param {Boolean} [saveToAPI=false] - should we save selected language to API?
+ */
+export default function MapStyleControl({ mapStyle, setMapstyle }) {
+  const { t } = useTranslation('core');
+
+  return (
+    <div
+      className="btn-group-vertical btn-group-xs"
+      role="group"
+      aria-label={t('Map style')}
+    >
+      <button
+        className={classnames('btn btn-default', {
+          'btn-primary': mapStyle === MAP_STYLE_MAPBOX_STREETS,
+        })}
+        disabled={!MAPBOX_TOKEN}
+        onClick={() => setMapstyle(MAP_STYLE_MAPBOX_STREETS)}
+      >
+        {t('Streets')}
+      </button>
+      <button
+        className={classnames('btn btn-default', {
+          'btn-primary': mapStyle === MAP_STYLE_MAPBOX_SATELLITE,
+        })}
+        disabled={!MAPBOX_TOKEN}
+        onClick={() => setMapstyle(MAP_STYLE_MAPBOX_SATELLITE)}
+      >
+        {t('Satellite')}
+      </button>
+      <button
+        className={classnames('btn btn-default', {
+          'btn-primary': mapStyle === MAP_STYLE_MAPBOX_OUTDOORS,
+        })}
+        disabled={!MAPBOX_TOKEN}
+        onClick={() => setMapstyle(MAP_STYLE_MAPBOX_OUTDOORS)}
+      >
+        {t('Outdoors')}
+      </button>
+      {process.env.NODE_ENV !== 'production' && (
+        <button
+          className={classnames('btn btn-default', {
+            'btn-primary': mapStyle === MAP_STYLE_OSM,
+          })}
+          onClick={() => setMapstyle(MAP_STYLE_OSM)}
+        >
+          OSM
+        </button>
+      )}
+    </div>
+  );
+}
+
+MapStyleControl.propTypes = {
+  mapStyle: PropTypes.string.isRequired,
+  setMapstyle: PropTypes.func.isRequired,
+};

--- a/modules/core/client/components/Map/MapStyleControl.js
+++ b/modules/core/client/components/Map/MapStyleControl.js
@@ -1,70 +1,76 @@
 // External dependencies
 import { useTranslation } from 'react-i18next';
-import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { DropdownButton, MenuItem, ButtonGroup } from 'react-bootstrap';
 
 // Internal dependencies
 import {
-  MAPBOX_TOKEN,
+  getMapboxToken,
   MAP_STYLE_MAPBOX_STREETS,
   MAP_STYLE_MAPBOX_SATELLITE,
   MAP_STYLE_MAPBOX_OUTDOORS,
   MAP_STYLE_OSM,
 } from './constants';
+import MapIcon from './MapIcon';
 
-/**
- * The main LanguageSwitch component.
- * @param {'dropdown'|'select'} presentation - should we show dropdown (header), or select (account) selector?
- * @param {Boolean} [saveToAPI=false] - should we save selected language to API?
- */
 export default function MapStyleControl({ mapStyle, setMapstyle }) {
   const { t } = useTranslation('core');
+  const mapboxToken = getMapboxToken();
+
+  const mapboxStyleNames = {};
+  mapboxStyleNames[MAP_STYLE_MAPBOX_STREETS] = t('Streets');
+  mapboxStyleNames[MAP_STYLE_MAPBOX_SATELLITE] = t('Satellite');
+  mapboxStyleNames[MAP_STYLE_MAPBOX_OUTDOORS] = t('Outdoors');
+
+  // If it's an object, it'll have a name. Otherwise it's Mapbox URL in string presentation.
+  const selectedStyle = mapStyle?.name || mapStyle;
 
   return (
-    <div
-      className="btn-group-vertical btn-group-xs"
-      role="group"
-      aria-label={t('Map style')}
-    >
-      <button
-        className={classnames('btn btn-default', {
-          'btn-primary': mapStyle === MAP_STYLE_MAPBOX_STREETS,
-        })}
-        disabled={!MAPBOX_TOKEN}
-        onClick={() => setMapstyle(MAP_STYLE_MAPBOX_STREETS)}
+    <ButtonGroup aria-label={t('Map style')}>
+      <DropdownButton
+        dropup
+        noCaret
+        title={
+          <>
+            <MapIcon
+              mapboxStyle={
+                selectedStyle !== MAP_STYLE_OSM.name ? selectedStyle : false
+              }
+              mapboxToken={mapboxToken}
+            />
+            {mapStyle?.name || mapboxStyleNames[mapStyle]}
+          </>
+        }
+        id="map-style-picker"
       >
-        {t('Streets')}
-      </button>
-      <button
-        className={classnames('btn btn-default', {
-          'btn-primary': mapStyle === MAP_STYLE_MAPBOX_SATELLITE,
-        })}
-        disabled={!MAPBOX_TOKEN}
-        onClick={() => setMapstyle(MAP_STYLE_MAPBOX_SATELLITE)}
-      >
-        {t('Satellite')}
-      </button>
-      <button
-        className={classnames('btn btn-default', {
-          'btn-primary': mapStyle === MAP_STYLE_MAPBOX_OUTDOORS,
-        })}
-        disabled={!MAPBOX_TOKEN}
-        onClick={() => setMapstyle(MAP_STYLE_MAPBOX_OUTDOORS)}
-      >
-        {t('Outdoors')}
-      </button>
-      {process.env.NODE_ENV !== 'production' && (
-        <button
-          className={classnames('btn btn-default', {
-            'btn-primary': mapStyle === MAP_STYLE_OSM,
-          })}
-          onClick={() => setMapstyle(MAP_STYLE_OSM)}
-        >
-          OSM
-        </button>
-      )}
-    </div>
+        {[
+          MAP_STYLE_MAPBOX_STREETS,
+          MAP_STYLE_MAPBOX_SATELLITE,
+          MAP_STYLE_MAPBOX_OUTDOORS,
+        ].map(mapboxStyle => (
+          <MenuItem
+            active={selectedStyle === mapboxStyle}
+            disabled={!mapboxToken}
+            key={mapboxStyle}
+            onClick={() => setMapstyle(mapboxStyle)}
+          >
+            <MapIcon mapboxStyle={mapboxStyle} mapboxToken={mapboxToken} />
+            {mapboxStyleNames[mapboxStyle]}
+          </MenuItem>
+        ))}
+        {process.env.NODE_ENV !== 'production' && (
+          <MenuItem
+            active={selectedStyle === MAP_STYLE_OSM.name}
+            key={MAP_STYLE_OSM.name}
+            onClick={() => setMapstyle(MAP_STYLE_OSM)}
+          >
+            <MapIcon />
+            {MAP_STYLE_OSM.name}
+          </MenuItem>
+        )}
+      </DropdownButton>
+    </ButtonGroup>
   );
 }
 

--- a/modules/core/client/components/Map/constants.js
+++ b/modules/core/client/components/Map/constants.js
@@ -1,0 +1,11 @@
+import osmStyle from './osm.json';
+
+export const MAPBOX_TOKEN = window.settings?.mapbox?.publicKey;
+export const MAP_STYLE_MAPBOX_OUTDOORS = 'mapbox://styles/mapbox/outdoors-v11';
+export const MAP_STYLE_MAPBOX_SATELLITE =
+  'mapbox://styles/mapbox/satellite-streets-v11';
+export const MAP_STYLE_MAPBOX_STREETS = 'mapbox://styles/mapbox/streets-v11';
+export const MAP_STYLE_OSM = osmStyle;
+export const MAP_STYLE_DEFAULT = MAPBOX_TOKEN
+  ? MAP_STYLE_MAPBOX_STREETS
+  : MAP_STYLE_OSM;

--- a/modules/core/client/components/Map/constants.js
+++ b/modules/core/client/components/Map/constants.js
@@ -1,11 +1,12 @@
 import osmStyle from './osm.json';
 
-export const MAPBOX_TOKEN = window.settings?.mapbox?.publicKey;
+export const getMapboxToken = () => window.settings?.mapbox?.publicKey;
+
 export const MAP_STYLE_MAPBOX_OUTDOORS = 'mapbox://styles/mapbox/outdoors-v11';
 export const MAP_STYLE_MAPBOX_SATELLITE =
   'mapbox://styles/mapbox/satellite-streets-v11';
 export const MAP_STYLE_MAPBOX_STREETS = 'mapbox://styles/mapbox/streets-v11';
 export const MAP_STYLE_OSM = osmStyle;
-export const MAP_STYLE_DEFAULT = MAPBOX_TOKEN
+export const MAP_STYLE_DEFAULT = getMapboxToken()
   ? MAP_STYLE_MAPBOX_STREETS
   : MAP_STYLE_OSM;

--- a/modules/core/client/components/Map/index.js
+++ b/modules/core/client/components/Map/index.js
@@ -5,16 +5,14 @@ import React, { useState } from 'react';
 import ReactMapGL, { NavigationControl, ScaleControl } from 'react-map-gl';
 
 // Internal dependencies
-import osmStyle from './osm.json';
+import MapStyleControl from './MapStyleControl';
 import '@/modules/core/client/components/Map/map.less';
+import { MAPBOX_TOKEN, MAP_STYLE_DEFAULT } from './constants';
 
 export default function Map(props) {
-  const MAPBOX_TOKEN = window.settings?.mapbox?.publicKey;
-  const MAP_STYLE_MAPBOX_STREETS = 'mapbox://styles/mapbox/streets-v11';
-  const MAP_STYLE_OSM = osmStyle;
-  const MAP_STYLE_DEFAULT = MAPBOX_TOKEN
-    ? MAP_STYLE_MAPBOX_STREETS
-    : MAP_STYLE_OSM;
+  const showMapStyles =
+    props.showMapStyles &&
+    (!!MAPBOX_TOKEN || process.env.NODE_ENV !== 'production');
 
   const {
     children,
@@ -24,6 +22,9 @@ export default function Map(props) {
   } = props;
 
   const { t } = useTranslation('core');
+
+  // Set default map style here
+  const [mapStyle, setMapstyle] = useState(MAP_STYLE_DEFAULT);
 
   const [viewport, setViewport] = useState({
     latitude: location[0],
@@ -36,7 +37,7 @@ export default function Map(props) {
       dragRotate={false}
       height={320}
       mapboxApiAccessToken={MAPBOX_TOKEN}
-      mapStyle={MAP_STYLE_DEFAULT}
+      mapStyle={mapStyle}
       onViewportChange={setViewport}
       touchRotate={false}
       {...viewport}
@@ -55,6 +56,11 @@ export default function Map(props) {
       <div className="map-scale-control-container">
         <ScaleControl />
       </div>
+      {showMapStyles && (
+        <div className="map-style-control-container">
+          <MapStyleControl mapStyle={mapStyle} setMapstyle={setMapstyle} />
+        </div>
+      )}
       {children}
     </ReactMapGL>
   );
@@ -63,5 +69,6 @@ export default function Map(props) {
 Map.propTypes = {
   children: PropTypes.node,
   location: PropTypes.arrayOf(PropTypes.number),
+  showMapStyles: PropTypes.bool,
   zoom: PropTypes.number,
 };

--- a/modules/core/client/components/Map/index.js
+++ b/modules/core/client/components/Map/index.js
@@ -7,12 +7,18 @@ import ReactMapGL, { NavigationControl, ScaleControl } from 'react-map-gl';
 // Internal dependencies
 import MapStyleControl from './MapStyleControl';
 import '@/modules/core/client/components/Map/map.less';
-import { MAPBOX_TOKEN, MAP_STYLE_DEFAULT } from './constants';
+import {
+  getMapboxToken,
+  MAP_STYLE_MAPBOX_STREETS,
+  MAP_STYLE_OSM,
+} from './constants';
 
 export default function Map(props) {
+  const mapboxToken = getMapboxToken();
+  const defaultStyle = mapboxToken ? MAP_STYLE_MAPBOX_STREETS : MAP_STYLE_OSM;
   const showMapStyles =
     props.showMapStyles &&
-    (!!MAPBOX_TOKEN || process.env.NODE_ENV !== 'production');
+    (!!mapboxToken || process.env.NODE_ENV !== 'production');
 
   const {
     children,
@@ -23,9 +29,7 @@ export default function Map(props) {
 
   const { t } = useTranslation('core');
 
-  // Set default map style here
-  const [mapStyle, setMapstyle] = useState(MAP_STYLE_DEFAULT);
-
+  const [mapStyle, setMapstyle] = useState(defaultStyle);
   const [viewport, setViewport] = useState({
     latitude: location[0],
     longitude: location[1],
@@ -36,7 +40,7 @@ export default function Map(props) {
     <ReactMapGL
       dragRotate={false}
       height={320}
-      mapboxApiAccessToken={MAPBOX_TOKEN}
+      mapboxApiAccessToken={mapboxToken}
       mapStyle={mapStyle}
       onViewportChange={setViewport}
       touchRotate={false}

--- a/modules/core/client/components/Map/map.less
+++ b/modules/core/client/components/Map/map.less
@@ -50,3 +50,10 @@
     color: @gray;
   }
 }
+
+.map-style-control-container {
+  left: 10px;
+  position: absolute;
+  top: 10px;
+  z-index: 5;
+}

--- a/modules/core/client/components/Map/map.less
+++ b/modules/core/client/components/Map/map.less
@@ -54,6 +54,24 @@
 .map-style-control-container {
   left: 10px;
   position: absolute;
-  top: 10px;
+  bottom: 40px;
   z-index: 5;
+  box-shadow: @map-toolbar-shadow;
+  .btn {
+    color: @text-color;
+    background: @map-toolbar-background;
+    transition: background 0.25s;
+
+    &:hover {
+      color: @text-color;
+      background: @map-toolbar-background-hover;
+    }
+  }
+  .btn img,
+  .dropdown-menu > li > a > img {
+    margin-right: 5px;
+  }
+  .dropdown-menu > li > a {
+    padding-left: 10px;
+  }
 }

--- a/modules/core/client/components/Map/osm.json
+++ b/modules/core/client/components/Map/osm.json
@@ -1,6 +1,6 @@
 {
   "version": 8,
-  "name": "OpenStreetMap",
+  "name": "OSM",
   "metadata": {},
   "sources": {
     "osm": {

--- a/modules/offers/client/components/OfferLocation.component.js
+++ b/modules/offers/client/components/OfferLocation.component.js
@@ -6,12 +6,7 @@ import React from 'react';
 import Map from '@/modules/core/client/components/Map/index';
 import OfferLocationOverlay from './OfferLocationOverlay';
 
-export default function OfferLocation({
-  location,
-  offerStatus,
-  offerType,
-  showMapStyles,
-}) {
+export default function OfferLocation({ location, offerStatus, offerType }) {
   if (!location || location.length !== 2) {
     return null;
   }
@@ -23,7 +18,6 @@ export default function OfferLocation({
       height={320}
       location={location}
       scrollZoom={false}
-      showMapStyles={showMapStyles}
       width="100%"
       zoom={11}
     >
@@ -40,5 +34,4 @@ OfferLocation.propTypes = {
   location: PropTypes.arrayOf(PropTypes.number).isRequired,
   offerStatus: PropTypes.string,
   offerType: PropTypes.string,
-  showMapStyles: PropTypes.bool,
 };

--- a/modules/offers/client/components/OfferLocation.component.js
+++ b/modules/offers/client/components/OfferLocation.component.js
@@ -6,7 +6,12 @@ import React from 'react';
 import Map from '@/modules/core/client/components/Map/index';
 import OfferLocationOverlay from './OfferLocationOverlay';
 
-export default function OfferLocation({ location, offerType, offerStatus }) {
+export default function OfferLocation({
+  location,
+  offerStatus,
+  offerType,
+  showMapStyles,
+}) {
   if (!location || location.length !== 2) {
     return null;
   }
@@ -17,9 +22,10 @@ export default function OfferLocation({ location, offerType, offerStatus }) {
       className="offer-location"
       height={320}
       location={location}
+      scrollZoom={false}
+      showMapStyles={showMapStyles}
       width="100%"
       zoom={11}
-      scrollZoom={false}
     >
       <OfferLocationOverlay
         location={location}
@@ -32,6 +38,7 @@ export default function OfferLocation({ location, offerType, offerStatus }) {
 
 OfferLocation.propTypes = {
   location: PropTypes.arrayOf(PropTypes.number).isRequired,
-  offerType: PropTypes.string,
   offerStatus: PropTypes.string,
+  offerType: PropTypes.string,
+  showMapStyles: PropTypes.bool,
 };

--- a/modules/offers/client/views/offer-meet-list.client.view.html
+++ b/modules/offers/client/views/offer-meet-list.client.view.html
@@ -46,9 +46,11 @@
   >
     <div class="panel-body">
       <!-- The map (React component) -->
+      <!-- showMapStyles prop should be boolean, and the !!offer thing is just Angular.js hack to get it be boolean -->
       <offer-location
         location="offer.location"
         offerType="offer.type"
+        showMapStyles="!!offer"
       ></offer-location>
 
       <br /><br />

--- a/modules/offers/client/views/offer-meet-list.client.view.html
+++ b/modules/offers/client/views/offer-meet-list.client.view.html
@@ -46,11 +46,9 @@
   >
     <div class="panel-body">
       <!-- The map (React component) -->
-      <!-- showMapStyles prop should be boolean, and the !!offer thing is just Angular.js hack to get it be boolean -->
       <offer-location
         location="offer.location"
         offerType="offer.type"
-        showMapStyles="!!offer"
       ></offer-location>
 
       <br /><br />


### PR DESCRIPTION
#### Proposed Changes

* Add a control to change between satellite/streets map layers in base `Map` component

<img width="385" alt="Screenshot 2020-04-12 at 22 51 30" src="https://user-images.githubusercontent.com/87168/79078884-23b36a00-7d14-11ea-8311-829eb0838173.png">
<img width="423" alt="Screenshot 2020-04-12 at 22 51 26" src="https://user-images.githubusercontent.com/87168/79078886-2746f100-7d14-11ea-8599-83aaa1cde62f.png">
<img width="420" alt="Screenshot 2020-04-12 at 22 51 21" src="https://user-images.githubusercontent.com/87168/79078887-2746f100-7d14-11ea-8888-f9c6581c5f6e.png">


#### Testing Instructions

* Add `showMapStyles={true}` prop in `modules/offers/client/components/OfferLocation.component.js` to test it.
* Otherwise the component isn't in use visibly anywhere
* This component will be useful for the main map canvas and I just wanted to Pr this separately to keep migration more focused.