### PR TITLE
Add img-src blob: to CSP policy for mapbox-gl

### DIFF
--- a/config/lib/express.js
+++ b/config/lib/express.js
@@ -363,7 +363,8 @@ module.exports.initHelmetHeaders = function(app) {
           'i1.wp.com', // Gravatar (WordPress.com)
           'i2.wp.com', // Gravatar (WordPress.com)
           'ucarecdn.com', // Our Tribe image CDN "Uploadcare.com"
-          'data:', // Inline images (`<img src="data:...">`)
+          'data:', // Inline images (`<img src="data:...">`) + mapbox-gl
+          'blob:', // mapbox-gl https://docs.mapbox.com/mapbox-gl-js/overview/#csp-directives
         ],
 
         // Limits the origins that you can connect to


### PR DESCRIPTION
See https://docs.mapbox.com/mapbox-gl-js/overview/#csp-directives

#### Proposed Changes

* I noticed CSP errors on localhost and dev2.trustroots.org for img-src blob: and found out it was mapbox-gl that wants it.

![csperrorlocal](https://user-images.githubusercontent.com/31616/78408981-cbd87d00-7608-11ea-98a0-bc2325c2a8d4.png)
![csperrors](https://user-images.githubusercontent.com/31616/78408982-cd09aa00-7608-11ea-97ad-64544e5b1387.png)

![reactmapglblobs](https://user-images.githubusercontent.com/31616/78408996-d561e500-7608-11ea-88fe-b1c26b8ca631.png)

^ shows it loading a blob on the react mapbox gl example page

#### Testing Instructions

* checkout the branch
* `npm install && npm start`
* make sure there are no CSP errors on mapbox pages (e.g. `/offer/meet` when you have at least one meet showing up)

Fixes #
