### PR TITLE
Refactor Navigation component

### DIFF
--- a/modules/core/client/components/Navigation.js
+++ b/modules/core/client/components/Navigation.js
@@ -49,7 +49,7 @@ export default function Navigation({
       onClick={onSubmit}
       disabled={tabDone < tabs - 1 || disabled}
     >
-      {t('Submit')}
+      {t('Finish')}
     </button>
   );
 

--- a/modules/core/client/components/Navigation.js
+++ b/modules/core/client/components/Navigation.js
@@ -1,6 +1,75 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
+import classnames from 'classnames';
+
+const BackButton = ({ small, ...props }) => {
+  const { t } = useTranslation('core');
+  return (
+    <button
+      type="button"
+      className={classnames({
+        btn: true,
+        'btn-lg': small,
+        'btn-primary': small,
+        'btn-action': !small,
+        'btn-link': !small,
+      })}
+      aria-label={t('Previous section')}
+      {...props}
+    >
+      <span className="icon-left" aria-hidden="true"></span>
+      {t('Back')}
+    </button>
+  );
+};
+BackButton.propTypes = { small: PropTypes.bool };
+
+const NextButton = ({ small, ...props }) => {
+  const { t } = useTranslation('core');
+
+  return (
+    <button
+      type="button"
+      className={classnames({
+        btn: true,
+        'btn-lg': small,
+        'btn-action': !small,
+        'btn-primary': true,
+      })}
+      aria-label={t('Next section')}
+      uib-tooltip="Write longer description first"
+      tooltip-enable="offerHostEdit.isDescriptionTooShort && offerHostEdit.offerTab === 1"
+      ng-disabled="offerHostEdit.isDescriptionTooShort && offerHostEdit.offerTab === 1"
+      {...props}
+    >
+      {t('Next')}
+      {small && <span className="icon-right" aria-hidden="true"></span>}
+    </button>
+  );
+};
+NextButton.propTypes = { small: PropTypes.bool };
+
+const SubmitButton = ({ small, ...props }) => {
+  const { t } = useTranslation('core');
+  return (
+    <button
+      type="submit"
+      className={classnames({
+        btn: true,
+        'btn-lg': small,
+        'btn-action': !small,
+        'btn-primary': true,
+      })}
+      aria-label={t('Finish editing and save')}
+      {...props}
+    >
+      {t('Finish')}
+      {small && <span className="icon-ok" aria-hidden="true"></span>}
+    </button>
+  );
+};
+SubmitButton.propTypes = { small: PropTypes.bool };
 
 /**
  * Navigation is a react component.
@@ -16,53 +85,59 @@ export default function Navigation({
   onNext,
   onSubmit,
 }) {
-  const { t } = useTranslation('reference');
+  const backButtonProps = {
+    onClick: onBack,
+  };
 
-  const backButton = (
-    <button
-      type="button"
-      className="btn btn-action btn-link"
-      aria-label="Previous section"
-      onClick={onBack}
-    >
-      <span className="icon-left"></span>
-      {t('Back')}
-    </button>
-  );
+  const nextButtonProps = {
+    onClick: onNext,
+    disabled: tabDone < tab,
+  };
 
-  const nextButton = (
-    <button
-      type="button"
-      className="btn btn-action btn-primary"
-      aria-label="Next section"
-      onClick={onNext}
-      disabled={tabDone < tab}
-    >
-      {t('Next')}
-    </button>
-  );
-
-  const submitButton = (
-    <button
-      className="btn btn-action btn-primary"
-      aria-label="Submit reference"
-      onClick={onSubmit}
-      disabled={tabDone < tabs - 1 || disabled}
-    >
-      {t('Finish')}
-    </button>
-  );
+  const submitButtonProps = {
+    onClick: onSubmit,
+    disabled: tabDone < tabs - 1 || disabled,
+  };
 
   const showBackButton = tab > 0; // not the first tab
   const showNextButton = tab < tabs - 1; // not the last tab
   const showSubmitButton = tab === tabs - 1; // the last tab
 
   return (
-    <div className="text-center">
-      {showBackButton && backButton}
-      {showNextButton && nextButton}
-      {showSubmitButton && submitButton}
-    </div>
+    <>
+      <div className="text-center hidden-xs">
+        {showBackButton && <BackButton {...backButtonProps} />}
+        {showNextButton && <NextButton {...nextButtonProps} />}
+        {showSubmitButton && <SubmitButton {...submitButtonProps} />}
+      </div>
+      <nav className="navbar navbar-default navbar-fixed-bottom visible-xs-block">
+        <div className="container">
+          <ul
+            className="nav navbar-nav nav-justified"
+            role="toolbar"
+            aria-label="Offer actions"
+          >
+            <li></li>
+            <li className="pull-right">{/* <!-- For last tab --> */}</li>
+            {showBackButton && (
+              <li>
+                <BackButton small {...backButtonProps} />
+              </li>
+            )}
+            {showNextButton && (
+              <li className="pull-right">
+                <NextButton small {...nextButtonProps} />
+              </li>
+            )}
+            {showSubmitButton && (
+              <li className="pull-right">
+                <SubmitButton small {...submitButtonProps} />
+              </li>
+            )}
+          </ul>
+        </div>
+      </nav>
+    </>
   );
 }
 

--- a/modules/core/client/components/StepNavigation.js
+++ b/modules/core/client/components/StepNavigation.js
@@ -71,11 +71,11 @@ const SubmitButton = ({ small, ...props }) => {
 SubmitButton.propTypes = { small: PropTypes.bool };
 
 /**
- * Navigation is a react component.
+ * StepNavigation is a react component.
  * It can contain three different buttons: Back, Next, Submit.
  * Each of them has a related property onBack, onNext, onSubmit
  */
-export default function Navigation({
+export default function StepNavigation({
   disabled,
   tab,
   tabs,
@@ -84,10 +84,14 @@ export default function Navigation({
   onNext,
   onSubmit,
 }) {
-  const errorTab = errors.findIndex(errors_ => errors_.length > 0);
+  const errorTab = errors.findIndex(tabErrors => tabErrors.length > 0);
   const tabDone = errorTab === -1 ? tabs : errorTab - 1;
-  // get the lowest error valid for the current tab
-  const error = errors.slice(0, tab + 1).flat()[0] ?? '';
+  // get the lowest non-empty error valid for the current tab
+  const error =
+    errors
+      .slice(0, tab + 1)
+      .flat()
+      .find(error => error.length > 0) ?? '';
 
   /**
    * We'll reuse the buttons and tooltip defined below
@@ -160,7 +164,7 @@ export default function Navigation({
   );
 }
 
-Navigation.propTypes = {
+StepNavigation.propTypes = {
   onBack: PropTypes.func.isRequired,
   onNext: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,

--- a/modules/core/client/components/StepNavigation.js
+++ b/modules/core/client/components/StepNavigation.js
@@ -1,4 +1,4 @@
-import React, { cloneElement } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 import classnames from 'classnames';
@@ -101,19 +101,15 @@ export default function StepNavigation({
    * We use React.cloneElement(element, props, children) for that purpose:
    * https://reactjs.org/docs/react-api.html#cloneelement
    */
-  const backButton = <BackButton onClick={onBack} />;
-  const nextButton = <NextButton onClick={onNext} disabled={disabled} />;
-  const submitButton = <SubmitButton onClick={onSubmit} disabled={disabled} />;
-  const tooltip = (
-    <Tooltip
-      tooltip={disabledReason}
-      id="tooltip-disabled-button"
-      hidden={!(disabled && disabledReason)}
-      placement="top"
-    >
-      placeholder
-    </Tooltip>
-  );
+  const backProps = { onClick: onBack };
+  const nextProps = { onClick: onNext, disabled: disabled };
+  const submitProps = { onClick: onSubmit, disabled: disabled };
+  const tooltipProps = {
+    tooltip: disabledReason,
+    id: 'tooltip-disabled-button',
+    hidden: !(disabled && disabledReason),
+    placement: 'top',
+  };
 
   const showBackButton = currentStep > 0; // not the first step
   const showNextButton = currentStep < numberOfSteps - 1; // not the last step
@@ -122,9 +118,17 @@ export default function StepNavigation({
   return (
     <>
       <div className="text-center hidden-xs">
-        {showBackButton && backButton}
-        {showNextButton && cloneElement(tooltip, null, nextButton)}
-        {showSubmitButton && cloneElement(tooltip, null, submitButton)}
+        {showBackButton && <BackButton {...backProps} />}
+        {showNextButton && (
+          <Tooltip {...tooltipProps}>
+            <NextButton {...nextProps} />
+          </Tooltip>
+        )}
+        {showSubmitButton && (
+          <Tooltip {...tooltipProps}>
+            <SubmitButton {...submitProps} />
+          </Tooltip>
+        )}
       </div>
       <nav className="navbar navbar-default navbar-fixed-bottom visible-xs-block">
         <div className="container">
@@ -134,24 +138,22 @@ export default function StepNavigation({
             aria-label="Offer actions"
           >
             {showBackButton && (
-              <li>{cloneElement(backButton, { small: true })}</li>
+              <li>
+                <BackButton {...backProps} small />
+              </li>
             )}
             {showNextButton && (
               <li className="pull-right">
-                {cloneElement(
-                  tooltip,
-                  null,
-                  cloneElement(nextButton, { small: true }),
-                )}
+                <Tooltip {...tooltipProps}>
+                  <NextButton {...nextProps} small />
+                </Tooltip>
               </li>
             )}
             {showSubmitButton && (
               <li className="pull-right">
-                {cloneElement(
-                  tooltip,
-                  null,
-                  cloneElement(submitButton, { small: true }),
-                )}
+                <Tooltip {...tooltipProps}>
+                  <SubmitButton {...submitProps} small />
+                </Tooltip>
               </li>
             )}
           </ul>

--- a/modules/core/client/utils/validation.js
+++ b/modules/core/client/utils/validation.js
@@ -1,0 +1,27 @@
+/**
+ * @typedef {array} rule - first element is testing function, second element is error
+ * testing function has value as the first argument
+ *    and all values as the second optional argument
+ * error can be anything
+ */
+/**
+ * provided a dictionary of rules and a dictionary of values,
+ * return a dictionary of errors for each value
+ *
+ * @param {Object.<string, rule[]>} ruleDict - dictionary of array of rules
+ * @param {Object.<string, any>} valueDict - dictionary of values
+ * @returns {Object.<string, any[]>} - dictionary of array of errors
+ */
+export const validate = (ruleDict, valueDict) => {
+  const entries = Object.entries(valueDict);
+
+  const outputEntries = entries.map(([name, value]) => {
+    const rules = ruleDict[name] ?? [];
+    const errors = rules
+      .filter(([rule]) => !rule(value, valueDict))
+      .map(([, error]) => error);
+    return [name, errors];
+  });
+
+  return Object.fromEntries(outputEntries);
+};

--- a/modules/core/client/utils/validation.js
+++ b/modules/core/client/utils/validation.js
@@ -12,7 +12,7 @@
  * @param {Object.<string, any>} valueDict - dictionary of values
  * @returns {Object.<string, any[]>} - dictionary of array of errors
  */
-export const validate = (ruleDict, valueDict) => {
+export const createValidator = ruleDict => valueDict => {
   const entries = Object.entries(valueDict);
 
   const outputEntries = entries.map(([name, value]) => {

--- a/modules/core/tests/client/components/Navigation.client.component.tests.js
+++ b/modules/core/tests/client/components/Navigation.client.component.tests.js
@@ -27,10 +27,17 @@ describe('Navigation through 3 tabs', () => {
       ' and ',
     )} button`, () => {
       const { getAllByRole } = render(
-        <Navigation tab={tab} tabs={tabs} tabDone={0} {...handlers} />,
+        <Navigation
+          tab={tab}
+          tabs={tabs}
+          errors={[[], [], []]}
+          {...handlers}
+        />,
       );
       const foundButtons = getAllByRole('button');
-      expect(foundButtons).toHaveLength(buttons.length);
+      // we have navigation for large and for small screen
+      // so we have all buttons twice
+      expect(foundButtons).toHaveLength(buttons.length * 2);
       buttons.forEach((button, index) => {
         expect(foundButtons[index]).toHaveTextContent(button);
       });
@@ -44,7 +51,7 @@ describe('Navigation through 3 tabs', () => {
     {
       tab: 1,
       tabs: 3,
-      tabDone: 0,
+      errors: [[], ['error'], []],
       buttons: [
         { name: 'Back', disabled: false },
         { name: 'Next', disabled: true },
@@ -53,7 +60,7 @@ describe('Navigation through 3 tabs', () => {
     {
       tab: 1,
       tabs: 3,
-      tabDone: 1,
+      errors: [[], [], ['error']],
       buttons: [
         { name: 'Back', disabled: false },
         { name: 'Next', disabled: false },
@@ -62,7 +69,7 @@ describe('Navigation through 3 tabs', () => {
     {
       tab: 2,
       tabs: 3,
-      tabDone: 1,
+      errors: [[], [], ['error']],
       buttons: [
         { name: 'Back', disabled: false },
         { name: 'Finish', disabled: true },
@@ -71,26 +78,28 @@ describe('Navigation through 3 tabs', () => {
     {
       tab: 2,
       tabs: 3,
-      tabDone: 2,
+      errors: [[], [], []],
       buttons: [
         { name: 'Back', disabled: false },
         { name: 'Finish', disabled: false },
       ],
     },
-  ].forEach(({ tab, tabs, tabDone, buttons }) => {
+  ].forEach(({ tab, tabs, errors, buttons }) => {
     const expectations = buttons.map(
       ({ name, disabled }) =>
         `the ${name} button should be ${disabled ? 'disabled' : 'enabled'}`,
     );
 
-    it(`when tab=${tab}, tabs=${tabs} and tabDone=${tabDone}, ${expectations.join(
-      ' and ',
-    )}`, () => {
+    it(`when tab=${tab}, tabs=${tabs} and errors=${JSON.stringify(
+      errors,
+    )}, ${expectations.join(' and ')}`, () => {
       const { getAllByRole } = render(
-        <Navigation tab={tab} tabDone={tabDone} tabs={tabs} {...handlers} />,
+        <Navigation tab={tab} errors={errors} tabs={tabs} {...handlers} />,
       );
       const foundButtons = getAllByRole('button');
-      expect(foundButtons).toHaveLength(buttons.length);
+      // we have navigation for large and for small screen
+      // so we have all buttons twice
+      expect(foundButtons).toHaveLength(buttons.length * 2);
       buttons.forEach(({ name, disabled }, index) => {
         const testedButton = foundButtons[index];
         expect(testedButton).toHaveTextContent(name);
@@ -109,35 +118,35 @@ describe('Navigation through 3 tabs', () => {
   [
     {
       tab: 1,
-      tabDone: 0,
       tabs: 3,
+      errors: [[], ['error'], []],
       button: 'Back',
       buttonIndex: 0,
       testTrigger: 'onBack',
     },
     {
       tab: 1,
-      tabDone: 1,
       tabs: 3,
+      errors: [[], [], ['error']],
       button: 'Next',
       buttonIndex: 1,
       testTrigger: 'onNext',
     },
     {
       tab: 2,
-      tabDone: 2,
       tabs: 3,
+      errors: [[], [], []],
       button: 'Finish',
       buttonIndex: 1,
       testTrigger: 'onSubmit',
     },
-  ].forEach(({ tab, tabs, tabDone, button, buttonIndex, testTrigger }) => {
+  ].forEach(({ tab, tabs, errors, button, buttonIndex, testTrigger }) => {
     it(`when ${button} button is clicked, the ${testTrigger} should be triggered`, () => {
       const handler = jest.fn();
       const { getAllByRole } = render(
         <Navigation
           tab={tab}
-          tabDone={tabDone}
+          errors={errors}
           tabs={tabs}
           {...handlers}
           {...{ [testTrigger]: handler }}

--- a/modules/core/tests/client/components/Navigation.client.component.tests.js
+++ b/modules/core/tests/client/components/Navigation.client.component.tests.js
@@ -4,7 +4,7 @@ import '@testing-library/jest-dom/extend-expect';
 
 import '@/config/client/i18n';
 
-import Navigation from '@/modules/references/client/components/create-reference/Navigation';
+import Navigation from '@/modules/core/client/components/Navigation';
 
 describe('Navigation through 3 tabs', () => {
   const f = () => {}; // dummy handler function
@@ -21,7 +21,7 @@ describe('Navigation through 3 tabs', () => {
   [
     { tab: 0, tabs: 3, buttons: ['Next'] },
     { tab: 1, tabs: 3, buttons: ['Back', 'Next'] },
-    { tab: 2, tabs: 3, buttons: ['Back', 'Submit'] },
+    { tab: 2, tabs: 3, buttons: ['Back', 'Finish'] },
   ].forEach(({ tab, tabs, buttons }) => {
     it(`when tab=${tab} and tabs=${3} there is only ${buttons.join(
       ' and ',
@@ -65,7 +65,7 @@ describe('Navigation through 3 tabs', () => {
       tabDone: 1,
       buttons: [
         { name: 'Back', disabled: false },
-        { name: 'Submit', disabled: true },
+        { name: 'Finish', disabled: true },
       ],
     },
     {
@@ -74,7 +74,7 @@ describe('Navigation through 3 tabs', () => {
       tabDone: 2,
       buttons: [
         { name: 'Back', disabled: false },
-        { name: 'Submit', disabled: false },
+        { name: 'Finish', disabled: false },
       ],
     },
   ].forEach(({ tab, tabs, tabDone, buttons }) => {
@@ -127,7 +127,7 @@ describe('Navigation through 3 tabs', () => {
       tab: 2,
       tabDone: 2,
       tabs: 3,
-      button: 'Submit',
+      button: 'Finish',
       buttonIndex: 1,
       testTrigger: 'onSubmit',
     },

--- a/modules/core/tests/client/components/StepNavigation.client.component.tests.js
+++ b/modules/core/tests/client/components/StepNavigation.client.component.tests.js
@@ -4,9 +4,9 @@ import '@testing-library/jest-dom/extend-expect';
 
 import '@/config/client/i18n';
 
-import Navigation from '@/modules/core/client/components/Navigation';
+import StepNavigation from '@/modules/core/client/components/StepNavigation';
 
-describe('Navigation through 3 tabs', () => {
+describe('Step Navigation through 3 tabs', () => {
   const f = () => {}; // dummy handler function
 
   const handlers = {
@@ -27,7 +27,7 @@ describe('Navigation through 3 tabs', () => {
       ' and ',
     )} button`, () => {
       const { getAllByRole } = render(
-        <Navigation
+        <StepNavigation
           tab={tab}
           tabs={tabs}
           errors={[[], [], []]}
@@ -94,7 +94,7 @@ describe('Navigation through 3 tabs', () => {
       errors,
     )}, ${expectations.join(' and ')}`, () => {
       const { getAllByRole } = render(
-        <Navigation tab={tab} errors={errors} tabs={tabs} {...handlers} />,
+        <StepNavigation tab={tab} errors={errors} tabs={tabs} {...handlers} />,
       );
       const foundButtons = getAllByRole('button');
       // we have navigation for large and for small screen
@@ -144,7 +144,7 @@ describe('Navigation through 3 tabs', () => {
     it(`when ${button} button is clicked, the ${testTrigger} should be triggered`, () => {
       const handler = jest.fn();
       const { getAllByRole } = render(
-        <Navigation
+        <StepNavigation
           tab={tab}
           errors={errors}
           tabs={tabs}

--- a/modules/core/tests/client/components/StepNavigation.client.component.tests.js
+++ b/modules/core/tests/client/components/StepNavigation.client.component.tests.js
@@ -6,7 +6,7 @@ import '@/config/client/i18n';
 
 import StepNavigation from '@/modules/core/client/components/StepNavigation';
 
-describe('Step Navigation through 3 tabs', () => {
+describe('Step Navigation through 3 steps', () => {
   const f = () => {}; // dummy handler function
 
   const handlers = {
@@ -16,21 +16,21 @@ describe('Step Navigation through 3 tabs', () => {
   };
 
   /**
-   * Given tab number and amount of tabs, test that specific buttons are present
+   * Given current step and amount of steps, test that specific buttons are present
    */
   [
-    { tab: 0, tabs: 3, buttons: ['Next'] },
-    { tab: 1, tabs: 3, buttons: ['Back', 'Next'] },
-    { tab: 2, tabs: 3, buttons: ['Back', 'Finish'] },
-  ].forEach(({ tab, tabs, buttons }) => {
-    it(`when tab=${tab} and tabs=${3} there is only ${buttons.join(
+    { currentStep: 0, numberOfSteps: 3, buttons: ['Next'] },
+    { currentStep: 1, numberOfSteps: 3, buttons: ['Back', 'Next'] },
+    { currentStep: 2, numberOfSteps: 3, buttons: ['Back', 'Finish'] },
+  ].forEach(({ currentStep, numberOfSteps, buttons }) => {
+    it(`when currentStep=${currentStep} and numberOfSteps=${3} there is only ${buttons.join(
       ' and ',
     )} button`, () => {
       const { getAllByRole } = render(
         <StepNavigation
-          tab={tab}
-          tabs={tabs}
-          errors={[[], [], []]}
+          currentStep={currentStep}
+          numberOfSteps={numberOfSteps}
+          disabled={false}
           {...handlers}
         />,
       );
@@ -49,52 +49,59 @@ describe('Step Navigation through 3 tabs', () => {
    */
   [
     {
-      tab: 1,
-      tabs: 3,
-      errors: [[], ['error'], []],
+      currentStep: 1,
+      numberOfSteps: 3,
+      disabled: true,
       buttons: [
         { name: 'Back', disabled: false },
         { name: 'Next', disabled: true },
       ],
     },
     {
-      tab: 1,
-      tabs: 3,
-      errors: [[], [], ['error']],
+      currentStep: 1,
+      numberOfSteps: 3,
+      disabled: false,
       buttons: [
         { name: 'Back', disabled: false },
         { name: 'Next', disabled: false },
       ],
     },
     {
-      tab: 2,
-      tabs: 3,
-      errors: [[], [], ['error']],
+      currentStep: 2,
+      numberOfSteps: 3,
+      disabled: true,
       buttons: [
         { name: 'Back', disabled: false },
         { name: 'Finish', disabled: true },
       ],
     },
     {
-      tab: 2,
-      tabs: 3,
-      errors: [[], [], []],
+      currentStep: 2,
+      numberOfSteps: 3,
+      disabled: false,
       buttons: [
         { name: 'Back', disabled: false },
         { name: 'Finish', disabled: false },
       ],
     },
-  ].forEach(({ tab, tabs, errors, buttons }) => {
+  ].forEach(({ currentStep, numberOfSteps, disabled, buttons }) => {
     const expectations = buttons.map(
-      ({ name, disabled }) =>
-        `the ${name} button should be ${disabled ? 'disabled' : 'enabled'}`,
+      ({ name, disabled: shouldBeDisabled }) =>
+        `the ${name} button should be ${
+          shouldBeDisabled ? 'disabled' : 'enabled'
+        }`,
     );
 
-    it(`when tab=${tab}, tabs=${tabs} and errors=${JSON.stringify(
-      errors,
+    it(`when currentStep=${currentStep}, numberOfSteps=${numberOfSteps} and disabled=${JSON.stringify(
+      disabled,
     )}, ${expectations.join(' and ')}`, () => {
       const { getAllByRole } = render(
-        <StepNavigation tab={tab} errors={errors} tabs={tabs} {...handlers} />,
+        <StepNavigation
+          currentStep={currentStep}
+          disabled={disabled}
+          numberOfSteps={numberOfSteps}
+          {...handlers}
+        />,
       );
       const foundButtons = getAllByRole('button');
       // we have navigation for large and for small screen
@@ -117,46 +124,55 @@ describe('Step Navigation through 3 tabs', () => {
    */
   [
     {
-      tab: 1,
-      tabs: 3,
-      errors: [[], ['error'], []],
+      currentStep: 1,
+      numberOfSteps: 3,
+      disabled: true,
       button: 'Back',
       buttonIndex: 0,
       testTrigger: 'onBack',
     },
     {
-      tab: 1,
-      tabs: 3,
-      errors: [[], [], ['error']],
+      currentStep: 1,
+      numberOfSteps: 3,
+      disabled: false,
       button: 'Next',
       buttonIndex: 1,
       testTrigger: 'onNext',
     },
     {
-      tab: 2,
-      tabs: 3,
-      errors: [[], [], []],
+      currentStep: 2,
+      numberOfSteps: 3,
+      disabled: false,
       button: 'Finish',
       buttonIndex: 1,
       testTrigger: 'onSubmit',
     },
-  ].forEach(({ tab, tabs, errors, button, buttonIndex, testTrigger }) => {
-    it(`when ${button} button is clicked, the ${testTrigger} should be triggered`, () => {
-      const handler = jest.fn();
-      const { getAllByRole } = render(
-        <StepNavigation
-          tab={tab}
-          errors={errors}
-          tabs={tabs}
-          {...handlers}
-          {...{ [testTrigger]: handler }}
-        />,
-      );
-      const testedButton = getAllByRole('button')[buttonIndex];
-      expect(testedButton).toHaveTextContent(button);
-      expect(handler).not.toHaveBeenCalled();
-      fireEvent.click(testedButton);
-      expect(handler).toHaveBeenCalledTimes(1);
-    });
-  });
+  ].forEach(
+    ({
+      currentStep,
+      numberOfSteps,
+      disabled,
+      button,
+      buttonIndex,
+      testTrigger,
+    }) => {
+      it(`when ${button} button is clicked, the ${testTrigger} should be triggered`, () => {
+        const handler = jest.fn();
+        const { getAllByRole } = render(
+          <StepNavigation
+            currentStep={currentStep}
+            disabled={disabled}
+            numberOfSteps={numberOfSteps}
+            {...handlers}
+            {...{ [testTrigger]: handler }}
+          />,
+        );
+        const testedButton = getAllByRole('button')[buttonIndex];
+        expect(testedButton).toHaveTextContent(button);
+        expect(handler).not.toHaveBeenCalled();
+        fireEvent.click(testedButton);
+        expect(handler).toHaveBeenCalledTimes(1);
+      });
+    },
+  );
 });

--- a/modules/references/client/components/CreateReference.component.js
+++ b/modules/references/client/components/CreateReference.component.js
@@ -26,7 +26,7 @@ export default function CreateReference({ userFrom, userTo }) {
   const [recommend, setRecommend] = useState(null);
   const [report, setReport] = useState(false);
   const [reportMessage, setReportMessage] = useState('');
-  const [tab, setTab] = useState(0);
+  const [step, setStep] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isDuplicate, setIsDuplicate] = useState(false);
@@ -114,8 +114,16 @@ export default function CreateReference({ userFrom, userTo }) {
     recommend,
   };
 
+  // find out whether the current tab is valid, and whether we can continue
   const errorDict = validate(ruleDict, valueDict);
+  // map errors to tabs and find errors relevant for current tab
   const navigationErrors = [errorDict.interaction, errorDict.recommend];
+  const currentStepErrors = navigationErrors.slice(0, step + 1).flat();
+  // can we continue?
+  const isNextStepDisabled = isSubmitting || currentStepErrors.length > 0;
+  // if not, why?
+  const nextStepError =
+    !isSubmitting && currentStepErrors.find(error => error.trim().length > 0);
 
   if (userFrom._id === userTo._id) return <ReferenceToSelfInfo />;
 
@@ -138,7 +146,7 @@ export default function CreateReference({ userFrom, userTo }) {
   return (
     <div>
       <Tabs
-        activeKey={tab}
+        activeKey={step}
         bsStyle="pills"
         onSelect={() => {}}
         id="create-reference-tabs"
@@ -151,12 +159,12 @@ export default function CreateReference({ userFrom, userTo }) {
         </Tab>
       </Tabs>
       <StepNavigation
-        tab={tab}
-        tabs={tabs.length}
-        errors={navigationErrors}
-        disabled={isSubmitting}
-        onBack={() => setTab(tab => tab - 1)}
-        onNext={() => setTab(tab => tab + 1)}
+        currentStep={step}
+        numberOfSteps={tabs.length}
+        disabled={isNextStepDisabled}
+        disabledReason={nextStepError}
+        onBack={() => setStep(step => step - 1)}
+        onNext={() => setStep(step => step + 1)}
         onSubmit={handleSubmit}
       />
     </div>

--- a/modules/references/client/components/CreateReference.component.js
+++ b/modules/references/client/components/CreateReference.component.js
@@ -13,6 +13,7 @@ import {
   DuplicateInfo,
   SubmittedInfo,
 } from './create-reference/Info';
+import { validate } from '@/modules/core/client/utils/validation';
 
 const api = { references };
 
@@ -98,7 +99,23 @@ export default function CreateReference({ userFrom, userTo }) {
     />,
   ];
 
-  const tabDone = recommend ? 1 : hostedMe || hostedThem || met ? 0 : -1;
+  const ruleDict = {
+    interaction: [
+      [
+        ({ hostedMe, hostedThem, met }) => hostedMe || hostedThem || met,
+        t('Choose your interaction'),
+      ],
+    ],
+    recommend: [[value => !!value, t('Choose your recommendation')]],
+  };
+
+  const valueDict = {
+    interaction: { hostedMe, hostedThem, met },
+    recommend,
+  };
+
+  const errorDict = validate(ruleDict, valueDict);
+  const navigationErrors = [errorDict.interaction, errorDict.recommend];
 
   if (userFrom._id === userTo._id) return <ReferenceToSelfInfo />;
 
@@ -133,11 +150,11 @@ export default function CreateReference({ userFrom, userTo }) {
           {tabs[1]}
         </Tab>
       </Tabs>
-      {/* <!-- Navigation for big screens -->*/}
+      {/* <!-- Navigation -->*/}
       <Navigation
         tab={tab}
-        tabDone={tabDone}
         tabs={tabs.length}
+        errors={navigationErrors}
         disabled={isSubmitting}
         onBack={() => setTab(tab => tab - 1)}
         onNext={() => setTab(tab => tab + 1)}

--- a/modules/references/client/components/CreateReference.component.js
+++ b/modules/references/client/components/CreateReference.component.js
@@ -4,7 +4,7 @@ import { Tab, Tabs } from 'react-bootstrap';
 import { useTranslation } from 'react-i18next';
 import '@/config/client/i18n';
 import * as references from '../api/references.api';
-import Navigation from './create-reference/Navigation';
+import Navigation from '@/modules/core/client/components/Navigation';
 import Interaction from './create-reference/Interaction';
 import Recommend from './create-reference/Recommend';
 import {

--- a/modules/references/client/components/CreateReference.component.js
+++ b/modules/references/client/components/CreateReference.component.js
@@ -150,7 +150,6 @@ export default function CreateReference({ userFrom, userTo }) {
           {tabs[1]}
         </Tab>
       </Tabs>
-      {/* <!-- Navigation -->*/}
       <StepNavigation
         tab={tab}
         tabs={tabs.length}

--- a/modules/references/client/components/CreateReference.component.js
+++ b/modules/references/client/components/CreateReference.component.js
@@ -4,7 +4,7 @@ import { Tab, Tabs } from 'react-bootstrap';
 import { useTranslation } from 'react-i18next';
 import '@/config/client/i18n';
 import * as references from '../api/references.api';
-import Navigation from '@/modules/core/client/components/Navigation';
+import StepNavigation from '@/modules/core/client/components/StepNavigation';
 import Interaction from './create-reference/Interaction';
 import Recommend from './create-reference/Recommend';
 import {
@@ -151,7 +151,7 @@ export default function CreateReference({ userFrom, userTo }) {
         </Tab>
       </Tabs>
       {/* <!-- Navigation -->*/}
-      <Navigation
+      <StepNavigation
         tab={tab}
         tabs={tabs.length}
         errors={navigationErrors}

--- a/modules/references/client/components/CreateReference.component.js
+++ b/modules/references/client/components/CreateReference.component.js
@@ -13,7 +13,7 @@ import {
   DuplicateInfo,
   SubmittedInfo,
 } from './create-reference/Info';
-import { validate } from '@/modules/core/client/utils/validation';
+import { createValidator } from '@/modules/core/client/utils/validation';
 
 const api = { references };
 
@@ -99,7 +99,10 @@ export default function CreateReference({ userFrom, userTo }) {
     />,
   ];
 
-  const ruleDict = {
+  // find out whether the current tab is valid, and whether we can continue
+  // we'd prefer to create validator outside the render function,
+  // but we'd need to translate errors in a very complicated way
+  const validate = createValidator({
     interaction: [
       [
         ({ hostedMe, hostedThem, met }) => hostedMe || hostedThem || met,
@@ -107,15 +110,11 @@ export default function CreateReference({ userFrom, userTo }) {
       ],
     ],
     recommend: [[value => !!value, t('Choose your recommendation')]],
-  };
-
-  const valueDict = {
+  });
+  const errorDict = validate({
     interaction: { hostedMe, hostedThem, met },
     recommend,
-  };
-
-  // find out whether the current tab is valid, and whether we can continue
-  const errorDict = validate(ruleDict, valueDict);
+  });
   // map errors to tabs and find errors relevant for current tab
   const navigationErrors = [errorDict.interaction, errorDict.recommend];
   const currentStepErrors = navigationErrors.slice(0, step + 1).flat();

--- a/modules/references/tests/client/components/CreateReference.client.component.tests.js
+++ b/modules/references/tests/client/components/CreateReference.client.component.tests.js
@@ -97,7 +97,7 @@ describe('<CreateReference />', () => {
     ).toBeInTheDocument();
     fireEvent.click(getByText('Yes'));
 
-    fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Finish'));
 
     expect(api.references.create).toHaveBeenCalledWith({
       met: false,
@@ -138,7 +138,7 @@ describe('<CreateReference />', () => {
       target: { value: 'they were mean to me' },
     });
 
-    fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Finish'));
 
     expect(api.references.create).toHaveBeenCalledWith({
       met: false,

--- a/modules/references/tests/client/components/CreateReference.client.component.tests.js
+++ b/modules/references/tests/client/components/CreateReference.client.component.tests.js
@@ -81,23 +81,27 @@ describe('<CreateReference />', () => {
     api.references.read.mockResolvedValueOnce([]);
     api.references.create.mockResolvedValueOnce({ public: false });
 
-    const { getByText, getByLabelText, queryByLabelText, queryByRole } = render(
-      <CreateReference userFrom={userFrom} userTo={userTo} />,
-    );
+    const {
+      getByText,
+      getAllByText,
+      getByLabelText,
+      queryByLabelText,
+      queryByRole,
+    } = render(<CreateReference userFrom={userFrom} userTo={userTo} />);
 
     await waitForLoader();
 
     expect(queryByLabelText('How do you know them?')).toBeInTheDocument();
     fireEvent.click(getByLabelText('They hosted me'));
 
-    fireEvent.click(getByText('Next'));
+    fireEvent.click(getAllByText('Next')[0]);
 
     expect(
       queryByLabelText('Would you recommend others to stay with them?'),
     ).toBeInTheDocument();
     fireEvent.click(getByText('Yes'));
 
-    fireEvent.click(getByText('Finish'));
+    fireEvent.click(getAllByText('Finish')[0]);
 
     expect(api.references.create).toHaveBeenCalledWith({
       met: false,
@@ -117,16 +121,20 @@ describe('<CreateReference />', () => {
     api.references.read.mockResolvedValueOnce([]);
     api.references.create.mockResolvedValueOnce({ public: false });
 
-    const { getByText, getByLabelText, queryByLabelText, queryByRole } = render(
-      <CreateReference userFrom={userFrom} userTo={userTo} />,
-    );
+    const {
+      getByText,
+      getAllByText,
+      getByLabelText,
+      queryByLabelText,
+      queryByRole,
+    } = render(<CreateReference userFrom={userFrom} userTo={userTo} />);
 
     await waitForLoader();
 
     expect(queryByLabelText('How do you know them?')).toBeInTheDocument();
     fireEvent.click(getByLabelText('They hosted me'));
 
-    fireEvent.click(getByText('Next'));
+    fireEvent.click(getAllByText('Next')[0]);
 
     expect(
       queryByLabelText('Would you recommend others to stay with them?'),
@@ -138,7 +146,7 @@ describe('<CreateReference />', () => {
       target: { value: 'they were mean to me' },
     });
 
-    fireEvent.click(getByText('Finish'));
+    fireEvent.click(getAllByText('Finish')[0]);
 
     expect(api.references.create).toHaveBeenCalledWith({
       met: false,


### PR DESCRIPTION
#### Proposed Changes

- move `Navigation` component from `references` to `core`
- add navigation for small screens
- block buttons based on provided (validation) errors
- add tooltip with error message to blocked buttons
- use in `CreateReference` component

#### Testing

- `git switch refactor-navigation`
- make sure you have references enabled: `{ featureFlags: { reference: true } }` in `/config/env/development.js`
- go to `/profile/{some-username}/references/new`
- see that navigation works on a big screen
  ![image](https://user-images.githubusercontent.com/7449720/78503061-9ba5f100-7764-11ea-8814-05be11b025b1.png)
- see that navigation works on a small screen
  ![image](https://user-images.githubusercontent.com/7449720/78503120-e58ed700-7764-11ea-8f38-73be7b793dbc.png)
- hover disabled buttons and see validation errors in tooltip
- see whether `modules/core/client/components/README.md` makes sense

~Depends on #1364, which should be merged first~
Preparation for #1350 