### PR TITLE
Search filter: enable "online in the past 6 months" by default

### DIFF
--- a/modules/search/client/services/filters.client.service.js
+++ b/modules/search/client/services/filters.client.service.js
@@ -11,7 +11,7 @@ function FiltersService($log, Authentication, locker) {
     types: ['host', 'meet'],
     languages: [],
     seen: {
-      months: 24,
+      months: 6,
     },
   };
 


### PR DESCRIPTION
As @rumwerfer noted in https://github.com/Trustroots/trustroots/issues/1381#issuecomment-615365707, "online within the last 6 months" toggle in map search wasn't on by default.

This makes 6 months default and requires people to toggle it off to get users from the past 24 months. Anyone not logged longer than that won't be visible on the map no matter how the toggle is set.

#### Proposed Changes

* Enable "online in the past 6 months" by default

#### Testing Instructions

* Open map search and filters panel
* You can either open in an incognito window to ensure you don't have filter settings in local storage saved, or you can manually delete "trustroots.search.filters" entry as seen in 2nd screenshot. Go to the "Application" tab and to "Local Storage".

<img width="1592" alt="Screenshot 2020-04-29 at 09 14 30" src="https://user-images.githubusercontent.com/87168/80566129-e8df5080-89fa-11ea-83db-859b3231f616.png">
<img width="1597" alt="Screenshot 2020-04-29 at 09 14 50" src="https://user-images.githubusercontent.com/87168/80566131-eaa91400-89fa-11ea-946d-2d64bd988780.png">

By default, the toggle is on. You can also ensure from networks tab that correct "seen" value is sent (24 when the toggle is disabled, 6 months when enabled):

![image](https://user-images.githubusercontent.com/87168/80566227-2b089200-89fb-11ea-9008-bc1b47ad2278.png)
