### PR TITLE
Stats: record spoken languages daily

### DIFF
--- a/modules/statistics/server/controllers/statistics.server.controller.js
+++ b/modules/statistics/server/controllers/statistics.server.controller.js
@@ -219,6 +219,29 @@ exports.getLastSeenStatistic = function (since, callback) {
 };
 
 /**
+ * Get count of languages users speak
+ *
+ * @param limit {int} Limit returned number of languages
+ * @param callback {function}
+ */
+exports.getUserLanguagesCount = function (limit, callback) {
+  User.aggregate(
+    [
+      { $unwind: '$languages' },
+      {
+        $group: {
+          _id: '$languages',
+          count: { $sum: 1 },
+        },
+      },
+      { $sort: { count: -1 } },
+      { $limit: limit },
+    ],
+    callback,
+  );
+};
+
+/**
  * Get all statistics
  */
 exports.getPublicStatistics = function (req, res) {

--- a/modules/statistics/server/jobs/daily-statistics.server.job.js
+++ b/modules/statistics/server/jobs/daily-statistics.server.job.js
@@ -230,6 +230,36 @@ module.exports = function (job, agendaDone) {
           done,
         );
       },
+
+      // Get number of languages spoken
+      function (done) {
+        statistics.getUserLanguagesCount(40, function (err, counts) {
+          if (err) {
+            log(
+              'error',
+              'Daily statistics: failed fetching languages spoken counts.',
+              err,
+            );
+            return done();
+          }
+
+          // Write numbers to stats
+          counts.map(({ _id, count }) => {
+            writeDailyStat(
+              {
+                namespace: 'language',
+                values: {
+                  count,
+                },
+                tags: {
+                  language: _id,
+                },
+              },
+              done,
+            );
+          });
+        });
+      },
     ],
     function (err) {
       if (err) {

--- a/modules/statistics/server/jobs/daily-statistics.server.job.js
+++ b/modules/statistics/server/jobs/daily-statistics.server.job.js
@@ -231,7 +231,7 @@ module.exports = function (job, agendaDone) {
         );
       },
 
-      // Get number of spoken languages
+      // Get statistics for top 40 spoken languages
       function (done) {
         statistics.getUserLanguagesCount(40, function (err, languageCounts) {
           if (err) {

--- a/modules/statistics/server/jobs/daily-statistics.server.job.js
+++ b/modules/statistics/server/jobs/daily-statistics.server.job.js
@@ -231,33 +231,38 @@ module.exports = function (job, agendaDone) {
         );
       },
 
-      // Get number of languages spoken
+      // Get number of spoken languages
       function (done) {
-        statistics.getUserLanguagesCount(40, function (err, counts) {
+        statistics.getUserLanguagesCount(40, function (err, languageCounts) {
           if (err) {
             log(
               'error',
-              'Daily statistics: failed fetching languages spoken counts.',
+              'Daily statistics: failed fetching spoken languages counts.',
               err,
             );
             return done();
           }
 
           // Write numbers to stats
-          counts.map(({ _id, count }) => {
-            writeDailyStat(
-              {
-                namespace: 'language',
-                values: {
-                  count,
+          async.eachOfSeries(
+            languageCounts,
+            function ({ _id, count }, index, doneLanguage) {
+              writeDailyStat(
+                {
+                  namespace: 'language',
+                  values: {
+                    count,
+                    percentage: (count / totalUserCount) * 100,
+                  },
+                  tags: {
+                    language: _id,
+                  },
                 },
-                tags: {
-                  language: _id,
-                },
-              },
-              done,
-            );
-          });
+                doneLanguage,
+              );
+            },
+            done,
+          );
         });
       },
     ],


### PR DESCRIPTION
Collects spoken languages from profiles as counts to Influx DB.

Kudos @nicksellen for writing the query:
```
db.users.aggregate([{$unwind: "$languages" }, { $group: { _id: '$languages', count: { $sum: 1 }  } }, { $sort: { count: -1 } }, { $limit: 40 }]).map(item => ([item._id, item.count].join(' '))).join('\n')
```

Which today on live DB gives:
```
eng 30895
spa 9448
fre 8876
ger 7660
ita 2742
rus 2715
por 2489
dut 1723
pol 1616
ara 1081
tur 1074
cze 858
hin 852
swe 792
chi 739
cat 535
rum 505
dan 486
hun 478
ukr 465
```

#### Proposed Changes

* Adds collecting top 40 languages in daily stats run

#### Testing Instructions

* Add some languages to the database: you can manually modify `users` collection and add codes to `languages` entry for profiles, or alternatively save some languages to profiles via UI.
* Run the app `npm start`
* Run the worker dash: `npm run dashboard:jobs` and open `http://localhost:1081/` to observe jobs.
* Pick "daily stats" and hit rerun:

    ![image](https://user-images.githubusercontent.com/87168/82738949-5786a400-9d44-11ea-9aef-676acbaea1ef.png)

* You should observe in console the job run with query:
    
    ![image](https://user-images.githubusercontent.com/87168/82738960-74bb7280-9d44-11ea-8551-de72017fe86f.png)
    
    You could add some console.logging to the job in [`modules/statistics/server/jobs/daily-statistics.server.job.js`](https://github.com/Trustroots/trustroots/pull/1466/files#diff-0752896853e5ef2c8805dc0e8d6e8c1aR236) to see what's going on as I've done.