### PR TITLE
Admin: add notes feature

### DIFF
--- a/modules/admin/client/api/admin-notes.api.js
+++ b/modules/admin/client/api/admin-notes.api.js
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+export async function addNote({ note, userId }) {
+  const { data } = await axios.post('/api/admin/notes', { note, userId });
+  return data;
+}
+
+export async function listNotes(userId) {
+  const { data } = await axios.get(`/api/admin/notes?userId=${userId}`);
+  return data;
+}

--- a/modules/admin/client/components/AdminNotes.js
+++ b/modules/admin/client/components/AdminNotes.js
@@ -1,0 +1,97 @@
+// External dependencies
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+
+import * as api from '../api/admin-notes.api';
+import TrEditor from '@/modules/core/client/components/TrEditor';
+import TimeAgo from '@/modules/core/client/components/TimeAgo';
+import UserLink from './UserLink.component';
+
+/**
+ * Lists notes about user and allows writing notes about them
+ */
+export default function AdminNotes({ id }) {
+  const [isFetching, setIsFetching] = useState(false);
+  const [notes, setNotes] = useState([]);
+  const [newNote, setNewNote] = useState('');
+
+  async function fetchNotes() {
+    setIsFetching(true);
+    try {
+      const notes = await api.listNotes(id);
+      setNotes(notes);
+    } catch {
+      // eslint-disable-next-line no-console
+      console.log(`Could not load admin notes for user ${id}`);
+    } finally {
+      setIsFetching(false);
+    }
+  }
+
+  useEffect(() => {
+    fetchNotes();
+  }, []);
+
+  const addNote = async () => {
+    try {
+      await api.addNote({
+        note: newNote,
+        userId: id,
+      });
+    } catch {
+      alert(`Could not write admin notes for user ${id}`);
+    } finally {
+      setNewNote('');
+      fetchNotes();
+    }
+  };
+
+  return (
+    <>
+      <h4 id="notes">
+        Admin notes about user
+        <a href="#notes" className="btn btn-link">
+          #
+        </a>
+      </h4>
+      <div className="panel panel-default admin-notes">
+        <div className="panel-body">
+          <TrEditor
+            className="admin-notes-field"
+            onChange={value => setNewNote(value)}
+            onCtrlEnter={addNote}
+            placeholder="Write a note"
+            text={newNote}
+          />
+          <button
+            className="btn btn-default"
+            disabled={isFetching || !newNote}
+            onClick={addNote}
+          >
+            Save note
+          </button>
+          {isFetching && <p>Loading notes...</p>}
+          {!isFetching &&
+            notes &&
+            notes.length > 0 &&
+            notes.map(({ _id, admin, note, date }) => {
+              return (
+                <div key={_id} className="admin-note">
+                  <p className="text-muted">
+                    <TimeAgo date={new Date(date)} />
+                    {' by '}
+                    <UserLink user={admin} />
+                  </p>
+                  <div dangerouslySetInnerHTML={{ __html: note }} />
+                </div>
+              );
+            })}
+        </div>
+      </div>
+    </>
+  );
+}
+
+AdminNotes.propTypes = {
+  id: PropTypes.string.isRequired,
+};

--- a/modules/admin/client/components/AdminUser.component.js
+++ b/modules/admin/client/components/AdminUser.component.js
@@ -5,6 +5,7 @@ import React, { Component } from 'react';
 // Internal dependencies
 import { getUser, setUserRole } from '../api/users.api';
 import AdminHeader from './AdminHeader.component';
+import AdminNotes from './AdminNotes';
 import Json from './Json.component';
 import UserEmailConfirmLink from './UserEmailConfirmLink.component';
 import UserState from './UserState.component';
@@ -212,6 +213,8 @@ export default class AdminUser extends Component {
                   <UserEmailConfirmLink user={user.profile} />
                 </div>
               </div>
+
+              <AdminNotes id={this.state.id} />
 
               <h4 id="profile">
                 Profile

--- a/modules/admin/client/less/admin.less
+++ b/modules/admin/client/less/admin.less
@@ -34,3 +34,18 @@ td:hover .admin-hidden-until-hover {
     }
   }
 }
+
+.admin-notes .tr-editor {
+  min-height: 100px;
+  margin: 5px 0;
+  padding: 10px;
+  &,
+  &:focus {
+    border: 1px solid #ccc;
+  }
+}
+.admin-note {
+  padding-top: 20px;
+  margin-top: 20px;
+  border-top: 1px solid #ccc;
+}

--- a/modules/admin/client/less/admin.less
+++ b/modules/admin/client/less/admin.less
@@ -43,11 +43,11 @@ td:hover .admin-hidden-until-hover {
   padding: 10px;
   &,
   &:focus {
-    border: 1px solid @gray-light;
+    border: 1px solid @gray-lighter;
   }
 }
 .admin-note {
   padding-top: 20px;
   margin-top: 20px;
-  border-top: 1px solid @gray-light;
+  border-top: 1px solid @gray-lighter;
 }

--- a/modules/admin/client/less/admin.less
+++ b/modules/admin/client/less/admin.less
@@ -1,3 +1,5 @@
+@import '~less/global-variables';
+
 .admin-search-users__actions {
   max-width: 30%;
 }
@@ -41,11 +43,11 @@ td:hover .admin-hidden-until-hover {
   padding: 10px;
   &,
   &:focus {
-    border: 1px solid #ccc;
+    border: 1px solid @gray-light;
   }
 }
 .admin-note {
   padding-top: 20px;
   margin-top: 20px;
-  border-top: 1px solid #ccc;
+  border-top: 1px solid @gray-light;
 }

--- a/modules/admin/server/controllers/admin.notes.server.controller.js
+++ b/modules/admin/server/controllers/admin.notes.server.controller.js
@@ -1,0 +1,82 @@
+/**
+ * Module dependencies.
+ */
+const _ = require('lodash');
+const path = require('path');
+const errorService = require(path.resolve(
+  './modules/core/server/services/error.server.service',
+));
+const textService = require(path.resolve(
+  './modules/core/server/services/text.server.service',
+));
+const sanitizeHtml = require('sanitize-html');
+const mongoose = require('mongoose');
+const AdminNote = mongoose.model('AdminNote');
+
+/**
+ * Add notes to any user
+ */
+exports.addNote = async (req, res) => {
+  const userId = _.get(req, ['body', 'userId']);
+  const note = _.get(req, ['body', 'note']);
+
+  if (typeof note !== 'string' || note.trim() === '') {
+    return res.status(400).send({
+      message: 'Empty note.',
+    });
+  }
+
+  // Check that the user id is provided
+  if (!userId || !mongoose.Types.ObjectId.isValid(userId)) {
+    return res.status(400).send({
+      message: errorService.getErrorMessageByKey('invalid-id'),
+    });
+  }
+
+  try {
+    const adminNoteItem = new AdminNote({
+      admin: req.user._id,
+      note: sanitizeHtml(note, textService.sanitizeOptions),
+      user: userId,
+    });
+
+    await adminNoteItem.save();
+    res.send({ message: 'Note saved.' });
+  } catch (err) {
+    if (err) {
+      return res.status(400).send({
+        message: errorService.getErrorMessage(err),
+      });
+    }
+  }
+};
+
+/**
+ * Read notes of a user
+ */
+exports.getNotes = async (req, res) => {
+  const userId = _.get(req, ['query', 'userId']);
+
+  // Check that the user id is provided
+  if (!userId || !mongoose.Types.ObjectId.isValid(userId)) {
+    return res.status(400).send({
+      message: errorService.getErrorMessageByKey('invalid-id'),
+    });
+  }
+
+  AdminNote.find({ user: userId })
+    .sort('-date')
+    .populate({
+      path: 'admin',
+      select: 'username displayname',
+      model: 'User',
+    })
+    .exec((err, items) => {
+      if (err) {
+        return res.status(400).send({
+          message: errorService.getErrorMessage(err),
+        });
+      }
+      res.send(items || []);
+    });
+};

--- a/modules/admin/server/models/admin-note.server.model.js
+++ b/modules/admin/server/models/admin-note.server.model.js
@@ -1,0 +1,36 @@
+// External dependencies
+const mongoose = require('mongoose');
+const path = require('path');
+
+// Internal dependencies
+const textService = require(path.resolve(
+  './modules/core/server/services/text.server.service',
+));
+
+const { Schema } = mongoose;
+
+const AdminNoteSchema = new Schema({
+  admin: {
+    type: Schema.ObjectId,
+    ref: 'User',
+  },
+  note: { type: String },
+  date: {
+    type: Date,
+    default: Date.now,
+  },
+  user: {
+    type: Schema.ObjectId,
+    ref: 'User',
+  },
+});
+
+// Sanitize and linkify note before output
+AdminNoteSchema.post('find', results =>
+  results.map(result => {
+    result.note = textService.html(result.note);
+    return result;
+  }),
+);
+
+mongoose.model('AdminNote', AdminNoteSchema);

--- a/modules/admin/server/policies/admin.server.policy.js
+++ b/modules/admin/server/policies/admin.server.policy.js
@@ -23,6 +23,7 @@ exports.invokeRolesPolicies = () => {
         { resources: '/api/admin/audit-log', permissions: ['get'] },
         { resources: '/api/admin/messages', permissions: ['post'] },
         { resources: '/api/admin/threads', permissions: ['post'] },
+        { resources: '/api/admin/notes', permissions: ['get', 'post'] },
         { resources: '/api/admin/user', permissions: ['post'] },
         { resources: '/api/admin/user/change-role', permissions: ['post'] },
         { resources: '/api/admin/users', permissions: ['post'] },

--- a/modules/admin/server/routes/admin.server.routes.js
+++ b/modules/admin/server/routes/admin.server.routes.js
@@ -7,6 +7,7 @@ const adminMessages = require('../controllers/admin.messages.server.controller')
 const adminPolicy = require('../policies/admin.server.policy');
 const adminThreads = require('../controllers/admin.threads.server.controller');
 const adminUsers = require('../controllers/admin.users.server.controller');
+const adminNotes = require('../controllers/admin.notes.server.controller');
 
 module.exports = app => {
   app
@@ -32,6 +33,12 @@ module.exports = app => {
       adminUsers.usernameToUserId,
       adminThreads.getThreads,
     );
+
+  app
+    .route('/api/admin/notes')
+    .all(adminPolicy.isAllowed)
+    .get(adminAuditLog.record, adminNotes.getNotes)
+    .post(adminAuditLog.record, adminNotes.addNote);
 
   app
     .route('/api/admin/users')

--- a/modules/admin/tests/server/admin.notes.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.notes.server.routes.tests.js
@@ -16,10 +16,6 @@ describe('Admin Notes Log CRUD tests', () => {
     '<p>test https://trustroots.org <script>alert()</script></p>';
   const noteOutputHtml =
     '<p>test <a href="https://trustroots.org">trustroots.org</a> </p>';
-  const testNote = {
-    userId: notesUserId,
-    note: 'test',
-  };
 
   const _usersRaw = utils.generateUsers(3);
   _usersRaw[0].roles = ['user', 'admin'];
@@ -60,7 +56,10 @@ describe('Admin Notes Log CRUD tests', () => {
 
       const { body } = await agent
         .post('/api/admin/notes')
-        .send(testNote)
+        .send({
+          userId: notesUserId,
+          note: 'test',
+        })
         .expect(403);
 
       body.message.should.equal('Forbidden.');
@@ -86,7 +85,10 @@ describe('Admin Notes Log CRUD tests', () => {
 
         const { body } = await agent
           .post('/api/admin/notes')
-          .send(testNote)
+          .send({
+            userId: notesUserId,
+            note: 'test',
+          })
           .expect(403);
 
         body.message.should.equal('Forbidden.');
@@ -107,7 +109,10 @@ describe('Admin Notes Log CRUD tests', () => {
 
         const { body } = await agent
           .post('/api/admin/notes')
-          .send(testNote)
+          .send({
+            userId: notesUserId,
+            note: 'test',
+          })
           .expect(200);
 
         body.message.should.equal('Note saved.');
@@ -119,7 +124,7 @@ describe('Admin Notes Log CRUD tests', () => {
         const { body } = await agent
           .post('/api/admin/notes')
           .send({
-            ...testNote,
+            userId: notesUserId,
             note: '',
           })
           .expect(400);

--- a/modules/admin/tests/server/admin.notes.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.notes.server.routes.tests.js
@@ -52,8 +52,6 @@ describe('Admin Notes Log CRUD tests', () => {
       agent.get(`/api/admin/notes?userId=${notesUserId}`).expect(403));
 
     it('non-authenticated users should not be allowed to write notes', async () => {
-      await utils.signIn(credentialsAdmin, agent);
-
       const { body } = await agent
         .post('/api/admin/notes')
         .send({

--- a/modules/admin/tests/server/admin.notes.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.notes.server.routes.tests.js
@@ -1,0 +1,143 @@
+const request = require('supertest');
+const path = require('path');
+const mongoose = require('mongoose');
+const express = require(path.resolve('./config/lib/express'));
+const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+
+const AdminNote = mongoose.model('AdminNote');
+
+describe('Admin Notes Log CRUD tests', () => {
+  // Get application
+  const app = express.init(mongoose.connection);
+  const agent = request.agent(app);
+  let adminUserId;
+  let notesUserId;
+  const noteInputHtml =
+    '<p>test https://trustroots.org <script>alert()</script></p>';
+  const noteOutputHtml =
+    '<p>test <a href="https://trustroots.org">trustroots.org</a> </p>';
+  const testNote = {
+    userId: notesUserId,
+    note: 'test',
+  };
+
+  const _usersRaw = utils.generateUsers(3);
+  _usersRaw[0].roles = ['user', 'admin'];
+
+  const credentialsAdmin = {
+    username: _usersRaw[0].username,
+    password: _usersRaw[0].password,
+  };
+
+  const credentialsRegular = {
+    username: _usersRaw[1].username,
+    password: _usersRaw[1].password,
+  };
+
+  beforeEach(async () => {
+    const _users = await utils.saveUsers(_usersRaw);
+    adminUserId = _users[0]._id;
+    notesUserId = _users[2]._id;
+
+    const note = new AdminNote({
+      date: new Date(),
+      note: noteInputHtml,
+      admin: adminUserId,
+      user: notesUserId,
+    });
+
+    await note.save();
+  });
+
+  afterEach(utils.clearDatabase);
+
+  describe('List notes', () => {
+    it('non-authenticated users should not be allowed to read notes', () =>
+      agent.get(`/api/admin/notes?userId=${notesUserId}`).expect(403));
+
+    it('non-authenticated users should not be allowed to write notes', async () => {
+      await utils.signIn(credentialsAdmin, agent);
+
+      const { body } = await agent
+        .post('/api/admin/notes')
+        .send(testNote)
+        .expect(403);
+
+      body.message.should.equal('Forbidden.');
+    });
+
+    describe('As authenticated user...', () => {
+      afterEach(async () => {
+        await utils.signOut(agent);
+      });
+
+      it('non-admin users should not be allowed to read audit log', async () => {
+        await utils.signIn(credentialsRegular, agent);
+
+        const { body } = await agent
+          .get(`/api/admin/notes?userId=${notesUserId}`)
+          .expect(403);
+
+        body.message.should.equal('Forbidden.');
+      });
+
+      it('non-admin users should not be allowed to write notes', async () => {
+        await utils.signIn(credentialsRegular, agent);
+
+        const { body } = await agent
+          .post('/api/admin/notes')
+          .send(testNote)
+          .expect(403);
+
+        body.message.should.equal('Forbidden.');
+      });
+
+      it('admin users should be allowed to read notes', async () => {
+        await utils.signIn(credentialsAdmin, agent);
+
+        const { body } = await agent
+          .get(`/api/admin/notes?userId=${notesUserId}`)
+          .expect(200);
+
+        body.length.should.equal(1);
+      });
+
+      it('admin users should be allowed to write notes', async () => {
+        await utils.signIn(credentialsAdmin, agent);
+
+        const { body } = await agent
+          .post('/api/admin/notes')
+          .send(testNote)
+          .expect(200);
+
+        body.message.should.equal('Note saved.');
+      });
+
+      it('notes cannot be empty', async () => {
+        await utils.signIn(credentialsAdmin, agent);
+
+        const { body } = await agent
+          .post('/api/admin/notes')
+          .send({
+            ...testNote,
+            note: '',
+          })
+          .expect(400);
+
+        body.message.should.equal('Empty note.');
+      });
+
+      it('notes are formatted before returning', async () => {
+        await utils.signIn(credentialsAdmin, agent);
+
+        const { body } = await agent
+          .get(`/api/admin/notes?userId=${notesUserId}`)
+          .expect(200);
+
+        // Script tag gets stripped out
+        // URL is turned into a link
+        body[0].note.should.equal(noteOutputHtml);
+      });
+    });
+  });
+});

--- a/modules/core/client/components/TrEditor.js
+++ b/modules/core/client/components/TrEditor.js
@@ -1,9 +1,10 @@
-import React, { useEffect } from 'react';
-import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
 import MediumEditor from 'react-medium-editor';
+import PropTypes from 'prop-types';
+import React, { useEffect } from 'react';
 import 'medium-editor/dist/css/medium-editor.css';
 
-const options = {
+const baseOptions = {
   disableReturn: false,
   disableDoubleReturn: false,
   disableExtraSpaces: false,
@@ -164,8 +165,15 @@ function removeTrailingBr(value) {
   return value.replace(/<br><\/p>$/, '</p>');
 }
 
-export default function TrEditor({ id, text, onChange, onCtrlEnter }) {
+export default function TrEditor({
+  id,
+  onChange,
+  onCtrlEnter,
+  placeholder,
+  text,
+}) {
   const ref = React.createRef();
+  const { t } = useTranslation('core');
 
   useEffect(() => {
     const { medium } = ref.current;
@@ -180,12 +188,21 @@ export default function TrEditor({ id, text, onChange, onCtrlEnter }) {
     };
   }, [onCtrlEnter]);
 
-  const props = { id, text, options, className: 'tr-editor' };
+  const options = {
+    // https://github.com/yabwe/medium-editor#placeholder-options
+    placeholder: {
+      hideOnClick: true,
+      text: placeholder ? placeholder : t('Type your text'),
+    },
+    ...baseOptions,
+  };
+
+  const editorProps = { id, text, options, className: 'tr-editor' };
   return (
     <MediumEditor
       ref={ref}
       onChange={value => onChange(removeTrailingBr(value))}
-      {...props}
+      {...editorProps}
     />
   );
 }
@@ -196,7 +213,8 @@ TrEditor.defaultProps = {
 
 TrEditor.propTypes = {
   id: PropTypes.string,
-  text: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   onCtrlEnter: PropTypes.func.isRequired,
+  placeholder: PropTypes.string,
+  text: PropTypes.string.isRequired,
 };


### PR DESCRIPTION
Part of https://github.com/Trustroots/trustroots/issues/1079

#### Proposed Changes

* Add simple user "notes" feature to admin tools; important for e.g. logging info about warnings we give to users or other such info. 
* Notes get saved to separate collection to avoid leaking via users collection
* Added also ability to customize `TrEditor` component's placeholder text: observe that when writing messages to someone, placeholder still says _"Type your text"_. As a bonus, this can now be translated while previously it was coming from the library's depths always in English. :-)
* Only known problem is that written note doesn't get emptied when sending it — don't have time to dig into that now and it can be fixed later.

<img width="656" alt="Screenshot 2020-06-20 at 23 44 07" src="https://user-images.githubusercontent.com/87168/85211836-a6305980-b355-11ea-8490-07769ae9e233.png">

#### Testing Instructions

- Have admin user
- Open `/admin`
- Find regular user
- Observe that you can write notes in their profile