### PR TITLE
Contacts: simple language functions update

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -102,7 +102,7 @@ The translated string can contain variables.
 
 ```jsx
 // unformatted
-t('A translation string with {{amount}} words.', { amount: 6 });
+t('A translation string with {{count}} words.', { count: 6 });
 
 // formatted
 t('Translation created on {{ date, MMM D YYYY }}.', {

--- a/modules/contacts/client/components/ContactListPresentational.js
+++ b/modules/contacts/client/components/ContactListPresentational.js
@@ -1,3 +1,4 @@
+import classnames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import '@/config/client/i18n';
@@ -23,28 +24,25 @@ export default function ContactListPresentational({
   const confirmedFiltered = filterContacts(confirmed, filter);
   const unconfirmedFiltered = filterContacts(unconfirmed, filter);
 
-  const overviewClassNames = [
-    'col-xs-12',
-    contacts.length >= 6 ? 'col-sm-8' : 'text-center',
-  ];
-
   return (
     <div className="contacts-list">
       <div className="row">
-        <div className={overviewClassNames.join(' ')}>
+        <div
+          className={classnames('col-xs-12', {
+            'col-sm-8': contacts.length >= 6,
+            'text-center': contacts.length < 6,
+          })}
+        >
           <h4 className="text-muted">
             {/* Confirmed contacts */}
-            {confirmed.length === 1 && <span>{t('One contact')}</span>}
-            {confirmed.length > 1 && (
-              <span>
-                {t('{{amount}} contacts', { amount: confirmed.length })}
-              </span>
-            )}{' '}
+            <span>
+              {t('{{count}} contacts', { count: confirmed.length })}
+            </span>{' '}
             {/* Pending contacts */}
             {unconfirmed.length > 0 && (
               <small>
-                {t('(additional {{amount}} pending)', {
-                  amount: unconfirmed.length,
+                {t('(additional {{count}} pending)', {
+                  count: unconfirmed.length,
                 })}
               </small>
             )}
@@ -59,7 +57,7 @@ export default function ContactListPresentational({
             <div className="col-xs-12 col-sm-4 text-right">
               <div className="form-group">
                 <label htmlFor="contacts-search" className="sr-only">
-                  Search contacts
+                  {t('Search contacts')}
                 </label>
                 <input
                   id="contacts-search"


### PR DESCRIPTION
#### Proposed Changes

* Add one missing translation function
* Use `count` for plurals; i18n-next automatically turns that into correct strings, see https://www.i18next.com/translation-function/plurals
* Use `classnames` for class name manipulation


#### Testing Instructions

Open Contacts tab with confirmed and un-confirmed users, with different counts and observe it work.
