### PR TITLE
Member search: take input from URL

### DIFF
--- a/modules/search/client/components/SearchUsers.component.js
+++ b/modules/search/client/components/SearchUsers.component.js
@@ -1,6 +1,6 @@
 // External dependencies
 import { useTranslation } from 'react-i18next';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 // Internal dependencies
 import { searchUsers } from '@/modules/users/client/api/search-users.api.js';
@@ -16,18 +16,32 @@ export default function SearchUsers() {
   const [hasSearched, setHasSearched] = useState(false);
   const [users, setUsers] = useState([]);
 
-  async function fetchUsers() {
+  async function fetchUsers(query) {
     setIsSearching(true);
     setHasSearched(true);
     setUsers([]);
     try {
-      const { data: users } = await searchUsers(searchQuery);
+      const { data: users } = await searchUsers(query);
       setUsers(users || []);
       setIsSearching(false);
+    } catch {
+      // Do nothing
     } finally {
       setIsSearching(false);
     }
   }
+
+  useEffect(() => {
+    const urlSearchQuery = new URL(window.location).searchParams.get('search');
+
+    if (urlSearchQuery) {
+      setHasSearched(true);
+      setSearchQuery(urlSearchQuery);
+      if (urlSearchQuery.length >= MINIMUM_QUERY_LENGTH) {
+        fetchUsers(urlSearchQuery);
+      }
+    }
+  }, []);
 
   const searchForm = (
     <form
@@ -35,7 +49,7 @@ export default function SearchUsers() {
       id="search-users-form"
       onSubmit={event => {
         event.preventDefault();
-        fetchUsers();
+        fetchUsers(searchQuery);
       }}
     >
       <div className="input-group">
@@ -76,6 +90,7 @@ export default function SearchUsers() {
               type="submit"
             >
               <i className="icon-search"></i>
+              <span className="visible-md-inline">{t('Search')}</span>
             </button>
           </span>
         </span>

--- a/modules/search/client/components/SearchUsers.component.js
+++ b/modules/search/client/components/SearchUsers.component.js
@@ -90,7 +90,7 @@ export default function SearchUsers() {
               type="submit"
             >
               <i className="icon-search"></i>
-              <span className="visible-md-inline">{t('Search')}</span>
+              <span className="hidden-xs">{t('Search')}</span>
             </button>
           </span>
         </span>


### PR DESCRIPTION
#### Proposed Changes

* On member search, populate search query from URL input. Useful for linking directly to search from https://couchspinner.com/
* Small additional UI improvement by adding "Search" next to search icon on bigger screens, just for extra clarity that people need to click that instead of wait results automatically show up:
    ![image](https://user-images.githubusercontent.com/87168/85931516-9cff3980-b8cd-11ea-8b46-35629c4587e3.png)


#### Testing Instructions

* Go http://localhost:3000/search/members?search=mikael and observe results (if you had user by that name)
* Too short query only sets input http://localhost:3000/search/members?search=m
* Empty query does nothing http://localhost:3000/search/members?search=
* URL without query works http://localhost:3000/search/members
* You can still manually modify the query in all cases and do searching as always