### PR TITLE
Fix user link in message thread on small screen

### DIFF
--- a/modules/messages/client/components/ThreadMessages.js
+++ b/modules/messages/client/components/ThreadMessages.js
@@ -33,7 +33,7 @@ export default function ThreadMessages({
       {isExtraSmall && (
         <div className="message">
           <div className="message-recipient panel panel-default">
-            <a className="panel-body" href={`/profile/${user.username}`}>
+            <a className="panel-body" href={`/profile/${otherUser.username}`}>
               <Avatar user={otherUser} size={32} link={false} />
               <h4>{otherUser.displayName}</h4>
               <small className="text-muted">@{otherUser.username}</small>


### PR DESCRIPTION
#### Proposed Changes

##### The bug in picture

![user-link-message-thread](https://user-images.githubusercontent.com/7449720/88950054-62097080-d294-11ea-9545-d975aadda253.png)

##### The bug in words

When going to message threads `[domain]/messages/:username`, there is a link to other user's profile on small screens. When clicking the link it goes to my own profile. This PR fixes it so the link goes to the other user's profile, as expected.

#### Testing Instructions

I've run the dev app locally and tested that it works. This is a very small fix. If you want to test anyways:

##### See the bug

* `git switch master`
* `npm start`
* go to `localhost:3000/messages/:username` (or skip previous steps and go to `https://trustroots.org/messages/:username`)
* make your screen small
* click the link to the other user's profile and see that it links to your own profile

##### See the fix

* `git switch fix/message-user-link`
* (`npm start` if necessary)
* go to `localhost:3000/messages/:username`
* make your screen small
* click the link to the other user's profile and see that it links to the other user's profile

Cheers! :slightly_smiling_face: 

#### Note about CI test

This behavior is apparently not automatically tested. If you think the test is needed before merging, feel free to take over this PR and write it. I don't intend to do it at the moment. Otherwise just go on and merge, please. I may not be online to do it myself.