### PR TITLE
Messages: fix reply button covering text

### DIFF
--- a/modules/messages/client/less/thread.less
+++ b/modules/messages/client/less/thread.less
@@ -168,6 +168,7 @@
         margin: 0;
       }
       @media (max-width: @screen-xs-max) {
+        padding-right: 45px;
         padding-top: 8px;
         margin-bottom: 0px;
         min-height: 43px;
@@ -182,7 +183,8 @@
     @media (max-width: @screen-xs-max) {
       margin-bottom: -1px;
       margin-left: -15px;
-      margin-right: 0px;
+      margin-right: 15px;
+      border-radius: 0;
     }
   }
   .message-reply-btn {


### PR DESCRIPTION
#### Proposed Changes

* Adjust CSS so that reply button doesn't cover the message itself

#### Before

<img width="590" alt="Screenshot 2020-08-03 at 23 04 15" src="https://user-images.githubusercontent.com/87168/89222657-18938b00-d5de-11ea-9a80-2bd660893a80.png">


#### After
<img width="593" alt="Screenshot 2020-08-03 at 23 03 37" src="https://user-images.githubusercontent.com/87168/89222665-1c271200-d5de-11ea-8833-1d780d614105.png">


#### Testing Instructions

* Open new message thread
* On mobile width screen...
* Write text so that it otherwise goes behind the button. Switch to this branch and confirm text now flows around the button
* Test that desktop sizes are unaffected

Fixes #
