### PR TITLE
Dynamic team page and move board to foundation page

### DIFF
--- a/modules/admin/client/components/AdminUser.component.js
+++ b/modules/admin/client/components/AdminUser.component.js
@@ -155,6 +155,16 @@ export default class AdminUser extends Component {
                     >
                       Make moderator
                     </button>
+                    <button
+                      className="btn btn-success"
+                      disabled={
+                        user.profile.roles.includes('volunteer') ||
+                        isSettingUserRole
+                      }
+                      onClick={() => this.handleUserRoleChange('volunteer')}
+                    >
+                      Make volunteer
+                    </button>
                   </div>
                 </div>
               </div>

--- a/modules/admin/server/controllers/admin.users.server.controller.js
+++ b/modules/admin/server/controllers/admin.users.server.controller.js
@@ -119,7 +119,9 @@ exports.listUsersByRole = (req, res) => {
   // Allowed roles to query
   if (
     !role ||
-    !['shadowban', 'suspended', 'admin', 'moderator'].includes(role)
+    !['shadowban', 'suspended', 'admin', 'moderator', 'volunteer'].includes(
+      role,
+    )
   ) {
     return res.status(400).send({
       message: 'Invalid role.',
@@ -255,7 +257,10 @@ exports.changeRole = async (req, res) => {
   const role = _.get(req, ['body', 'role']);
 
   // Allowed new roles — for security reasons never allow `admin` role to be changed programmatically.
-  if (!role || !['shadowban', 'suspended', 'moderator'].includes(role)) {
+  if (
+    !role ||
+    !['shadowban', 'suspended', 'moderator', 'volunteer'].includes(role)
+  ) {
     return res.status(400).send({
       message: 'Invalid role.',
     });

--- a/modules/core/server/views/partials/footer.server.view.html
+++ b/modules/core/server/views/partials/footer.server.view.html
@@ -8,7 +8,7 @@
     <div class="col-xs-3">
       <ul class="list-unstyled">
         <li><a ui-sref="volunteering">Volunteering</a></li>
-        <li><a ui-sref="team">Teams</a></li>
+        <li><a ui-sref="team">Team</a></li>
         <li><a href="https://wiki.trustroots.org/">Wiki</a></li>
       </ul>
     </div>

--- a/modules/core/server/views/partials/header.server.view.html
+++ b/modules/core/server/views/partials/header.server.view.html
@@ -218,6 +218,9 @@
                 >
               </li>
               <li>
+                <a class="text-muted" ui-sref="team">Team</a>
+              </li>
+              <li>
                 <a
                   class="text-muted"
                   ui-sref="privacy"

--- a/modules/pages/client/api/volunteers.api.js
+++ b/modules/pages/client/api/volunteers.api.js
@@ -1,0 +1,6 @@
+import axios from 'axios';
+
+export async function getVolunteers() {
+  const { data } = await axios.get('/api/volunteers');
+  return data;
+}

--- a/modules/pages/client/components/FaqFoundation.component.js
+++ b/modules/pages/client/components/FaqFoundation.component.js
@@ -118,7 +118,7 @@ export default function FaqFoundation({ invitationsEnabled }) {
       <div className="faq-question" id="who-are-the-board">
         <h3>{t('Who are the board?')}</h3>
         <Trans t={t} ns="pages">
-          <a href="/team">We</a>: Mikael, Kasper, and Natalia.
+          <a href="/foundation#board">We</a>: Mikael, Kasper, and Natalia.
         </Trans>
       </div>
 

--- a/modules/pages/client/components/Foundation.component.js
+++ b/modules/pages/client/components/Foundation.component.js
@@ -1,8 +1,11 @@
+// External dependencies
+import { Trans, useTranslation } from 'react-i18next';
 import React from 'react';
+
+// Internal dependencies`
 import { userType } from '@/modules/users/client/users.prop-types';
-import ManifestoText from './ManifestoText.component.js';
 import Board from '@/modules/core/client/components/Board.js';
-import { useTranslation } from 'react-i18next';
+import ManifestoText from './ManifestoText.component.js';
 
 export default function Foundation({ user }) {
   const { t } = useTranslation('pages');
@@ -46,9 +49,6 @@ export default function Foundation({ user }) {
                 <small className="text-muted">(pdf)</small>
               </li>
               <li>
-                <a href="/team">{t('Board')}</a>
-              </li>
-              <li>
                 <a href="/faq/foundation">{t('FAQ')}</a>
               </li>
               <li>
@@ -58,22 +58,243 @@ export default function Foundation({ user }) {
                 <small className="text-muted">{t('(March, 2015)')}</small>
               </li>
               <li>
-                <a href="/donate">{t('Donate')}</a>
-              </li>
-              <li>
                 <a href="/support">{t('Contact us')}</a>
               </li>
               <li>
                 <a href="/volunteering">{t('Volunteering')}</a>
               </li>
             </ul>
-            <br />
-            <br />
           </div>
         </div>
         {/* /.row */}
       </section>
       {/* /.container */}
+
+      {/* Board */}
+      <section className="container container-spacer">
+        <hr />
+
+        <div className="row">
+          <div className="col-xs-12 col-sm-8 col-sm-offset-2 col-md-6 col-md-offset-3 text-center">
+            <h2 id="board">{t('Board')}</h2>
+            <p>
+              <Trans t={t} ns="pages">
+                We are a group of hospitality exchange enthusiasts with
+                backgrounds in some notable projects. The same people who also
+                brought you <a href="https://hitchwiki.org/">Hitchwiki</a>,{' '}
+                <a href="https://trashwiki.org/">Trashwiki</a>,{' '}
+                <a href="https://nomadwihki.org/">Nomadwiki</a> &amp; more.
+              </Trans>
+            </p>
+            <p>
+              {t(
+                'All current board members are also members of the founding team. We will have non-founding members in the board at some point.',
+              )}
+            </p>
+            <br />
+            <br />
+          </div>
+        </div>
+        <div className="row">
+          <div className="col-xs-12 col-sm-4">
+            {/* Mikael */}
+            <div className="media">
+              <a className="pull-left" href="https://mikaelkorpela.fi/">
+                <img
+                  className="media-object img-circle"
+                  src={`/api/users/544b7832f1bf94f007de9fe0/avatar?size=512`}
+                  width="100"
+                  alt="Mikael"
+                />
+              </a>
+              <div className="media-body">
+                <h4 className="media-heading">Mikael</h4>
+                <p className="text-color-links">
+                  <Trans t={t} ns="pages">
+                    Working on big freegan/travel projects such as{' '}
+                    <a href="https://hitchwiki.org/">Hitchwiki</a>,{' '}
+                    <a href="http://hitchgathering.org/">
+                      Hitchgathering festival
+                    </a>
+                    , <a href="https://trashwiki.org/">Trashwiki</a> and{' '}
+                    <a href="https://nomadwiki.org/">Nomadwiki</a> since 2008.
+                    In the past has volunteered for BeWelcome (2013). Active
+                    open source contributor and visionary free/gift-economics
+                    activist. A developer at{' '}
+                    <a href="https://automattic.com/">Automattic</a>.
+                  </Trans>
+                </p>
+                <p>
+                  <ul className="list-inline">
+                    <li>
+                      <a href="https://www.mikaelkorpela.fi/">
+                        mikaelkorpela.fi
+                      </a>
+                    </li>
+                    <li>
+                      <a href="/profile/mikael">Trustroots profile</a>
+                    </li>
+                  </ul>
+                </p>
+              </div>
+            </div>
+            <br />
+            <br />
+          </div>
+          <div className="col-xs-12 col-sm-4">
+            {/* Natalia */}
+            <div className="media">
+              <img
+                className="media-object img-circle pull-left"
+                src={`/api/users/549806aa484045191404ad0b/avatar?size=512`}
+                width="100"
+                alt="Natalia"
+              />
+              <div className="media-body">
+                <h4 className="media-heading">Natalia</h4>
+                <p className="text-color-links">
+                  {t(
+                    'Coming from a multinational business background, Natalia is an enthusiastic of the share and gift economy. Veteran globetrotter and volunteer for different NGOs from hospex as Couchsurfing to nonprofit lobbying orgs.',
+                  )}
+                </p>
+                <p>
+                  <ul className="list-inline">
+                    <li>
+                      <a href="https://www.linkedin.com/in/natalia-s%C3%A1enz-alban%C3%A9s-38469227/">
+                        LinkedIn
+                      </a>
+                    </li>
+                    <li>
+                      <a href="/profile/natalia_sevilla">Trustroots profile</a>
+                    </li>
+                  </ul>
+                </p>
+              </div>
+            </div>
+          </div>
+          <div className="col-xs-12 col-sm-4">
+            {/* Kasper */}
+            <div className="media">
+              <a className="pull-left" href="https://guaka.org/">
+                <img
+                  className="media-object img-circle"
+                  src={`/api/users/546dbde4b90879c125849c0c/avatar?size=512`}
+                  width="100"
+                  alt="Kasper"
+                />
+              </a>
+              <div className="media-body">
+                <h4 className="media-heading">Kasper</h4>
+                <p className="text-color-links">
+                  <Trans t={t} ns="pages">
+                    Founded multiple popular and trusted websites such as{' '}
+                    <a href="https://hitchwiki.org/">Hitchwiki</a>,{' '}
+                    <a href="https://trashwiki.org/">Trashwiki</a>,{' '}
+                    <a href="https://nomadwiki.org/">Nomadwiki</a>,{' '}
+                    <a href="https://couchwiki.org/">Couchwiki</a> and{' '}
+                    <a href="https://deletionpedia.org/">Deletionpedia</a>.{' '}
+                    Volunteered for CouchSurfing as a tech team coordinator in
+                    2006 and 2007 and for{' '}
+                    <a href="https://www.bewelcome.org/">BeWelcome</a> since
+                    2007. Loves paradoxes, makes money with{' '}
+                    <a href="https://moneyless.org/">moneyless.org</a>.
+                  </Trans>
+                </p>
+                <p>
+                  <ul className="list-inline">
+                    <li>
+                      <a href="https://guaka.org/">guaka.org</a>
+                    </li>
+                    <li>
+                      <a href="/profile/guaka">Trustroots profile</a>
+                    </li>
+                  </ul>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <hr />
+
+        <div className="row">
+          <div className="col-xs-12 col-sm-8 col-sm-offset-2 col-md-6 col-md-offset-3 text-center">
+            <h2>{t('Past board members')}</h2>
+            <p>{t('Callum and Carlos were also part of the founding team.')}</p>
+            <br />
+            <br />
+          </div>
+        </div>
+
+        <div className="row">
+          <div className="col-xs-12 col-sm-4 col-sm-offset-2">
+            {/* Callum */}
+            <div className="media">
+              <a className="pull-left" href="https://www.callum-macdonald.com/">
+                <img
+                  className="media-object img-circle"
+                  src={`/api/users/54a13db94f09e7192a46c548/avatar?size=512`}
+                  width="100"
+                  alt=""
+                />
+              </a>
+              <div className="media-body">
+                <h4 className="media-heading">Callum</h4>
+                <p className="text-color-links">
+                  {t(
+                    'Long term nomad and technology expert. Volunteered for BeWelcome BoD in 2013 and for CouchSurfing in 2007.',
+                  )}
+                </p>
+                <p>
+                  <ul className="list-inline">
+                    <li>
+                      <a href="https://www.callum-macdonald.com/">
+                        callum-macdonald.com
+                      </a>
+                    </li>
+                    <li>
+                      <a href="/profile/chmac">Trustroots profile</a>
+                    </li>
+                  </ul>
+                </p>
+              </div>
+            </div>
+          </div>
+          <div className="col-xs-12 col-sm-4">
+            {/* Carlos */}
+            <div className="media">
+              <img
+                className="media-object img-circle pull-left"
+                src={`/api/users/54997f0681f11598701b7e4a/avatar?size=512`}
+                width="100"
+                alt="Carlos"
+              />
+              <div className="media-body">
+                <h4 className="media-heading">Carlos</h4>
+                <p className="text-color-links">
+                  {t(
+                    'Love to travel, passionate and enthusiastic about share economy and hospitality exchange as human development tools. Volunteered CouchSurfing from 2008 to 2010 as well as other NGOs.',
+                  )}
+                </p>
+                <p>
+                  <ul className="list-inline">
+                    <li>
+                      <a href="https://www.linkedin.com/in/carlosmcardenas/">
+                        LinkedIn
+                      </a>
+                    </li>
+                    <li>
+                      <a href="/profile/carlos">Trustroots profile</a>
+                    </li>
+                  </ul>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <hr />
+      </section>
 
       <section className="vision-footer">
         <div className="container">

--- a/modules/pages/client/components/Team.component.js
+++ b/modules/pages/client/components/Team.component.js
@@ -1,488 +1,178 @@
-import React from 'react';
-import Tooltip from '@/modules/core/client/components/Tooltip.js';
-import { Trans, useTranslation } from 'react-i18next';
+// External dependencies
+import { useTranslation } from 'react-i18next';
+import React, { useState, useEffect } from 'react';
 
-export default function Team() {
+// Internal dependencies
+import { getVolunteers } from '../api/volunteers.api';
+import { userType } from '@/modules/users/client/users.prop-types';
+import Board from '@/modules/core/client/components/Board.js';
+import ManifestoText from './ManifestoText.component.js';
+import LoadingIndicator from '@/modules/core/client/components/LoadingIndicator';
+
+export default function Team({ user }) {
   const { t } = useTranslation('pages');
+  const [isFetching, setIsFetching] = useState(false);
+  const [volunteers, setVolunteers] = useState([]);
+
+  async function fetchVolunteers() {
+    setIsFetching(true);
+    try {
+      const volunteers = await getVolunteers();
+      setVolunteers(volunteers);
+    } finally {
+      setIsFetching(false);
+    }
+  }
+
+  useEffect(() => {
+    fetchVolunteers();
+  }, []);
 
   return (
-    <section className="container container-spacer">
-      {/* Intro */}
-      <div className="row">
-        <div className="col-xs-12 col-sm-6 col-sm-offset-3 col-md-4 col-md-offset-4 text-center">
-          <img
-            className="hidden-xs"
-            src="/img/tree-color.svg"
-            alt="Trustroots"
-            width="120"
-            height="120"
-          />
-          <br />
-          <br />
-          <h1>{t('Trustroots Teams')}</h1>
-          <p className="lead">
-            <em>
-              {t(
-                '“If you want to go fast, go alone. If you want to go far, go together.”',
-              )}
-            </em>
-          </p>
-          <small className="text-muted">{t('African proverb')}</small>
-          <hr />
+    <>
+      <section className="container container-spacer">
+        {/* Intro */}
+        <div className="row">
+          <div className="col-xs-12 col-sm-6 col-sm-offset-3 col-md-4 col-md-offset-4 text-center">
+            <img
+              alt="Trustroots"
+              className="hidden-xs"
+              height="120"
+              src="/img/tree-color.svg"
+              width="120"
+            />
+            <br />
+            <br />
+            <h1>{t('Trustroots Team')}</h1>
+            <br />
+            <p className="lead">
+              <em>
+                {t(
+                  '“If you want to go fast, go alone. If you want to go far, go together.”',
+                )}
+              </em>
+            </p>
+            <small className="text-muted">{t('African proverb')}</small>
+            <hr />
+          </div>
         </div>
-      </div>
 
-      {/* Volunteers */}
-      <div className="row text-center" id="volunteering">
-        <div className="col-xs-12 col-sm-8 col-sm-offset-2 col-md-6 col-md-offset-3">
-          <br />
-          <br />
-          <h2>{t('Volunteering')}</h2>
-          <br />
-          <br />
-          <p>
-            <em className="lead">
-              {t('Help us build Trustroots!')}
+        <div className="row">
+          <div className="col-xs-12">
+            <div className="team-volunteers">
+              {isFetching && <LoadingIndicator />}
+              {volunteers.length > 0 &&
+                volunteers.map(({ _id, username, displayName }) => (
+                  <div className="team-volunteer" key={_id}>
+                    <a href={`/profile/${username}`}>
+                      <img
+                        className="img-circle"
+                        src={`/api/users/${_id}/avatar?size=512`}
+                        width="100"
+                        alt={displayName}
+                      />
+                      <h4 className="media-heading">{displayName}</h4>
+                    </a>
+                  </div>
+                ))}
+            </div>
+          </div>
+        </div>
+        <hr />
+        <div className="row">
+          <div className="col-xs-12 text-center">
+            <h2>{t('Help us build Trustroots!')}</h2>
+            <p className="lead">
+              <em>
+                <br />
+                {t('Nobody can do everything, but everyone can do something.')}
+              </em>
+            </p>
+            <p>
+              <a
+                className="btn btn-lg btn-primary"
+                href="https://team.trustroots.org/Volunteering.html"
+              >
+                {t('Get active!')}
+              </a>
               <br />
-              {t('Nobody can do everything, but everyone can do something.')}
-            </em>
-          </p>
-          <p>
-            <a href="https://team.trustroots.org/Volunteering.html">
-              {t('Get active!')}
-            </a>
-          </p>
-        </div>
-      </div>
-
-      <hr />
-
-      {/* Board */}
-      <div className="row">
-        <div className="col-xs-12 col-sm-8 col-sm-offset-2 col-md-6 col-md-offset-3 text-center">
-          <h2 id="board">{t('Board')}</h2>
-          <h5>
-            <a href="/foundation" className="text-uppercase">
-              {t('Trustroots Foundation')}
-            </a>
-          </h5>
-          <p>
-            <Trans t={t} ns="pages">
-              We are a group of hospitality exchange enthusiasts with
-              backgrounds in some notable projects. The same people who also
-              brought you <a href="http://hitchwiki.org/">Hitchwiki</a>,{' '}
-              <a href="http://trashwiki.org/">Trashwiki</a>,{' '}
-              <a href="http://nomadwihki.org/">Nomadwiki</a> &amp; more.
-            </Trans>
-          </p>
-          <p>
-            {t(
-              'All current board members are also members of the founding team. We will have non-founding members in the board at some point.',
-            )}
-          </p>
-          <br />
-          <br />
-        </div>
-      </div>
-      <div className="row">
-        <div className="col-xs-12 col-sm-4">
-          {/* Mikael */}
-          <div className="media">
-            <a className="pull-left" href="http://www.mikaelkorpela.fi/">
-              <img
-                className="media-object img-circle"
-                src="//gravatar.com/avatar/d0229f23745d3c266f81c6b0cd014a38?s=200"
-                width="100"
-                alt="Mikael"
-              />
-            </a>
-            <div className="media-body">
-              <h4 className="media-heading">Mikael</h4>
-              <p className="text-color-links">
-                <Trans t={t} ns="pages">
-                  Working on big freegan/travel projects such as{' '}
-                  <a href="http://hitchwiki.org/">Hitchwiki</a>,{' '}
-                  <a href="http://hitchgathering.org/">
-                    Hitchgathering festival
-                  </a>
-                  , <a href="http://trashwiki.org/">Trashwiki</a> and{' '}
-                  <a href="http://nomadwiki.org/">Nomadwiki</a> since 2008. In
-                  the past has volunteered for BeWelcome (2013). Active open
-                  source contributor and visionary free/gift-economics activist.
-                  A developer at{' '}
-                  <a href="https://automattic.com/">Automattic</a>.
-                </Trans>
-              </p>
-              <p>
-                <a href="https://www.mikaelkorpela.fi/" className="text-muted">
-                  mikaelkorpela.fi
-                </a>{' '}
-                <Tooltip
-                  id="trustroot-tooltip"
-                  tooltip="Trustroots"
-                  placement="bottom"
-                >
-                  <a href="/profile/mikael">
-                    <i className="text-muted icon-fw icon-lg icon-tree"></i>{' '}
-                  </a>
-                </Tooltip>
-                <Tooltip
-                  id="twitter-tooltip"
-                  tooltip="Twitter"
-                  placement="bottom"
-                >
-                  <a href="https://twitter.com/simison">
-                    <i className="text-muted icon-fw icon-lg icon-twitter"></i>{' '}
-                  </a>
-                </Tooltip>
-                <Tooltip
-                  id="github-tooltip"
-                  tooltip="GitHub"
-                  placement="bottom"
-                >
-                  <a href="https://github.com/simison">
-                    <i className="text-muted icon-fw icon-lg icon-github"></i>{' '}
-                  </a>
-                </Tooltip>
-                <Tooltip
-                  id="linkedin-tooltip"
-                  tooltip="LinkedIn"
-                  placement="bottom"
-                >
-                  <a href="https://www.linkedin.com/in/mikaelkorpela">
-                    <i className="text-muted icon-fw icon-lg icon-linkedin"></i>{' '}
-                  </a>
-                </Tooltip>
-              </p>
-            </div>
+              <br />
+            </p>
           </div>
-          <br />
-          <br />
         </div>
-        <div className="col-xs-12 col-sm-4">
-          {/* Natalia */}
-          <div className="media">
-            <img
-              className="media-object img-circle pull-left"
-              src="/img/team-natalia.jpg"
-              width="100"
-              alt="Natalia"
-            />
-            <div className="media-body">
-              <h4 className="media-heading">Natalia</h4>
-              <p className="text-color-links">
-                {t(
-                  'Coming from a multinational business background, Natalia is an enthusiastic of the share and gift economy. Veteran globetrotter and volunteer for different NGOs from hospex as Couchsurfing to nonprofit lobbying orgs.',
-                )}
-              </p>
-              <p>
-                <Tooltip
-                  id="trustroot-tooltip"
-                  tooltip="Trustroots"
-                  placement="bottom"
-                >
-                  <a href="/profile/natalia_sevilla">
-                    <i className="text-muted icon-fw icon-lg icon-tree"></i>{' '}
+      </section>
+
+      <Board
+        className="board-primary board-inset"
+        names="jungleroad"
+        id="manifesto"
+      >
+        <div className="container">
+          <div className="row">
+            <div className="col-md-offset-3 col-md-6 text-center lead font-brand-light">
+              <ManifestoText></ManifestoText>
+              {!user && (
+                <p>
+                  <br />
+                  <br />
+                  <a
+                    href="/signup"
+                    className="btn btn-lg btn-action btn-inverse"
+                  >
+                    {t('Join Trustroots')}
                   </a>
-                </Tooltip>
-                <Tooltip
-                  id="linkedin-tooltip"
-                  tooltip="LinkedIn"
-                  placement="bottom"
-                >
-                  <a href="https://www.linkedin.com/in/natalia-s%C3%A1enz-alban%C3%A9s-38469227/">
-                    <i className="text-muted icon-fw icon-lg icon-linkedin"></i>{' '}
-                  </a>
-                </Tooltip>
-              </p>
+                </p>
+              )}
             </div>
           </div>
         </div>
-        <div className="col-xs-12 col-sm-4">
-          {/* Kasper */}
-          <div className="media">
-            <a className="pull-left" href="https://guaka.org/">
-              <img
-                className="media-object img-circle"
-                src="//gravatar.com/avatar/edccc1f234833b3b5c266c18c2db139d?s=200"
-                width="100"
-                alt="Kasper"
-              />
-            </a>
-            <div className="media-body">
-              <h4 className="media-heading">Kasper</h4>
-              <p className="text-color-links">
-                <Trans t={t} ns="pages">
-                  Founded multiple popular and trusted websites such as{' '}
-                  <a href="http://hitchwiki.org/">Hitchwiki</a>,{' '}
-                  <a href="http://trashwiki.org/">Trashwiki</a>,{' '}
-                  <a href="http://nomadwiki.org/">Nomadwiki</a>,{' '}
-                  <a href="http://couchwiki.org/">Couchwiki</a> and{' '}
-                  <a href="http://deletionpedia.org/">Deletionpedia</a>.{' '}
-                  Volunteered for CouchSurfing as a tech team coordinator in
-                  2006 and 2007 and for{' '}
-                  <a href="https://www.bewelcome.org/">BeWelcome</a> since 2007.
-                  Loves paradoxes, makes money with{' '}
-                  <a href="https://moneyless.org/">moneyless.org</a>.
-                </Trans>
-              </p>
-              <p>
-                <Tooltip
-                  id="trustroot-tooltip"
-                  tooltip="Trustroots"
-                  placement="bottom"
-                >
-                  <a href="/profile/guaka">
-                    <i className="text-muted icon-fw icon-lg icon-tree"></i>{' '}
-                  </a>
-                </Tooltip>
-                <Tooltip
-                  id="github-tooltip"
-                  tooltip="GitHub"
-                  placement="bottom"
-                >
-                  <a href="https://github.com/guaka">
-                    <i className="text-muted icon-fw icon-lg icon-github"></i>{' '}
-                  </a>
-                </Tooltip>
-                <a href="https://guaka.org/" className="text-muted">
-                  guaka.org
-                </a>{' '}
-              </p>
+      </Board>
+
+      <section className="container container-spacer">
+        <div className="row">
+          <div className="col-xs-12 text-center">
+            <p className="text-muted">{t('Follow Trustroots')}</p>
+            <div className="btn-group">
+              <a
+                href="https://ideas.trustroots.org/"
+                className="btn btn-link btn-lg"
+              >
+                {t('Blog')}
+              </a>
+              <a
+                href="https://www.facebook.com/trustroots.org"
+                className="btn btn-link btn-lg"
+              >
+                {t('Facebook page')}
+              </a>
+              <a
+                href="https://www.facebook.com/groups/trustroots/"
+                className="btn btn-link btn-lg"
+              >
+                {t('Facebook group')}
+              </a>
+              <a
+                href="https://www.instagram.com/trustroots_org/"
+                className="btn btn-link btn-lg"
+              >
+                Twitter
+              </a>
+              <a
+                href="https://twitter.com/trustroots"
+                className="btn btn-link btn-lg"
+              >
+                Instagram
+              </a>
             </div>
+            <br />
+            <br />
           </div>
         </div>
-      </div>
-
-      <hr />
-
-      {/* Support team */}
-      <div className="row" id="support-team">
-        <div className="col-xs-12 col-sm-8 col-sm-offset-2 col-md-6 col-md-offset-3 text-center">
-          <h2 id="board">{t('Support team')}</h2>
-          <br />
-          <br />
-        </div>
-      </div>
-      <div className="row">
-        <div className="col-xs-12 col-sm-4 col-sm-offset-2">
-          {/* Noah */}
-          <div className="media">
-            <img
-              className="media-object img-circle pull-left"
-              src="/img/team-noah.jpg"
-              width="100"
-              alt="Noah"
-            />
-            <div className="media-body">
-              <h4 className="media-heading">Noah</h4>
-              <p className="text-color-links">
-                {t(
-                  'Focussed on community building. Technical know-how in various fields. Likes to create safe spaces everywhere around the world, digital and analog ones.',
-                )}
-              </p>
-              <p>
-                <Tooltip
-                  id="trustroot-tooltip"
-                  tooltip="Trustroots"
-                  placement="bottom"
-                >
-                  <a href="/profile/noah_my_noah">
-                    <i className="text-muted icon-fw icon-lg icon-tree"></i>{' '}
-                  </a>
-                </Tooltip>
-              </p>
-            </div>
-          </div>
-        </div>
-        <div className="col-xs-12 col-sm-4">
-          {/* Dario */}
-          <div className="media">
-            <img
-              className="media-object img-circle pull-left"
-              src="/img/team-dario.jpg"
-              width="100"
-              alt="Dario"
-            />
-            <div className="media-body">
-              <h4 className="media-heading">Dario</h4>
-              <p className="text-color-links">
-                {t(
-                  'Likes to contribute to projects empowering people, putting them in control of their own resources. Currently reeducating himself to work as a software developer.',
-                )}
-              </p>
-              <p>
-                <Tooltip
-                  id="trustroot-tooltip"
-                  tooltip="Trustroots"
-                  placement="bottom"
-                >
-                  <a href="/profile/rumwerfer">
-                    <i className="text-muted icon-fw icon-lg icon-tree"></i>{' '}
-                  </a>
-                </Tooltip>
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <hr />
-
-      <div className="row">
-        <div className="col-xs-12 col-sm-8 col-sm-offset-2 col-md-6 col-md-offset-3 text-center">
-          <h2>{t('Initial Co-Founders')}</h2>
-          <p>{t('Callum and Carlos were also part of the founding team.')}</p>
-          <br />
-          <br />
-        </div>
-      </div>
-
-      <div className="row">
-        <div className="col-xs-12 col-sm-4 col-sm-offset-2">
-          {/* Callum */}
-          <div className="media">
-            <a className="pull-left" href="https://www.callum-macdonald.com/">
-              <img
-                className="media-object img-circle"
-                src="//gravatar.com/avatar/1e2eebc68bae7e891391688ad1c331d1?s=100"
-                width="100"
-                alt=""
-              />
-            </a>
-            <div className="media-body">
-              <h4 className="media-heading">Callum</h4>
-              <p className="text-color-links">
-                {t(
-                  'Long term nomad and technology expert. Volunteered for BeWelcome BoD in 2013 and for CouchSurfing in 2007.',
-                )}
-              </p>
-              <p>
-                <a
-                  href="https://www.callum-macdonald.com/"
-                  className="text-muted"
-                >
-                  callum-macdonald.com
-                </a>{' '}
-                <Tooltip
-                  id="trustroot-tooltip"
-                  tooltip="Trustroots"
-                  placement="bottom"
-                >
-                  <a href="/profile/chmac">
-                    <i className="text-muted icon-fw icon-lg icon-tree"></i>{' '}
-                  </a>
-                </Tooltip>
-                <Tooltip
-                  id="twitter-tooltip"
-                  tooltip="Twitter"
-                  placement="bottom"
-                >
-                  <a href="https://twitter.com/chmac">
-                    <i className="text-muted icon-fw icon-lg icon-twitter"></i>{' '}
-                  </a>
-                </Tooltip>
-                <Tooltip
-                  id="github-tooltip"
-                  tooltip="GitHub"
-                  placement="bottom"
-                >
-                  <a href="https://github.com/chmac">
-                    <i className="text-muted icon-fw icon-lg icon-github"></i>{' '}
-                  </a>
-                </Tooltip>
-                <Tooltip
-                  id="linkedin-tooltip"
-                  tooltip="LinkedIn"
-                  placement="bottom"
-                >
-                  <a href="https://www.linkedin.com/in/chmac">
-                    <i className="text-muted icon-fw icon-lg icon-linkedin"></i>{' '}
-                  </a>
-                </Tooltip>
-              </p>
-            </div>
-          </div>
-        </div>
-        <div className="col-xs-12 col-sm-4">
-          {/* Carlos */}
-          <div className="media">
-            <img
-              className="media-object img-circle pull-left"
-              src="/img/team-carlos.jpg"
-              width="100"
-              alt="Carlos"
-            />
-            <div className="media-body">
-              <h4 className="media-heading">Carlos</h4>
-              <p className="text-color-links">
-                {t(
-                  'Love to travel, passionate and enthusiastic about share economy and hospitality exchange as human development tools. Volunteered CouchSurfing from 2008 to 2010 as well as other NGOs.',
-                )}
-              </p>
-              <p>
-                <Tooltip
-                  id="trustroot-tooltip"
-                  tooltip="Trustroots"
-                  placement="bottom"
-                >
-                  <a href="/profile/carlos">
-                    <i className="text-muted icon-fw icon-lg icon-tree"></i>{' '}
-                  </a>
-                </Tooltip>
-                <Tooltip
-                  id="linkedin-tooltip"
-                  tooltip="LinkedIn"
-                  placement="bottom"
-                >
-                  <a href="https://www.linkedin.com/in/carlosmcardenas/">
-                    <i className="text-muted icon-fw icon-lg icon-linkedin"></i>{' '}
-                  </a>
-                </Tooltip>
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div className="row">
-        <div className="col-xs-12 text-center">
-          <hr />
-          <br />
-          <br />
-          <p className="text-muted">{t('Follow Trustroots')}</p>
-          <div className="btn-group">
-            <a
-              href="https://ideas.trustroots.org/"
-              className="btn btn-link btn-lg"
-            >
-              {t('Blog')}
-            </a>
-            <a
-              href="https://www.facebook.com/trustroots.org"
-              className="btn btn-link btn-lg"
-            >
-              {t('Facebook page')}
-            </a>
-            <a
-              href="https://www.facebook.com/groups/trustroots/"
-              className="btn btn-link btn-lg"
-            >
-              {t('Facebook group')}
-            </a>
-            <a
-              href="https://twitter.com/trustroots"
-              className="btn btn-link btn-lg"
-            >
-              Twitter
-            </a>
-          </div>
-          <br />
-          <br />
-        </div>
-      </div>
-    </section>
+      </section>
+    </>
   );
 }
 
-Team.propTypes = {};
+Team.propTypes = {
+  user: userType,
+};

--- a/modules/pages/client/components/Team.component.js
+++ b/modules/pages/client/components/Team.component.js
@@ -1,5 +1,5 @@
 // External dependencies
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import React, { useState, useEffect } from 'react';
 
 // Internal dependencies
@@ -76,6 +76,12 @@ export default function Team({ user }) {
                   </div>
                 ))}
             </div>
+            <p className="text-center">
+              <Trans t={t} ns="pages">
+                <a href="/support">Contact support team</a> to get in touch with
+                us.
+              </Trans>
+            </p>
           </div>
         </div>
         <hr />

--- a/modules/pages/client/components/Volunteering.component.js
+++ b/modules/pages/client/components/Volunteering.component.js
@@ -45,7 +45,14 @@ export default function Volunteering() {
               )}
             </p>
             <p>
-              <a href="https://team.trustroots.org/">{t('Team Guide')}</a>
+              <ul className="list-inline">
+                <li>
+                  <a href="https://team.trustroots.org/">{t('Team Guide')}</a>
+                </li>
+                <li>
+                  <a href="/team">{t('Meet the team')}</a>
+                </li>
+              </ul>
             </p>
           </div>
         </div>

--- a/modules/pages/client/config/pages.client.routes.js
+++ b/modules/pages/client/config/pages.client.routes.js
@@ -28,7 +28,10 @@ function PagesRoutes($stateProvider) {
     })
     .state('team', {
       url: '/team',
-      template: '<team />',
+      template: `
+        <team
+          user="app.user"
+        />`,
       data: {
         pageTitle: 'Team',
       },

--- a/modules/pages/client/less/team.less
+++ b/modules/pages/client/less/team.less
@@ -1,0 +1,36 @@
+@import '~less/global-variables';
+
+.team-volunteers {
+  column-gap: 30px;
+  display: grid;
+  grid-template-columns: 1fr;
+  margin: 0 0 40px;
+  row-gap: 30px;
+
+  @media (min-width: @screen-xs-min) {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  @media (min-width: @screen-sm-min) {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+
+  @media (min-width: @screen-md-min) {
+    grid-template-columns: 1fr 1fr 1fr 1fr;
+  }
+
+  @media (min-width: @screen-lg-min) {
+    grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
+  }
+}
+
+.team-volunteer {
+  text-align: center;
+  align-self: center;
+  img {
+    margin: 20px;
+  }
+  a {
+    color: @text-color;
+  }
+}

--- a/modules/pages/server/controllers/pages.volunteers.server.controller.js
+++ b/modules/pages/server/controllers/pages.volunteers.server.controller.js
@@ -1,0 +1,34 @@
+/**
+ * Module dependencies.
+ */
+const path = require('path');
+const _ = require('lodash');
+const mongoose = require('mongoose');
+const errorService = require(path.resolve(
+  './modules/core/server/services/error.server.service',
+));
+
+const User = mongoose.model('User');
+
+/*
+ * This middleware sends response with an array of users with volunteer role
+ */
+exports.list = (req, res) => {
+  const VOLUNTEER_LIST_FIELDS = ['username', 'displayName'].join(' ');
+
+  User.find({
+    roles: { $in: ['volunteer'] },
+  })
+    .select(VOLUNTEER_LIST_FIELDS)
+    .sort('username displayName volunteerStory')
+    .limit(1000)
+    .exec((err, users) => {
+      if (err) {
+        return res.status(400).send({
+          message: errorService.getErrorMessage(err),
+        });
+      }
+
+      res.send(_.shuffle(users || []));
+    });
+};

--- a/modules/pages/server/routes/admin.server.routes.js
+++ b/modules/pages/server/routes/admin.server.routes.js
@@ -1,0 +1,8 @@
+/**
+ * Module dependencies.
+ */
+const volunteers = require('../controllers/pages.volunteers.server.controller');
+
+module.exports = app => {
+  app.route('/api/volunteers').get(volunteers.list);
+};

--- a/modules/users/server/models/user.server.model.js
+++ b/modules/users/server/models/user.server.model.js
@@ -242,7 +242,14 @@ const UserSchema = new Schema({
     type: [
       {
         type: String,
-        enum: ['user', 'admin', 'suspended', 'shadowban', 'moderator'],
+        enum: [
+          'admin',
+          'moderator',
+          'shadowban',
+          'suspended',
+          'user',
+          'volunteer',
+        ],
       },
     ],
     default: ['user'],


### PR DESCRIPTION
### Proposed Changes

* Adds new `volunteer` role
* Adds API which returns everyone in `volunteer` role
* Lists said volunteers at `/team` page in random order: profile image, name, and link to TR profile
* Moves board members from `/team` page to `/foundation` page
* Small adjustments to links and language here and there
* Pulls images from Trustroots instead of using gravatar/stored image files; that's why in screenshots board images are gone; they'll work at the actual site then.
* I'll leave static images in the folder for now and we can clean them up a bit later until they no longer are in search engine memories and such.


### Testing Instructions

* Open `/foundation` and `/team` pages and observe it looks ok on desktop and mobile
* As an admin user, open user via `/admin` and grant them volunteer role

**Current live pages:**
- https://www.trustroots.org/team
- https://www.trustroots.org/foundation

**Here are screenshots of changes:**

### Team page before
![old-team-page](https://user-images.githubusercontent.com/87168/89327399-8ac6a700-d694-11ea-93b8-cf4e77207df5.png)

### Team page after
![new-team-page](https://user-images.githubusercontent.com/87168/89327289-5f43bc80-d694-11ea-9a40-364ca65a6439.png)

### Foundation page before
![old-foundation-page](https://user-images.githubusercontent.com/87168/89327420-91edb500-d694-11ea-8c1f-cf61c3f10f20.png)

### Foundation page after
![new-foundation-page](https://user-images.githubusercontent.com/87168/89327271-581cae80-d694-11ea-9931-9e934b71da56.png)
