### PR TITLE
Messages: don't attempt to read unread notification count as unconfirmed user

### DIFF
--- a/modules/messages/client/services/unread-message-count.client.service.js
+++ b/modules/messages/client/services/unread-message-count.client.service.js
@@ -102,7 +102,7 @@ function setPollingInterval(interval) {
 
 export async function update() {
   const user = getUser();
-  if (!user) return;
+  if (!user || !user.public) return;
   const newCount = await unreadCount();
   if (newCount === count) return;
   count = newCount;


### PR DESCRIPTION
This error was flooding logs in Sentry.io. :-) 13K of this there 💥 

#### Proposed Changes

* don't attempt to read unread notification count as an unconfirmed user

#### Testing Instructions

Create new account, you'll see:

<img width="601" alt="Screenshot 2020-08-07 at 23 22 47" src="https://user-images.githubusercontent.com/87168/89685436-0595f900-d905-11ea-9eb4-33c49458e33f.png">

I could add error catching to this API but the problem also is that we even try to read it just to get 403 error.