### PR TITLE
Signup: warn about used email

### DIFF
--- a/modules/users/client/controllers/signup.client.controller.js
+++ b/modules/users/client/controllers/signup.client.controller.js
@@ -37,6 +37,7 @@ function SignupController(
   vm.credentials = {};
   vm.step = 1;
   vm.isLoading = false;
+  vm.isEmailTaken = false;
   vm.submitSignup = submitSignup;
   vm.getUsernameValidationError = getUsernameValidationError;
   vm.openRules = openRules;
@@ -174,6 +175,7 @@ function SignupController(
    */
   function submitSignup() {
     vm.isLoading = true;
+    vm.isEmailTaken = false;
 
     $http.post('/api/auth/signup', vm.credentials).then(
       function (newUser) {
@@ -201,11 +203,18 @@ function SignupController(
       function (error) {
         // On error function
         vm.isLoading = false;
-        const errorMessage =
-          error.data && error.data.message
-            ? error.data.message
-            : 'Something went wrong while signing you up. Try again!';
-        messageCenterService.add('danger', errorMessage);
+
+        const message =
+          error?.data?.message ??
+          'Something went wrong while signing you up. Try again!';
+
+        // Handle emaail errors
+        if (message === 'Account with this email exists already.') {
+          vm.isEmailTaken = true;
+          return;
+        }
+
+        messageCenterService.add('danger', message);
       },
     );
   }

--- a/modules/users/client/views/authentication/signup.client.view.html
+++ b/modules/users/client/views/authentication/signup.client.view.html
@@ -105,6 +105,38 @@
           </div>
           <div
             class="form-group"
+            ng-class="{'has-error': userForm.email.$invalid && userForm.email.$dirty}"
+          >
+            <label for="email" class="col-sm-4 control-label">Email</label>
+            <div class="col-sm-8">
+              <input
+                type="email"
+                required
+                mailcheck
+                id="email"
+                name="email"
+                class="form-control input-lg"
+                ng-model="signup.credentials.email"
+                ng-disabled="signup.isLoading"
+                ng-change="signup.isEmailTaken = false"
+                uib-tooltip="{{ (userForm.email.$error.email && userForm.email.$dirty) ? 'Please give a valid email.' : ''}}"
+                tooltip-trigger="blur"
+                tooltip-placement="top"
+              />
+              <div
+                class="alert alert-danger"
+                role="alert"
+                ng-if="signup.isEmailTaken"
+              >
+                Account with this email exists already.
+                <a ui-sref="forgot({ userhandle: signup.credentials.email })"
+                  >Try recover password?</a
+                >
+              </div>
+            </div>
+          </div>
+          <div
+            class="form-group"
             ng-class="{'has-error': userForm.username.$invalid && userForm.username.$dirty}"
           >
             <label for="username" class="col-sm-4 control-label"
@@ -131,29 +163,6 @@
                 tooltip-trigger="'none'"
                 tooltip-placement="top"
               />
-            </div>
-          </div>
-          <div
-            class="form-group"
-            ng-class="{'has-error': userForm.email.$invalid && userForm.email.$dirty}"
-          >
-            <label for="email" class="col-sm-4 control-label">Email</label>
-            <div class="col-sm-8">
-              <input
-                type="email"
-                required
-                mailcheck
-                id="email"
-                name="email"
-                class="form-control input-lg"
-                ng-model="signup.credentials.email"
-                ng-disabled="signup.isLoading"
-                uib-tooltip="{{ (userForm.email.$error.email && userForm.email.$dirty) ? 'Please give a valid email.' : ''}}"
-                tooltip-trigger="blur"
-                tooltip-placement="top"
-              />
-              <!-- Temporarily disabled due isolate scope errors with mailcheck:
-                     tr-focustip="'We will not reveal this to anyone.'"> -->
             </div>
           </div>
           <div
@@ -194,35 +203,12 @@
                         'icon-eye': !showPassword,
                         'icon-eye-off': showPassword
                       }"
+                      uib-tooltip="{{ showPassword ? 'Hide password.' : 'Show password.'}}"
+                      tooltip-placement="top"
                     ></i>
                   </a>
                 </span>
               </div>
-            </div>
-          </div>
-          <div
-            class="form-group"
-            ng-class="{'has-error': userForm.password.$invalid && userForm.password.$dirty}"
-          >
-            <label for="verifyPassword" class="col-sm-4 control-label"
-              >Repeat password</label
-            >
-            <div class="col-sm-8">
-              <input
-                required
-                id="verifyPassword"
-                name="verifyPassword"
-                class="form-control input-lg"
-                tr-confirm-password="signup.credentials.password"
-                tooltip-is-open="!userForm.verifyPassword.$pending && userForm.verifyPassword.$dirty && !userForm.verifyPassword.$valid"
-                uib-tooltip="Passwords don't match."
-                tooltip-popup-delay="500"
-                tooltip-trigger="'none'"
-                tooltip-placement="top"
-                ng-attr-type="{{ showPassword ? 'text' : 'password' }}"
-                ng-model="verifyPassword"
-                ng-disabled="signup.isLoading"
-              />
             </div>
           </div>
           <div class="form-group checkbox">
@@ -464,7 +450,8 @@
         class="text-center col-xs-offset-2 col-xs-8 col-md-offset-4 col-md-4"
       >
         <br /><br />
-        <a ui-sref="signin" class="btn btn-link">Login</a>
+        Already have an account?
+        <a ui-sref="signin">Login</a>
         <br /><br />
         <p class="visible-xs-block">
           <a ui-sref="home" class="btn btn-link">About Trustroots</a>

--- a/modules/users/server/models/user.server.model.js
+++ b/modules/users/server/models/user.server.model.js
@@ -117,13 +117,16 @@ const UserSchema = new Schema({
   firstName: {
     type: String,
     required: true,
-    validate: [validateLocalStrategyProperty, 'Please fill in your first name'],
+    validate: [
+      validateLocalStrategyProperty,
+      'Please fill in your first name.',
+    ],
     set: setPlainTextField,
   },
   lastName: {
     type: String,
     required: true,
-    validate: [validateLocalStrategyProperty, 'Please fill in your last name'],
+    validate: [validateLocalStrategyProperty, 'Please fill in your last name.'],
     set: setPlainTextField,
   },
   /* This is generated in Schema pre-save hook below */
@@ -133,10 +136,13 @@ const UserSchema = new Schema({
   email: {
     type: String,
     trim: true,
-    unique: 'Email exists already.',
+    unique: 'Account with this email exists already.',
     lowercase: true,
     required: true,
-    validate: [validateLocalStrategyEmail, 'Please fill a valid email address'],
+    validate: [
+      validateLocalStrategyEmail,
+      'Please fill a valid email address.',
+    ],
   },
   /* New email is stored here until it is confirmed */
   emailTemporary: {
@@ -144,7 +150,7 @@ const UserSchema = new Schema({
     trim: true,
     lowercase: true,
     default: '',
-    match: [/.+@.+\..+/, 'Please enter a valid email address'],
+    match: [/.+@.+\..+/, 'Please enter a valid email address.'],
   },
   tagline: {
     type: String,


### PR DESCRIPTION
#### Proposed Changes

* Switch email / username fields another way around to emphasize email
* Remove duplicate password checked; there's the eye icon already, and password recovery works. Just less barriers for people.
* Show error under email form if the email is in use so that folks know to try password reset instead:
* Add "Hide password. / Show password." tooltip to eye toggle to make it more clear

<img width="527" alt="Screenshot 2020-08-07 at 23 39 31" src="https://user-images.githubusercontent.com/87168/89687118-45aaab00-d908-11ea-97ec-9fd66c403af9.png">


#### Testing Instructions

* Signup with an email
* Try signup again :-)