### PR TITLE
Signup: improved circles experience

### DIFF
--- a/modules/users/client/controllers/signup.client.controller.js
+++ b/modules/users/client/controllers/signup.client.controller.js
@@ -1,4 +1,5 @@
 import rulesModalTemplateUrl from '@/modules/users/client/views/authentication/rules-modal.client.view.html';
+import shuffle from 'lodash/shuffle';
 
 angular.module('users').controller('SignupController', SignupController);
 
@@ -143,7 +144,7 @@ function SignupController(
   function getSuggestedTribes(withoutTribeId) {
     TribesService.query(
       {
-        limit: 20,
+        limit: 40,
       },
       function (tribes) {
         const suggestedTribes = [];
@@ -152,7 +153,7 @@ function SignupController(
         // We'll always show 2 or 3 of these at the frontend depending on if referred tribe is shown.
         if (withoutTribeId) {
           angular.forEach(
-            tribes,
+            shuffle(tribes),
             function (suggestedTribe) {
               if (suggestedTribe._id !== withoutTribeId) {
                 // eslint-disable-next-line angular/controller-as-vm
@@ -163,7 +164,7 @@ function SignupController(
           );
           vm.suggestedTribes = suggestedTribes;
         } else {
-          vm.suggestedTribes = tribes;
+          vm.suggestedTribes = shuffle(tribes);
         }
       },
     );

--- a/modules/users/client/views/authentication/signup.client.view.html
+++ b/modules/users/client/views/authentication/signup.client.view.html
@@ -356,7 +356,12 @@
             class="lead text-center"
             ng-if="signup.suggestedTribes && signup.suggestedTribes.length && !tribe"
           >
-            Join these popular circles?
+            Do you want to join any Circles?
+          </p>
+          <p class="text-center">
+            Circles help you find likeminded members and tell others what you're
+            interested in. There's no need to join any, and if unsure you can
+            always join them later.
           </p>
 
           <ul
@@ -399,20 +404,16 @@
             </li>
           </ul>
 
-          <button
-            class="btn btn-default center-block"
-            ng-disabled="signup.suggestedTribesLimit >= signup.suggestedTribes.length"
-            ng-click="signup.suggestedTribesLimit = signup.suggestedTribesLimit + 3"
-          >
-            Show more circles
-          </button>
-
-          <br />
-
-          <p class="lead text-center">
-            Joining circles helps you find likeminded Trustroots members and
-            tells others what you're interested in.
-          </p>
+          <div class="text-center">
+            <button
+              class="btn btn-default center-block"
+              ng-disabled="signup.suggestedTribesLimit >= signup.suggestedTribes.length"
+              ng-click="signup.suggestedTribesLimit = signup.suggestedTribesLimit + 3"
+            >
+              Show more circles
+            </button>
+            <br />
+          </div>
 
           <div class="text-center form-group">
             <br /><br />
@@ -422,6 +423,13 @@
               ng-disabled="signup.isLoading"
             >
               Next
+            </button>
+            <button
+              class="btn btn-lg btn-default"
+              ng-click="signup.step = 3"
+              ng-disabled="signup.isLoading"
+            >
+              Skip
             </button>
             <br /><br />
           </div>
@@ -436,6 +444,8 @@
         <div
           class="col-xs-offset-2 col-xs-8 col-md-offset-4 col-md-4 text-center"
         >
+          <h3>Welcome to Trustroots!</h3>
+          <br />
           <p class="lead">
             We sent you an email to
             <strong ng-bind="::app.user.email"></strong> with further


### PR DESCRIPTION
#### Proposed Changes

* Add reassurance that circles are not mandatory
* Shuffle suggested circles to expose other ones, not just most popular ones
* Add "skip" button to help people pass this step if they aren't sure what to do
* Add a bit of celebration by adding "congrats!" once signup is done

#### Testing Instructions

* Signup, observe circles step:

### Before
<img width="678" alt="Screenshot 2020-08-08 at 00 06 35" src="https://user-images.githubusercontent.com/87168/89688541-15b0d700-d90b-11ea-839c-96ce9ee6b7db.png">

<img width="689" alt="Screenshot 2020-08-08 at 00 06 39" src="https://user-images.githubusercontent.com/87168/89688535-1184b980-d90b-11ea-82dd-bdc6a238b13f.png">


### After
<img width="783" alt="Screenshot 2020-08-07 at 23 57 48" src="https://user-images.githubusercontent.com/87168/89688435-d4b8c280-d90a-11ea-9053-08c72905db3c.png">

<img width="735" alt="Screenshot 2020-08-07 at 23 57 42" src="https://user-images.githubusercontent.com/87168/89688443-d8e4e000-d90a-11ea-8b7b-bbc82a5e5072.png">

