### PR TITLE
Hide the background image of the footer on the home page on small screens

### DIFF
--- a/modules/core/client/components/Board.js
+++ b/modules/core/client/components/Board.js
@@ -26,7 +26,7 @@ function selectName(names) {
  */
 export default function Board({
   names = 'bokeh',
-  ignoreSmall = false,
+  ignoreBackgroundOnSmallScreen = false,
   style = null,
   children,
   className,
@@ -60,7 +60,7 @@ export default function Board({
       : (style = { backgroundImage: `url("${photo.imageUrl}")` });
   }
   const addedClasses = ['board'];
-  if (ignoreSmall) {
+  if (ignoreBackgroundOnSmallScreen) {
     addedClasses.push('small-screen-bad-background');
   }
   return (
@@ -79,7 +79,7 @@ Board.propTypes = {
     PropTypes.string,
     PropTypes.arrayOf(PropTypes.string),
   ]).isRequired,
-  ignoreSmall: PropTypes.bool,
+  ignoreBackgroundOnSmallScreen: PropTypes.bool,
   style: PropTypes.object,
   className: PropTypes.string,
   children: PropTypes.node,

--- a/modules/core/client/components/Board.js
+++ b/modules/core/client/components/Board.js
@@ -21,12 +21,12 @@ function selectName(names) {
  * Partially migrated tr-boards directive
  * modules/core/client/directives/tr-boards.client.directive.js
  *
- * @TODO implement tr-boards-ignore-small directive
  * @TODO implement primary, inset, error and maybe other attributes, which are currently board classes
  *  and which could become attributes <Board primary inset error names="bokeh" />
  */
 export default function Board({
   names = 'bokeh',
+  ignoreSmall = false,
   style = null,
   children,
   className,
@@ -59,10 +59,14 @@ export default function Board({
       ? (style.backgroundImage = `url("${photo.imageUrl}")`)
       : (style = { backgroundImage: `url("${photo.imageUrl}")` });
   }
+  const addedClasses = ['board'];
+  if (ignoreSmall) {
+    addedClasses.push('small-screen-bad-background');
+  }
   return (
     <section
       style={{ ...style }}
-      className={classNames('board', className)}
+      className={classNames(addedClasses, className)}
       {...rest}
     >
       {children}
@@ -75,6 +79,7 @@ Board.propTypes = {
     PropTypes.string,
     PropTypes.arrayOf(PropTypes.string),
   ]).isRequired,
+  ignoreSmall: PropTypes.bool,
   style: PropTypes.object,
   className: PropTypes.string,
   children: PropTypes.node,

--- a/modules/core/client/less/layout/board.less
+++ b/modules/core/client/less/layout/board.less
@@ -95,6 +95,13 @@
     box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.3);
   }
 
+  &.small-screen-bad-background {
+    @media (max-width: @screen-sm-max) {
+      background-image: none !important;
+      box-shadow: none !important;
+    }
+  }
+
   .page-header {
     margin: 0;
     h1 {

--- a/modules/pages/client/components/Home.component.js
+++ b/modules/pages/client/components/Home.component.js
@@ -294,7 +294,11 @@ export default function Home({ user, isNativeMobileApp, photoCredits }) {
       </Board>
 
       {/* Footer */}
-      <Board className="board-primary board-inset home-footer" names="bokeh">
+      <Board
+        className="board-primary board-inset home-footer"
+        names="bokeh"
+        ignoreSmall={true}
+      >
         <div className="container">
           <div className="row">
             <div className="col-sm-6 col-md-3">

--- a/modules/pages/client/components/Home.component.js
+++ b/modules/pages/client/components/Home.component.js
@@ -297,7 +297,7 @@ export default function Home({ user, isNativeMobileApp, photoCredits }) {
       <Board
         className="board-primary board-inset home-footer"
         names="bokeh"
-        ignoreSmall={true}
+        ignoreBackgroundOnSmallScreen={true}
       >
         <div className="container">
           <div className="row">

--- a/modules/pages/client/components/Home.component.js
+++ b/modules/pages/client/components/Home.component.js
@@ -297,7 +297,7 @@ export default function Home({ user, isNativeMobileApp, photoCredits }) {
       <Board
         className="board-primary board-inset home-footer"
         names="bokeh"
-        ignoreBackgroundOnSmallScreen={true}
+        ignoreBackgroundOnSmallScreen
       >
         <div className="container">
           <div className="row">

--- a/modules/pages/client/less/home.less
+++ b/modules/pages/client/less/home.less
@@ -263,13 +263,6 @@
   background-position: 50% bottom;
   padding-top: 30px;
   text-shadow: none;
-  // Normally this background won't work well on small screens with white text, so we'll just hide it
-  &.board-bokeh {
-    @media (max-width: @screen-sm-max) {
-      background-image: none !important;
-      box-shadow: none;
-    }
-  }
   .boards-credits {
     display: block;
     padding: 30px;


### PR DESCRIPTION
#### Proposed Changes

Hide the background image of the footer on the home page on small devices: white text on such background is not readable.

#### Testing Instructions
Go to the home page on a mobile device and scroll down to the bottom. The should be no background:

<img src="https://user-images.githubusercontent.com/2955794/89957095-e1088c80-dc36-11ea-92d9-1f275e1e2c38.png" height="400px" width="250px"/>

On desktop version, the background should be present:

<img src="https://user-images.githubusercontent.com/2955794/89957476-cedb1e00-dc37-11ea-85eb-2f652b98a4b9.png" height="250px" width="400px"/>



