### PR TITLE
contacts_plural was in the string

### DIFF
--- a/public/locales/en/contacts.json
+++ b/public/locales/en/contacts.json
@@ -24,5 +24,5 @@
   "{{count}} contacts": "{{count}} contacts",
   "{{count}} contacts in common": "One contact in common",
   "{{count}} contacts in common_plural": "{{count}} contacts in common",
-  "{{count}} contacts_plural": "{{count}} contacts_plural"
+  "{{count}} contacts_plural": "{{count}} contacts"
 }


### PR DESCRIPTION
changed to contacts

Fixes heading at contacts page:

<img width="690" alt="image" src="https://user-images.githubusercontent.com/87168/89994828-543eec80-dc91-11ea-8f3a-99f4c64668fe.png">


#### Proposed Changes

* Update English string source

#### Testing Instructions

* see `/contacts`
