### PR TITLE
References: basic listing

### DIFF
--- a/modules/core/server/views/email-templates-text/reference-notification-first.server.view.html
+++ b/modules/core/server/views/email-templates-text/reference-notification-first.server.view.html
@@ -5,7 +5,7 @@ Hello {{userTo.firstName}}!
 
 Great news! {{userFrom.firstName}} ({{userFromProfileUrl}}) left you a reference on Trustroots.
 
-You will be able to see their reference after you leave them a reference as well.
+You will be able to see their reference after you leave them a reference as well, at which poit both references will become public
 
 Go to {{giveReferenceUrl}} and give them a reference right now!
 

--- a/modules/core/server/views/email-templates/reference-notification-first.server.view.html
+++ b/modules/core/server/views/email-templates/reference-notification-first.server.view.html
@@ -6,10 +6,14 @@
   </p>
 
   <p>
-    Great news! <a href="{{userFromProfileUrl}}">{{userFrom.firstName}}</a> left you a reference on Trustroots.
+    Great news! <a href="{{userFromProfileUrl}}">{{userFrom.firstName}}</a>
+    left you a reference on Trustroots.
   </p>
 
-  <p>You will be able to see their reference after you leave them a reference as well.</p>
+  <p>
+    You will be able to see their reference after you leave them a reference
+    as well, at which poit both references will become public
+  </p>
 
   <p>
     You have two weeks to do this.

--- a/modules/references/client/api/references.api.js
+++ b/modules/references/client/api/references.api.js
@@ -34,7 +34,10 @@ const referenceMapping = [
   ['recommend', 'recommend'],
   ['feedbackPublic', 'feedbackPublic'],
   ['userTo', 'userTo'],
+  ['userFrom', 'userFrom'],
   ['public', 'public'],
+  ['created', 'created'],
+  ['_id', '_id'],
 ];
 
 /**
@@ -58,9 +61,14 @@ export async function create(reference) {
  * @returns Promise<Reference[]> - array of the found references
  */
 export async function read({ userFrom, userTo }) {
-  const { data: references } = await axios.get(
-    `/api/references?userFrom=${userFrom}&userTo=${userTo}`,
-  );
+  const params = {};
+  if (userFrom) {
+    params.userFrom = userFrom;
+  }
+  if (userTo) {
+    params.userTo = userTo;
+  }
+  const { data: references } = await axios.get('/api/references', { params });
   return references.map(reference =>
     mapObjectToObject(reference, referenceMapping, true),
   );

--- a/modules/references/client/components/CreateReference.component.js
+++ b/modules/references/client/components/CreateReference.component.js
@@ -10,10 +10,10 @@ import Recommend from './create-reference/Recommend';
 import Feedback from './create-reference/Feedback';
 import {
   ReferenceToSelfInfo,
-  LoadingInfo,
   DuplicateInfo,
   SubmittedInfo,
 } from './create-reference/Info';
+import LoadingIndicator from '@/modules/core/client/components/LoadingIndicator';
 import { createValidator } from '@/modules/core/client/utils/validation';
 
 const api = { references };
@@ -131,11 +131,17 @@ export default function CreateReference({ userFrom, userTo }) {
   const nextStepError =
     !isSubmitting && currentStepErrors.find(error => error.trim().length > 0);
 
-  if (userFrom._id === userTo._id) return <ReferenceToSelfInfo />;
+  if (userFrom._id === userTo._id) {
+    return <ReferenceToSelfInfo />;
+  }
 
-  if (isLoading) return <LoadingInfo />;
+  if (isLoading) {
+    return <LoadingIndicator />;
+  }
 
-  if (isDuplicate) return <DuplicateInfo userTo={userTo} />;
+  if (isDuplicate) {
+    return <DuplicateInfo userTo={userTo} />;
+  }
 
   if (isSubmitted) {
     const isReported = recommend === 'no' && report;

--- a/modules/references/client/components/ListReferences.component.js
+++ b/modules/references/client/components/ListReferences.component.js
@@ -1,8 +1,51 @@
-// import React from 'react';
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import ReferencesReadPresentational from './read-references/ReferencesReadPresentational';
+import * as referencesApi from '../api/references.api';
+import LoadingIndicator from '@/modules/core/client/components/LoadingIndicator';
 
-const lineoftext = 'Hola World!';
-export default function ListReferences() {
-  return lineoftext;
+const api = { references: referencesApi };
+
+/**
+ * This is a container component for a list of user's References
+ */
+export default function ListReferences({ user }) {
+  const [references, setReferences] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // load references from api
+  useEffect(() => {
+    (async () => {
+      setIsLoading(true);
+      const references = await api.references.read({
+        userTo: user._id,
+      });
+
+      setReferences(references);
+      setIsLoading(false);
+    })();
+  }, [user]);
+
+  if (isLoading) {
+    return <LoadingIndicator />;
+  }
+
+  const publicReferences = references
+    .filter(reference => reference.public)
+    .sort((a, b) => a.created < b.created);
+  const nonpublicReferences = references
+    .filter(reference => !reference.public)
+    .sort((a, b) => a.created > b.created);
+
+  return (
+    <ReferencesReadPresentational
+      user={user}
+      publicReferences={publicReferences}
+      nonpublicReferences={nonpublicReferences}
+    />
+  );
 }
 
-ListReferences.propTypes = {};
+ListReferences.propTypes = {
+  user: PropTypes.object.isRequired,
+};

--- a/modules/references/client/components/create-reference/Info.js
+++ b/modules/references/client/components/create-reference/Info.js
@@ -2,27 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import '@/config/client/i18n';
 import { useTranslation, Trans } from 'react-i18next';
+import UserLink from '@/modules/users/client/components/UserLink';
 
 // @TODO provide the value from API config endpoint
 const daysToReply = 14;
-
-/**
- * Link to a user
- * @param {User} user - user to link to
- */
-function UserLink({ user }) {
-  return (
-    <strong>
-      <a href={`/profile/${user.username}`}>
-        {user.displayName || user.username}
-      </a>
-    </strong>
-  );
-}
-
-UserLink.propTypes = {
-  user: PropTypes.object.isRequired,
-};
 
 /**
  * Error message when trying to give a reference to oneself.
@@ -33,19 +16,6 @@ export function ReferenceToSelfInfo() {
   return (
     <div role="alert" className="alert alert-warning">
       {t("Sorry, you can't give a reference to yourself.")}
-    </div>
-  );
-}
-
-/**
- * Info that data are loading.
- */
-export function LoadingInfo() {
-  const { t } = useTranslation('references');
-
-  return (
-    <div role="alert" aria-busy="true" className="alert alert-warning">
-      {t('Wait a moment...')}
     </div>
   );
 }

--- a/modules/references/client/components/create-reference/Recommend.js
+++ b/modules/references/client/components/create-reference/Recommend.js
@@ -41,7 +41,7 @@ export default function Recommend({
             className="btn btn-lg"
             aria-checked={recommend === 'yes'}
             value="yes"
-            bsStyle="success"
+            bsStyle="default"
             bsSize="large"
           >
             {t('Yes')}
@@ -50,7 +50,7 @@ export default function Recommend({
             className="btn btn-lg"
             aria-checked={recommend === 'no'}
             value="no"
-            bsStyle="danger"
+            bsStyle="default"
             bsSize="large"
           >
             {t('No')}

--- a/modules/references/client/components/read-references/NonpublicReference.js
+++ b/modules/references/client/components/read-references/NonpublicReference.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
+
+export default function NonpublicReference({ reference }) {
+  const { t } = useTranslation('references');
+
+  const daysLeft =
+    14 -
+    Math.round(
+      (Date.now() - new Date(reference.created).getTime()) / 3600 / 24 / 1000,
+    );
+  return (
+    <div>
+      <div>
+        <small>{t('pending')}</small>
+      </div>
+      <div>{t('{{daysLeft}} days left', { daysLeft })}</div>
+      <div>
+        <a
+          className="btn btn-xs btn-primary"
+          href={`/profile/${reference.userFrom.username}/references/new`}
+        >
+          {t('Give a reference')}
+        </a>
+      </div>
+    </div>
+  );
+}
+
+NonpublicReference.propTypes = {
+  reference: PropTypes.object.isRequired,
+};

--- a/modules/references/client/components/read-references/PublicReference.js
+++ b/modules/references/client/components/read-references/PublicReference.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
+
+export default function PublicReference({ reference }) {
+  const { t } = useTranslation('references');
+  const created = new Date(reference.created);
+  return (
+    <div>
+      <div>
+        {reference.hostedMe && t('guest')} {reference.hostedThem && t('host')}{' '}
+        {reference.met && t('met')}
+      </div>
+      <div>
+        {t('Recommends: {{recommend}}', { recommend: reference.recommend })}
+      </div>
+      <div>{t('Given {{created, MMM D YYYY}}', { created })}</div>
+    </div>
+  );
+}
+
+PublicReference.propTypes = {
+  reference: PropTypes.object.isRequired,
+};

--- a/modules/references/client/components/read-references/Reference.js
+++ b/modules/references/client/components/read-references/Reference.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import PublicReference from './PublicReference';
+import NonpublicReference from './NonpublicReference';
+import Avatar from '@/modules/users/client/components/Avatar.component';
+import UserLink from '@/modules/users/client/components/UserLink';
+
+export default function Reference({ reference }) {
+  const body = reference.public ? (
+    <PublicReference reference={reference} />
+  ) : (
+    <NonpublicReference reference={reference} />
+  );
+
+  return (
+    <div className="panel panel-default">
+      <div className="panel-body reference">
+        <Avatar user={reference.userFrom} size={64} />
+        <h4>
+          <UserLink user={reference.userFrom} />
+        </h4>
+        {body}
+      </div>
+    </div>
+  );
+}
+
+Reference.propTypes = {
+  reference: PropTypes.object.isRequired,
+};

--- a/modules/references/client/components/read-references/ReferencesReadPresentational.js
+++ b/modules/references/client/components/read-references/ReferencesReadPresentational.js
@@ -1,0 +1,93 @@
+import { useTranslation } from 'react-i18next';
+import PropTypes from 'prop-types';
+import React from 'react';
+import Reference from './Reference';
+
+export default function ReferencesReadPresentational({
+  publicReferences,
+  nonpublicReferences,
+  user,
+}) {
+  const { t } = useTranslation('references');
+
+  const hasAnyPublicReferences =
+    publicReferences && publicReferences.length > 0;
+  const hasAnyNonpublicReferences =
+    nonpublicReferences && nonpublicReferences.length > 0;
+
+  // No references
+  if (!hasAnyNonpublicReferences && !hasAnyPublicReferences) {
+    return (
+      <div className="row content-empty">
+        <i className="icon-3x icon-users"></i>
+        <h4>{t('No references yet.')}</h4>
+        <a href={`/profile/${user.username}/references/new`}>
+          {t('Write one!')}
+        </a>
+      </div>
+    );
+  }
+
+  const renderReferenceCount = () => {
+    const positiveCount = publicReferences.filter(
+      ({ recommend }) => recommend === 'yes',
+    ).length;
+    const unknownCount = publicReferences.filter(
+      ({ recommend }) => recommend === 'unknown',
+    ).length;
+    const negativeCount = publicReferences.filter(
+      ({ recommend }) => recommend === 'no',
+    ).length;
+
+    return (
+      <div className="panel panel-default">
+        <div className="panel-body references-summary">
+          <span className="text-success">
+            {t('{{count}} recommend', { count: positiveCount })}
+          </span>{' '}
+          <span>{t('{{count}} unknown', { count: unknownCount })}</span>{' '}
+          <span className="text-danger">
+            {t('{{count}} not recommend', { count: negativeCount })}
+          </span>
+        </div>
+      </div>
+    );
+  };
+
+  const renderReferencesSection = (sectionTitle, references) => (
+    <section>
+      <div className="row">
+        <div className="col-xs-12 col-sm-6">
+          <h4 className="text-muted">{sectionTitle}</h4>
+        </div>
+      </div>
+      <div className="row">
+        <div className="col-xs-12">
+          {references.map(reference => (
+            <Reference
+              id={reference._id}
+              key={reference._id}
+              reference={reference}
+            />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+
+  return (
+    <>
+      {publicReferences && renderReferenceCount()}
+      {hasAnyNonpublicReferences &&
+        renderReferencesSection(t('Pending'), nonpublicReferences)}
+      {hasAnyPublicReferences &&
+        renderReferencesSection(t('Public'), publicReferences)}
+    </>
+  );
+}
+
+ReferencesReadPresentational.propTypes = {
+  user: PropTypes.object.isRequired,
+  publicReferences: PropTypes.array.isRequired,
+  nonpublicReferences: PropTypes.array,
+};

--- a/modules/references/tests/client/components/CreateReference.client.component.tests.js
+++ b/modules/references/tests/client/components/CreateReference.client.component.tests.js
@@ -17,7 +17,7 @@ jest.mock('@/modules/references/client/api/references.api');
 afterEach(() => jest.clearAllMocks());
 
 async function waitForLoader() {
-  await waitForElementToBeRemoved(() => screen.getByText('Wait a moment...'));
+  await waitForElementToBeRemoved(() => screen.getByText('Wait a moment…'));
 }
 
 describe('<CreateReference />', () => {

--- a/modules/users/client/components/UserLink.js
+++ b/modules/users/client/components/UserLink.js
@@ -1,0 +1,20 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+/**
+ * Link to a user
+ * @param {User} user - user to link to
+ * @param {string} user.displayName
+ * @param {string} user.username
+ */
+export default function UserLink({ user }) {
+  return (
+    <a href={`/profile/${user.username}`}>
+      {user.displayName || user.username}
+    </a>
+  );
+}
+
+UserLink.propTypes = {
+  user: PropTypes.object.isRequired,
+};

--- a/modules/users/client/config/users.client.routes.js
+++ b/modules/users/client/config/users.client.routes.js
@@ -382,7 +382,8 @@ function UsersRoutes($stateProvider) {
       })
       .state('profile.references.list', {
         url: '',
-        template: '<list-references></list-references>',
+        template:
+          '<list-references user="profileCtrl.profile"></list-references>',
         requiresAuth: true,
         noScrollingTop: true,
         data: {

--- a/modules/users/client/views/profile/profile-view.client.view.html
+++ b/modules/users/client/views/profile/profile-view.client.view.html
@@ -251,15 +251,7 @@ this is a fallback when the contacts are loading
                   ng-if="app.appSettings.referencesEnabled"
                 >
                   <a ui-sref="profile.references.list" role="tab">
-                    <span aria-hidden="true">References</span>
-                    <span
-                      class="badge"
-                      aria-hidden="true"
-                      ng-bind="profileCtrl.referencesCount || 0"
-                    ></span>
-                    <span class="sr-only">
-                      {{profileCtrl.referencesCount || 0}} References
-                    </span>
+                    References
                   </a>
                 </li>
               </ul>


### PR DESCRIPTION
Follow up to https://github.com/Trustroots/trustroots/pull/918 (created new branch, instead of rebasing it)

Partly solving https://github.com/Trustroots/trustroots/issues/1494

#### Proposed Changes

Basic skeleton for listing references.

![image](https://user-images.githubusercontent.com/87168/90312477-73e24900-df0d-11ea-8438-ee4b2b342e1d.png)

Misses a few things here (see list at https://github.com/Trustroots/trustroots/pull/918) and there plus design, but let's get this going as a base. It's hidden behind feature-flag.



#### Testing Instructions

- Open other member's profile, and leave them a reference
- As the other person, reply to reference
- Now open `/references` list
