### PR TITLE
References: hide components, not routes

### DIFF
--- a/modules/users/client/config/users.client.routes.js
+++ b/modules/users/client/config/users.client.routes.js
@@ -22,8 +22,6 @@ import resetPasswordTemplateUrl from '@/modules/users/client/views/password/rese
 import profileRemoveTemplateUrl from '@/modules/users/client/views/profile/remove.client.view.html';
 import profileReferencesTemplateUrl from '@/modules/users/client/views/profile/profile-view-references.client.view.html';
 
-import AppConfig from '@/modules/core/client/app/config';
-
 angular.module('users').config(UsersRoutes);
 
 /* @ngInject */
@@ -366,39 +364,35 @@ function UsersRoutes($stateProvider) {
       data: {
         pageTitle: 'Remove profile',
       },
+    })
+    .state('profile.references', {
+      url: '/references',
+      templateUrl: profileReferencesTemplateUrl,
+      requiresAuth: true,
+      noScrollingTop: true,
+      abstract: true,
+      data: {
+        pageTitle: 'Profile references',
+      },
+    })
+    .state('profile.references.list', {
+      url: '',
+      template:
+        '<list-references ng-if="app.appSettings.referencesEnabled"></list-references>',
+      requiresAuth: true,
+      noScrollingTop: true,
+      data: {
+        pageTitle: 'Profile references',
+      },
+    })
+    .state('profile.references.new', {
+      url: '/new',
+      template:
+        '<create-reference ng-if="app.appSettings.referencesEnabled" userTo="profileCtrl.profile" userFrom="app.user"></create-reference>',
+      requiresAuth: true,
+      noScrollingTop: true,
+      data: {
+        pageTitle: 'Leave a reference',
+      },
     });
-
-  if (AppConfig.appEnv !== 'production') {
-    $stateProvider
-      .state('profile.references', {
-        url: '/references',
-        templateUrl: profileReferencesTemplateUrl,
-        requiresAuth: true,
-        noScrollingTop: true,
-        abstract: true,
-        data: {
-          pageTitle: 'Profile references',
-        },
-      })
-      .state('profile.references.list', {
-        url: '',
-        template:
-          '<list-references user="profileCtrl.profile"></list-references>',
-        requiresAuth: true,
-        noScrollingTop: true,
-        data: {
-          pageTitle: 'Profile references',
-        },
-      })
-      .state('profile.references.new', {
-        url: '/new',
-        template:
-          '<create-reference userTo="profileCtrl.profile" userFrom="app.user"></create-reference>',
-        requiresAuth: true,
-        noScrollingTop: true,
-        data: {
-          pageTitle: 'Leave a reference',
-        },
-      });
-  }
 }


### PR DESCRIPTION
#### Proposed Changes

* Remove gating on route registrations for `/references` and `/references/new`
* Instead, hide the components if the feature flag is falsy. 

Context: `dev2` server runs in `production` mode and with feature-flags turned on, so this will make testing references easier, for non-techies in particular.

#### Testing Instructions

* Open `/references` and `/references/new`
* You should see them when feature flag is on, and be able to open those routes but not see anything when feature flag is off

To set feature flag, go to `config/env/local.js` with:

```js
  featureFlags: {
    ...require('./development').featureFlags,
    reference: true,
    i18n: true,
  },
```
