### PR TITLE
Hide 'Write one!' nudge when looking at own profile and there are no experiences

### DIFF
--- a/modules/references/client/components/ListReferences.component.js
+++ b/modules/references/client/components/ListReferences.component.js
@@ -12,7 +12,7 @@ import ReferenceCounts from './read-references/ReferenceCounts';
 /**
  * List of user's references
  */
-export default function ListReferences({ profile }) {
+export default function ListReferences({ profile, authenticatedUser }) {
   const { t } = useTranslation('references');
   const [publicReferences, setPublicReferences] = useState([]);
   const [pendingReferences, setPendingReferences] = useState([]);
@@ -55,9 +55,11 @@ export default function ListReferences({ profile }) {
       <div className="row content-empty">
         <i className="icon-3x icon-users"></i>
         <h4>{t('No references yet.')}</h4>
-        <a href={`/profile/${profile.username}/references/new`}>
-          {t('Write one!')}
-        </a>
+        {authenticatedUser._id !== profile._id && (
+          <a href={`/profile/${profile.username}/references/new`}>
+            {t('Write one!')}
+          </a>
+        )}
       </div>
     );
   }
@@ -94,4 +96,5 @@ export default function ListReferences({ profile }) {
 
 ListReferences.propTypes = {
   profile: PropTypes.object.isRequired,
+  authenticatedUser: PropTypes.object.isRequired,
 };


### PR DESCRIPTION
Ongoing work on  #1493 : [Overview] references.

When the logged-in user is viewing the profile of another user that doesn't have any experiences, they see the 'write one!' nudge:

![image](https://user-images.githubusercontent.com/2955794/90669811-7c5eba80-e252-11ea-9985-e47984a48b4b.png)

### Proposed Changes
#### Before
The nudge is also present when the logged-in user is viewing their own page.

#### After 
The nudge is hidden when the logged-in user is viewing their own page:

![image](https://user-images.githubusercontent.com/2955794/90669979-cc3d8180-e252-11ea-9ed3-09ce7a23edee.png)


