### PR TITLE
Experiences: fix sorting by creation date

### DIFF
--- a/modules/references/client/api/references.api.js
+++ b/modules/references/client/api/references.api.js
@@ -55,7 +55,9 @@ export async function create(reference) {
 }
 
 /**
- * API request: read references and filter by userFrom and userTo
+ * API request: read references, filter them by userFrom and userTo,
+ * and sort by 'created' field starting from the most recent date
+ *
  * @param {string} userFrom - id of user who gave the reference
  * @param {string} userTo - id of user who received the reference
  * @returns Promise<Reference[]> - array of the found references

--- a/modules/references/client/components/ListReferences.component.js
+++ b/modules/references/client/components/ListReferences.component.js
@@ -25,16 +25,17 @@ export default function ListReferences({ profile, authenticatedUser }) {
         userTo: profile._id,
       });
 
-      const filteredPublic = references
-        .filter(reference => reference.public)
-        .sort((a, b) => a.created < b.created);
+      const publicNewestFirst = references.filter(
+        reference => reference.public,
+      );
 
-      const filteredPending = references
-        .filter(reference => !reference.public)
-        .sort((a, b) => a.created > b.created);
+      const pendingNewestFirst = references.filter(
+        reference => !reference.public,
+      );
+      const pendingOldestFirst = [...pendingNewestFirst].reverse();
 
-      setPublicReferences(filteredPublic);
-      setPendingReferences(filteredPending);
+      setPublicReferences(publicNewestFirst);
+      setPendingReferences(pendingOldestFirst);
     } finally {
       setIsLoading(false);
     }

--- a/modules/references/server/controllers/reference.server.controller.js
+++ b/modules/references/server/controllers/reference.server.controller.js
@@ -368,6 +368,7 @@ function validateReadMany(req) {
 
 /**
  * Read references filtered by userFrom or userTo
+ * and sorted by 'created' field starting from the most recent date
  */
 exports.readMany = async function readMany(req, res, next) {
   try {
@@ -410,6 +411,7 @@ exports.readMany = async function readMany(req, res, next) {
     // find references by query
     const references = await Reference.find(query)
       .select(referenceFields)
+      .sort({ created: -1 })
       .populate(
         'userFrom userTo',
         userProfile.userMiniProfileFields + ' created',


### PR DESCRIPTION
#### Proposed Changes

Fix sorting of experiences when displaying them in a user's profile as a part of ongoing work on #1494, which is a part of #1493.

Currently, the sorting in master is not working correctly:

https://github.com/Trustroots/trustroots/blob/0b4026830735eaa585d7051a93fa1dd206a50ee3/modules/references/client/components/ListReferences.component.js#L28-L30

![image](https://user-images.githubusercontent.com/2955794/91645002-acbc0b00-ea41-11ea-9434-441db3ff0c03.png)

I thought that we most probably would want to do sorting and filtering on the backend (if implementing pagination or just not loading all the experiences), so instead of fixing it on the front-end, I moved it there. Please let me know you think if I'm wrong.

#### After the change:

![image](https://user-images.githubusercontent.com/2955794/91645082-729f3900-ea42-11ea-9df2-cb9c21b5d809.png)



