### PR TITLE
Update/stats images

### DIFF
--- a/modules/statistics/client/views/statistics.client.view.html
+++ b/modules/statistics/client/views/statistics.client.view.html
@@ -132,7 +132,7 @@
             <a href="https://grafana.trustroots.org/d/000000002/members">
               <img
                 class="img-responsive"
-                src="https://grafana.trustroots.org/render/d-solo/000000002/members?orgId=1&from=1419289200000&to=1543142370362&panelId=1&width=800&height=300&theme=light"
+                src="https://grafana.trustroots.org/render/d-solo/000000002/members?orgId=1&theme=light&panelId=1&width=1000&height=500&tz=Europe%2FVilnius"
                 width="100%"
                 alt="Trustroots member growth"
               />
@@ -148,7 +148,7 @@
             <a href="https://grafana.trustroots.org/d/000000001/messages">
               <img
                 class="img-responsive"
-                src="https://grafana.trustroots.org/render/d-solo/000000001/messages?panelId=3&from=1419289200000&to=1543142370362&panelId=1&width=800&height=300&theme=light"
+                src="https://grafana.trustroots.org/render/d-solo/000000001/messages?orgId=1&refresh=1m&theme=light&panelId=3&width=1000&height=500&tz=Europe%2FVilnius"
                 width="100%"
                 alt="Trustroots weekly messages"
               />

--- a/modules/statistics/client/views/statistics.client.view.html
+++ b/modules/statistics/client/views/statistics.client.view.html
@@ -142,13 +142,33 @@
 
         <div class="panel panel-default">
           <div class="panel-heading">
-            <h3 class="panel-title">Number of messages sent</h3>
+            <h3 class="panel-title">Member retention</h3>
           </div>
           <div class="panel-body">
-            <a href="https://grafana.trustroots.org/d/000000001/messages">
+            <a
+              href="https://grafana.trustroots.org/d/UCqv_IYiz/member-retention"
+            >
               <img
                 class="img-responsive"
-                src="https://grafana.trustroots.org/render/d-solo/000000001/messages?orgId=1&theme=light&panelId=3&width=800&height=400&tz=UTC"
+                src="https://grafana.trustroots.org/render/d-solo/UCqv_IYiz/member-retention?orgId=1&theme=light&panelId=4&width=800&height=400&tz=UTC"
+                width="100%"
+                alt="Trustroots member retention"
+              />
+            </a>
+          </div>
+        </div>
+
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            <h3 class="panel-title">How often members get replies?</h3>
+          </div>
+          <div class="panel-body">
+            <a
+              href="https://grafana.trustroots.org/d/000000004/messages-detailed"
+            >
+              <img
+                class="img-responsive"
+                src="https://grafana.trustroots.org/render/d-solo/000000004/messages-detailed?orgId=1&theme=light&panelId=4&width=800&height=400&tz=UTC"
                 width="100%"
                 alt="Trustroots weekly messages"
               />

--- a/modules/statistics/client/views/statistics.client.view.html
+++ b/modules/statistics/client/views/statistics.client.view.html
@@ -122,8 +122,6 @@
           </div>
         </div>
 
-        <hr />
-
         <div class="panel panel-default">
           <div class="panel-heading">
             <h3 class="panel-title">Member growth</h3>
@@ -176,20 +174,25 @@
           </div>
         </div>
 
-        <p>
-          Are you an (aspiring) data scientist? Check
-          <a href="https://grafana.trustroots.org/">our grafana</a> for stats
-          galore.
-        </p>
-
-        <p>
-          Wanna help get better numbers? Consider
-          <a ui-sref="volunteering">joining us</a>.
-        </p>
-
         <hr />
-        <h3>Enabling the latent trust between humans since</h3>
-        <time class="lead" ng-bind="stats.launchDate | date:mediumDate"></time>
+
+        <p class="lead">
+          Enabling the latent trust between humans since
+          <time
+            class="lead"
+            ng-bind="stats.launchDate | date:mediumDate"
+          ></time>
+        </p>
+
+        <p class="lead">
+          Check <a href="https://grafana.trustroots.org/">our Grafana</a> for
+          stats galore.
+        </p>
+
+        <p class="lead">
+          Wanna help get better numbers? Consider
+          <a ui-sref="volunteering">volunteering</a>!
+        </p>
       </section>
 
       <p>

--- a/modules/statistics/client/views/statistics.client.view.html
+++ b/modules/statistics/client/views/statistics.client.view.html
@@ -132,7 +132,7 @@
             <a href="https://grafana.trustroots.org/d/000000002/members">
               <img
                 class="img-responsive"
-                src="https://grafana.trustroots.org/render/d-solo/000000002/members?orgId=1&theme=light&panelId=1&width=1000&height=500&tz=Europe%2FVilnius"
+                src="https://grafana.trustroots.org/render/d-solo/000000002/members?orgId=1&theme=light&panelId=1&width=800&height=400&tz=UTC"
                 width="100%"
                 alt="Trustroots member growth"
               />
@@ -148,7 +148,7 @@
             <a href="https://grafana.trustroots.org/d/000000001/messages">
               <img
                 class="img-responsive"
-                src="https://grafana.trustroots.org/render/d-solo/000000001/messages?orgId=1&refresh=1m&theme=light&panelId=3&width=1000&height=500&tz=Europe%2FVilnius"
+                src="https://grafana.trustroots.org/render/d-solo/000000001/messages?orgId=1&theme=light&panelId=3&width=800&height=400&tz=UTC"
                 width="100%"
                 alt="Trustroots weekly messages"
               />


### PR DESCRIPTION
Resolves https://github.com/Trustroots/trustroots/issues/1650

#### Proposed Changes

* Update image URLs to dynamic
* Switch graph showing pure number of messages, to a graph illustrating how often you can expect replies on Trustroots
* Add retention graph to illustrate how big portion of members actually spends time at the site monthly
* Light copy updates

#### Testing Instructions

* Open `/statistics`

![image](https://user-images.githubusercontent.com/87168/97788033-62c8e000-1bbe-11eb-9949-c05acb070759.png)
