### PR TITLE
Fix npm command after upgrading to webpack-cli v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "test:server": "NODE_ENV=test gulp test:server",
     "test": "npm run check-environment && npm run lint && npm run test:client && npm run test:server",
     "webpack": "webpack --config config/webpack/webpack.config.js",
-    "webpack:server": "webpack-dev-server --hot --config config/webpack/webpack.config.js",
+    "webpack:server": "webpack serve --hot --config config/webpack/webpack.config.js",
     "webpack:service-worker": "webpack --config config/webpack/webpack.push-messaging-sw.config.js",
     "ensure-indexes": "node ./bin/db-maintenance/ensure-indexes.js"
   },


### PR DESCRIPTION
#### Fix `webpack:server` npm command after upgrading to webpack-cli v4: #1794 

I pulled the recent changes and was trying to run npm start locally and got the error:
`Error: Cannot find module 'webpack-cli/bin/config-yargs'`
I changed `webpack-dev-server` to `webpack serve`  as suggested here: https://github.com/webpack/webpack-dev-server/issues/2759 and it worked. 