### PR TITLE
Make pending experiences you shared with someone visible for you in their profile

### DIFF
--- a/modules/references/client/components/ListReferences.component.js
+++ b/modules/references/client/components/ListReferences.component.js
@@ -30,14 +30,8 @@ export default function ListReferences({ profile, authenticatedUser }) {
       );
       setPublicExperiences(publicExperiences);
 
-      // TODO for now we add `experience.userTo._id.equals(profile._id)`
-      // condition to filter out the experiences written by the user,
-      // which are currently not displayed. Later, we will be showing also
-      // those: https://github.com/Trustroots/trustroots/pull/1860
       const pendingNewestFirst = experiences.filter(
-        experience =>
-          !experience.public &&
-          experience.userFrom._id !== authenticatedUser._id,
+        experience => !experience.public,
       );
 
       const pendingOldestFirst = [...pendingNewestFirst].reverse();

--- a/modules/references/client/components/read-references/Reference.js
+++ b/modules/references/client/components/read-references/Reference.js
@@ -116,7 +116,7 @@ export default function Reference({ experience }) {
             <TimeAgo date={createdDate} />
           </ReferenceLink>
         </Header>
-        {!isPublicReference && (
+        {!isPublicReference && feedbackPublic === undefined && (
           <>
             <PendingNotice>
               <PendingNoticePlaceholder aria-hidden="true">
@@ -159,6 +159,16 @@ export default function Reference({ experience }) {
               <FeedbackPublic>{response.feedbackPublic}</FeedbackPublic>
             )}
           </Response>
+        )}
+        {!isPublicReference && feedbackPublic !== undefined && (
+          <>
+            <PendingNotice>
+              {t(
+                'Your experience will become public in {{count}} days, or when they share their experience with you.',
+                { count: getDaysLeft(createdDate) },
+              )}
+            </PendingNotice>
+          </>
         )}
       </div>
     </div>

--- a/modules/references/server/controllers/reference.server.controller.js
+++ b/modules/references/server/controllers/reference.server.controller.js
@@ -422,13 +422,23 @@ exports.readMany = async function readMany(req, res, next) {
     const selfId = req.user._id;
 
     const userToId = new mongoose.Types.ObjectId(userTo);
-    const matchQuery = {
+    let matchQuery = {
       $or: [{ userTo: userToId }, { userFrom: userToId }],
     };
     // Allow non-public references only when userTo is self
     if (!selfId.equals(userToId)) {
       matchQuery.public = true;
     }
+
+    const privateFromSelfQuery = {
+      userFrom: selfId,
+      userTo: userToId,
+      public: false,
+    };
+
+    matchQuery = {
+      $or: [matchQuery, privateFromSelfQuery],
+    };
 
     // Aggregate projection for User in reference
     const userKeys = {

--- a/modules/references/tests/server/reference-read-many.server.routes.tests.js
+++ b/modules/references/tests/server/reference-read-many.server.routes.tests.js
@@ -210,8 +210,8 @@ describe('Read references by userTo Id', () => {
       should(body[0].userFrom._id).eql(users[0].id);
       should(body[0].userTo._id).eql(users[3].id);
 
-      should(body[0].response).eql(null);
-      should(body[0].public).eql(false);
+      should(body[0].response).be.null();
+      should(body[0].public).be.false();
 
       should(body[0]).have.properties(
         '_id',

--- a/modules/references/tests/server/reference-read-many.server.routes.tests.js
+++ b/modules/references/tests/server/reference-read-many.server.routes.tests.js
@@ -202,6 +202,25 @@ describe('Read references by userTo Id', () => {
       should(body[2].userFrom._id).eql(users[5].id);
     });
 
+    it('[param userTo] response should contain private experience from self', async () => {
+      const { body } = await agent
+        .get(`/api/experiences?userTo=${users[3]._id}`)
+        .expect(200);
+
+      should(body[0].userFrom._id).eql(users[0].id);
+      should(body[0].userTo._id).eql(users[3].id);
+
+      should(body[0].response).eql(null);
+      should(body[0].public).eql(false);
+
+      should(body[0]).have.properties(
+        '_id',
+        'created',
+        'recommend',
+        'interactions',
+      );
+    });
+
     it('[no params] 400 and error', async () => {
       const { body } = await agent.get('/api/experiences').expect(400);
 


### PR DESCRIPTION
# Proposed changes:

![image](https://user-images.githubusercontent.com/2955794/103321068-3dc6e100-4a38-11eb-916f-c21e9972ee78.png)



# Testing instructions:

- go to the profile of any user with which you haven't yet shared experience. Write an experience. An experience should appear under "Experiences pending publishing"  


WIP on #1493 
Fixes #1842
