### PR TITLE
Add email confirmation tracking

### DIFF
--- a/modules/users/server/controllers/users.profile.server.controller.js
+++ b/modules/users/server/controllers/users.profile.server.controller.js
@@ -101,6 +101,7 @@ exports.userSearchProfileFields =
  * Update user profile
  */
 exports.update = function (req, res) {
+  console.log(req.body); //eslint-disable-line
   if (!req.user) {
     return res.status(403).send({
       message: errorService.getErrorMessageByKey('forbidden'),
@@ -231,6 +232,8 @@ exports.update = function (req, res) {
 
         // This is set only if user edited email
         if (token && email) {
+          console.log('setting email', token, email); //eslint-disable-line
+          user.emailTokenDate = Date.now();
           user.emailToken = token;
           user.emailTemporary = email;
         }

--- a/modules/users/server/models/user.server.model.js
+++ b/modules/users/server/models/user.server.model.js
@@ -297,6 +297,9 @@ const UserSchema = new Schema({
   emailToken: {
     type: String,
   },
+  emailTokenDate: {
+    type: Date,
+  },
   /* New users are public=false until they validate their email. If public=false,
      users can't email other users, can't be seen by other users. They are
      effectively black holed... */


### PR DESCRIPTION
### TODO:

- [x] Add datestamp to DB
  - directly into the email token hash? 👎 ideal, but too much work at this point.
  - as a separate field 👍 
- [ ] calculate time between confirm / sending email
  - It's there but isn't working, `.diff()` always gives `0` :-( https://momentjs.com/docs/#/displaying/difference/
- send tracking event to InfluxDB: 
  - [ ] failure
  - [x] success
- InfluxDB tags: do they need to be strings or are booleans ok? Suspecting they need to be strings.

#### Proposed Changes

* Adds tracking for email confirmation, mainly to track time between the email sent and email confirmed

#### Testing Instructions

* Enable influx DB from `env/config/local.js` (best if you set it up locally so you can actually see it working, otherwise you see just error https://www.influxdata.com/)
* Change email from the account page
* Receive email http://localhost:1080/
* Check from DB that user has new `emailTokenDate`
* Confirm your email
* Check from DB that user no longer has `emailTokenDate`
* Check console

**Test:**
- [ ] signup, 
- [ ] email change, and 
- [ ] email change resend

