### PR TITLE
Rewrite "user not found" message in React

### DIFF
--- a/modules/users/client/components/UserDoesNotExist.component.js
+++ b/modules/users/client/components/UserDoesNotExist.component.js
@@ -18,9 +18,7 @@ export default function UserDoesNotExist() {
       </a>
       <br />
       <br />
-      <a href="/search" className="btn btn-secondary">
-        {t('Map search')}
-      </a>
+      <a href="/search">{t('Map search')}</a>
     </div>
   );
 }

--- a/modules/users/client/components/UserDoesNotExist.component.js
+++ b/modules/users/client/components/UserDoesNotExist.component.js
@@ -16,6 +16,11 @@ export default function UserDoesNotExist() {
       <a href="/search/members" className="btn btn-primary">
         {t('Find people')}
       </a>
+      <br />
+      <br />
+      <a href="/search" className="btn btn-secondary">
+        {t('Map search')}
+      </a>
     </div>
   );
 }

--- a/modules/users/client/components/UserDoesNotExist.component.js
+++ b/modules/users/client/components/UserDoesNotExist.component.js
@@ -9,7 +9,7 @@ export default function UserDoesNotExist() {
     <div className="row text-center" role="alert">
       <h1>{t('Oops!')}</h1>
       <em className="lead">
-        {t('Member you are looking for is not available.')}
+        {t('The Trustrooter you are looking for is not available.')}
       </em>
       <br />
       <br />

--- a/modules/users/client/components/UserDoesNotExist.component.js
+++ b/modules/users/client/components/UserDoesNotExist.component.js
@@ -1,0 +1,23 @@
+// External dependencies
+import { useTranslation } from 'react-i18next';
+import React from 'react';
+
+export default function UserDoesNotExist() {
+  const { t } = useTranslation('users');
+
+  return (
+    <div className="row text-center" role="alert">
+      <h1>{t('Oops!')}</h1>
+      <em className="lead">
+        {t('Member you are looking for is not available.')}
+      </em>
+      <br />
+      <br />
+      <a href="/search/members" className="btn btn-primary">
+        {t('Find people')}
+      </a>
+    </div>
+  );
+}
+
+UserDoesNotExist.propTypes = {};

--- a/modules/users/client/components/UserDoesNotExist.component.js
+++ b/modules/users/client/components/UserDoesNotExist.component.js
@@ -9,7 +9,7 @@ export default function UserDoesNotExist() {
     <div className="row text-center" role="alert">
       <h1>{t('Oops!')}</h1>
       <em className="lead">
-        {t('The Trustrooter you are looking for is not available.')}
+        {t('The person you are looking for is not available.')}
       </em>
       <br />
       <br />

--- a/modules/users/client/views/profile/profile-view.client.view.html
+++ b/modules/users/client/views/profile/profile-view.client.view.html
@@ -55,16 +55,9 @@ this is a fallback when the contacts are loading
   </div>
 
   <!-- Couldn't find profile... -->
-  <div
-    class="row text-center"
-    aria-role="alert"
+  <user-does-not-exist
     ng-if="!profileCtrl.profile.username && profileCtrl.profile.$resolved && app.user.public !== false"
-  >
-    <h1>Don't panic!</h1>
-    <em class="lead">User does not exist.</em>
-    <br /><br />
-    <a ui-sref="search.map">Continue...</a>
-  </div>
+  />
 
   <!-- Own profile is non-public -->
   <div


### PR DESCRIPTION
A super simple example for rewriting bit of Angular code into React.

#### Proposed Changes

* Rewrite "user not found" Angular template part to a simple React component
* While at it, change the copy to be more meaningful
* Add additional "find people" link instead of only map search, which should be more useful next action for these folks.

#### Testing Instructions

* Open http://localhost:3000/profile/doesnotexist
* ✨ 


**Before:**

<img width="1055" alt="Screenshot 2020-11-28 at 20 08 11" src="https://user-images.githubusercontent.com/87168/100523033-dfe37700-31b5-11eb-86e1-efc46c56c8ec.png">

**After:**

![image](https://user-images.githubusercontent.com/87168/100523058-1620f680-31b6-11eb-9057-7da7dc45b954.png)
