### PR TITLE
Hide "public" title unless also "pending" experiences are showing

### DIFF
--- a/modules/references/client/components/ListReferences.component.js
+++ b/modules/references/client/components/ListReferences.component.js
@@ -50,11 +50,11 @@ export default function ListReferences({ profile, authenticatedUser }) {
     return <LoadingIndicator />;
   }
 
-  const hasPublicReferencs = publicReferences.length > 0;
+  const hasPublicReferences = publicReferences.length > 0;
   const hasPendingReferences = pendingReferences.length > 0;
 
   // No references
-  if (!hasPendingReferences && !hasPublicReferencs) {
+  if (!hasPendingReferences && !hasPublicReferences) {
     return (
       <div className="row content-empty">
         <i className="icon-3x icon-users"></i>
@@ -70,7 +70,7 @@ export default function ListReferences({ profile, authenticatedUser }) {
 
   return (
     <>
-      {hasPublicReferencs && (
+      {hasPublicReferences && (
         <ReferenceCounts publicReferences={publicReferences} />
       )}
       {hasPendingReferences && (
@@ -79,7 +79,7 @@ export default function ListReferences({ profile, authenticatedUser }) {
           references={pendingReferences}
         />
       )}
-      {hasPublicReferencs && (
+      {hasPublicReferences && (
         <ReferencesSection
           // Show "Public" title only if there are also pending experiences listed
           title={hasPendingReferences && t('Public experiences')}

--- a/modules/references/client/components/ListReferences.component.js
+++ b/modules/references/client/components/ListReferences.component.js
@@ -81,7 +81,8 @@ export default function ListReferences({ profile, authenticatedUser }) {
       )}
       {hasPublicReferencs > 0 && (
         <ReferencesSection
-          title={t('Public experiences')}
+          // Show "Public" title only if there are also pending experiences listed
+          title={hasPendingReferences && t('Public experiences')}
           references={publicReferences}
         />
       )}

--- a/modules/references/client/components/ListReferences.component.js
+++ b/modules/references/client/components/ListReferences.component.js
@@ -6,8 +6,8 @@ import React, { useState, useEffect } from 'react';
 // Internal dependencies
 import { read as readReferences } from '../api/references.api';
 import LoadingIndicator from '@/modules/core/client/components/LoadingIndicator';
-import Reference from './read-references/Reference';
 import ReferenceCounts from './read-references/ReferenceCounts';
+import ReferencesSection from './read-references/ReferencesSection';
 
 /**
  * List of user's references
@@ -50,8 +50,11 @@ export default function ListReferences({ profile, authenticatedUser }) {
     return <LoadingIndicator />;
   }
 
+  const hasPublicReferencs = publicReferences.length > 0;
+  const hasPendingReferences = pendingReferences.length > 0;
+
   // No references
-  if (pendingReferences.length === 0 && publicReferences.length === 0) {
+  if (!hasPendingReferences && !hasPublicReferencs) {
     return (
       <div className="row content-empty">
         <i className="icon-3x icon-users"></i>
@@ -65,32 +68,24 @@ export default function ListReferences({ profile, authenticatedUser }) {
     );
   }
 
-  const renderReferencesSection = (sectionTitle, references) => (
-    <section>
-      <div className="row">
-        <div className="col-xs-12 col-sm-6">
-          <h4 className="text-muted">{sectionTitle}</h4>
-        </div>
-      </div>
-      <div className="row">
-        <div className="col-xs-12">
-          {references.map(reference => (
-            <Reference key={reference._id} reference={reference} />
-          ))}
-        </div>
-      </div>
-    </section>
-  );
-
   return (
     <>
-      {publicReferences.length > 0 && (
+      {hasPublicReferencs && (
         <ReferenceCounts publicReferences={publicReferences} />
       )}
-      {pendingReferences.length > 0 &&
-        renderReferencesSection(t('Pending'), pendingReferences)}
-      {publicReferences.length > 0 &&
-        renderReferencesSection(t('Public'), publicReferences)}
+      {hasPendingReferences && (
+        <ReferencesSection
+          title={t('Pending')}
+          references={pendingReferences}
+        />
+      )}
+      {hasPublicReferencs > 0 && (
+        <ReferencesSection
+          // Show "Public" title only if there are also pending experiences listed
+          title={t('Public')}
+          references={publicReferences}
+        />
+      )}
     </>
   );
 }

--- a/modules/references/client/components/ListReferences.component.js
+++ b/modules/references/client/components/ListReferences.component.js
@@ -79,7 +79,7 @@ export default function ListReferences({ profile, authenticatedUser }) {
           references={pendingReferences}
         />
       )}
-      {hasPublicReferencs > 0 && (
+      {hasPublicReferencs && (
         <ReferencesSection
           // Show "Public" title only if there are also pending experiences listed
           title={hasPendingReferences && t('Public experiences')}

--- a/modules/references/client/components/ListReferences.component.js
+++ b/modules/references/client/components/ListReferences.component.js
@@ -75,14 +75,13 @@ export default function ListReferences({ profile, authenticatedUser }) {
       )}
       {hasPendingReferences && (
         <ReferencesSection
-          title={t('Pending')}
+          title={t('Experiences pending publishing')}
           references={pendingReferences}
         />
       )}
       {hasPublicReferencs > 0 && (
         <ReferencesSection
-          // Show "Public" title only if there are also pending experiences listed
-          title={t('Public')}
+          title={t('Public experiences')}
           references={publicReferences}
         />
       )}

--- a/modules/references/client/components/read-references/ReferencesSection.js
+++ b/modules/references/client/components/read-references/ReferencesSection.js
@@ -1,0 +1,35 @@
+// External dependencies
+import PropTypes from 'prop-types';
+import React from 'react';
+
+// Internal dependencies
+import Reference from './Reference';
+
+/**
+ * List of user's references
+ */
+export default function ReferencesSection({ title, references }) {
+  return (
+    <section>
+      {title && (
+        <div className="row">
+          <div className="col-xs-12 col-sm-6">
+            <h4 className="text-muted">{title}</h4>
+          </div>
+        </div>
+      )}
+      <div className="row">
+        <div className="col-xs-12">
+          {references.map(reference => (
+            <Reference key={reference._id} reference={reference} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+ReferencesSection.propTypes = {
+  references: PropTypes.array.isRequired,
+  title: PropTypes.string,
+};


### PR DESCRIPTION
## Proposed Changes

* Split references section into its own component for clarity
* Change copy of pending/public for clarity
* Don't show "public" title unless we show also "pending" title

## Testing Instructions

* Open your profile with references
* Note no "public" title visible
* Open another profile in incognito and write an experience about the 1st profile
* Refresh the 1st profile's references. Do titles make more sense now?


### Before

"Public" title is always visible. Confusing without context.

![image](https://user-images.githubusercontent.com/87168/100550472-be9c8c80-3282-11eb-975f-1320f07b9223.png)


### After

**New copy for section titles**

<img width="878" alt="Screenshot 2020-11-29 at 20 19 36" src="https://user-images.githubusercontent.com/87168/100550429-8dbc5780-3282-11eb-8bfa-8821aa7c03c6.png">

**No titles visible if there are no pending experiences**

<img width="881" alt="Screenshot 2020-11-29 at 20 19 21" src="https://user-images.githubusercontent.com/87168/100550430-90b74800-3282-11eb-8e5e-b35f98fdb385.png">
