### PR TITLE
Update: refactor experiences time

### DIFF
--- a/modules/core/client/components/TimeAgo.js
+++ b/modules/core/client/components/TimeAgo.js
@@ -18,7 +18,7 @@ const REFRESH_INTERVAL = 10000; // 10s
  *  Well, I think it's useful to be able to reuse our date formatting library,
  *  given we have it already. But, lets see, can always switch it out later...
  */
-export default function TimeAgo({ date }) {
+export default function TimeAgo({ date, className }) {
   const momentDate = moment(date);
 
   const [fromNow, setFromNow] = useState(momentDate.fromNow());
@@ -32,9 +32,18 @@ export default function TimeAgo({ date }) {
     };
   }, [date]);
 
-  return <span title={momentDate.format('LLLL')}>{fromNow}</span>;
+  return (
+    <time
+      className={className}
+      dateTime={date}
+      title={momentDate.format('LLLL')}
+    >
+      {fromNow}
+    </time>
+  );
 }
 
 TimeAgo.propTypes = {
+  className: PropTypes.string,
   date: PropTypes.instanceOf(Date).isRequired,
 };

--- a/modules/core/client/components/TimeAgo.js
+++ b/modules/core/client/components/TimeAgo.js
@@ -18,7 +18,7 @@ const REFRESH_INTERVAL = 10000; // 10s
  *  Well, I think it's useful to be able to reuse our date formatting library,
  *  given we have it already. But, lets see, can always switch it out later...
  */
-export default function TimeAgo({ date, className }) {
+export default function TimeAgo({ date }) {
   const momentDate = moment(date);
 
   const [fromNow, setFromNow] = useState(momentDate.fromNow());
@@ -33,17 +33,12 @@ export default function TimeAgo({ date, className }) {
   }, [date]);
 
   return (
-    <time
-      className={className}
-      dateTime={date}
-      title={momentDate.format('LLLL')}
-    >
+    <time dateTime={date} title={momentDate.format('LLLL')}>
       {fromNow}
     </time>
   );
 }
 
 TimeAgo.propTypes = {
-  className: PropTypes.string,
   date: PropTypes.instanceOf(Date).isRequired,
 };

--- a/modules/references/client/components/read-references/Reference.js
+++ b/modules/references/client/components/read-references/Reference.js
@@ -16,13 +16,24 @@ const DAYS_TO_REPLY = 14;
 
 const ReferenceHeading = styled.div`
   display: flex;
-  align-items: center;
+  flex-wrap: wrap-reverse;
+  line-height: 1.3em;
+
   .avatar {
     margin-right: 10px;
   }
-  time {
+
+  .reference-time {
     margin-left: auto;
+    color: #333;
   }
+
+  @media (max-width: 480px) {
+   .reference-time {
+     width: 100%;
+     margin-left: 0;
+     margin-bottom: 10px;
+   }
 `;
 
 const UserMeta = styled.div`
@@ -84,11 +95,12 @@ export default function Reference({ reference }) {
               {userFrom.gender && `, ${getGender(userFrom.gender)}`}
             </span>
           </UserMeta>
-          <time dateTime={createdDate} className="text-color-links">
-            <a href={`/profile/${userTo.username}/references#${_id}`}>
-              <TimeAgo date={createdDate} />
-            </a>
-          </time>
+          <a
+            className="reference-time"
+            href={`/profile/${userTo.username}/references#${_id}`}
+          >
+            <TimeAgo date={createdDate} />
+          </a>
         </ReferenceHeading>
 
         {!isPublicReference && (


### PR DESCRIPTION
#### Proposed Changes

* Small refactor of `TimeAgo` component to be based on [`<time>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time) HTML element: just semantics...

    <img width="400" alt="time tag" src="https://user-images.githubusercontent.com/87168/101258232-d7e18500-3729-11eb-9438-c1cc5017582e.png">

* Simplify HTML and improve styling for the time; works better especially on mobile now when either name, or translated strings might be longer than in English.

     No changes on desktop version:
    <img width="558" alt="Screenshot 2020-12-05 at 18 27 18" src="https://user-images.githubusercontent.com/87168/101258185-905af900-3729-11eb-89bb-44e27ff73c7c.png">

    Mobile version before:

    <img width="360" alt="Screenshot 2020-12-05 at 18 27 14" src="https://user-images.githubusercontent.com/87168/101258383-d49ac900-372a-11eb-848c-9c2a202d3765.png">


    Mobile version after:

    <img width="417" alt="Screenshot 2020-12-05 at 18 27 14" src="https://user-images.githubusercontent.com/87168/101258187-918c2600-3729-11eb-80f1-cb70595b3b01.png">


#### Testing Instructions

* Check References list and "time ago" bit in the corner
* Confirm other places continue unchanged where `TimeAgo` component is used: message list most prominently.