### PR TITLE
Upgrade Node.js 12 → 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,13 @@ matrix:
   # Generally using active LTS versions here, see https://github.com/nodejs/Release
   include:
     - name: Test client
-      node_js: 12
+      node_js: 14
       env: RUN="npm run test:client"
     - name: Test server
-      node_js: 12
+      node_js: 14
       env: RUN="npm run test:server"
     - name: Lint and build
-      node_js: 12
+      node_js: 14
       env: RUN="npx concurrently --kill-others-on-fail 'npm:lint' 'npm:build:tarball'" DEPLOY="true"
 # https://docs.travis-ci.com/user/reference/overview/#Virtualisation-Environment-vs-Operating-System
 script: '$RUN'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:14
 
 # Install prerequisites
 # https://docs.docker.com/engine/articles/dockerfile_best-practices/#apt-get

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ volumes:
 
 services:
   trustroots:
-    image: node:12
+    image: node:14
     container_name: trustroots
     restart: unless-stopped
     build:


### PR DESCRIPTION
Upgrading from Node.js 12 to 14; it's active LTS since 2020-10-27

I'll merge as long CI turns green.

https://nodejs.org/en/about/releases/