### PR TITLE
Janitorial: remove Angular-Waypoints

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,9 +2,6 @@ module.exports = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
     '^modules/(.*)$': '<rootDir>/modules/$1',
-    // doesn't play nicely with jest, see jest.setup.js for more info
-    'angular-waypoints/dist/angular-waypoints.all':
-      '<rootDir>/jest/jest.empty-module.js',
     '^.+\\.(css)$': '<rootDir>/jest/jest.empty-module.js',
   },
   testMatch: ['<rootDir>/modules/*/tests/client/**/*.tests.js'],

--- a/jest/jest.setup.js
+++ b/jest/jest.setup.js
@@ -1,13 +1,5 @@
 global.L = require('leaflet');
 global.jQuery = require('jquery');
-
-const angular = require('angular');
 require('angular-mocks');
-
 require('@/modules/core/client/app/init');
 require('@/modules/core/client/core.client.module');
-
-// loading angular-waypoints doesn't play nicely
-// in jest, so we stub it's loading in jest.config.js
-// and provide an empty module definition for use in tests
-angular.module('zumba.angular-waypoints', []);

--- a/jest/jest.setup.js
+++ b/jest/jest.setup.js
@@ -1,5 +1,6 @@
 global.L = require('leaflet');
 global.jQuery = require('jquery');
+require('angular');
 require('angular-mocks');
 require('@/modules/core/client/app/init');
 require('@/modules/core/client/core.client.module');

--- a/modules/core/client/app/config.js
+++ b/modules/core/client/app/config.js
@@ -36,8 +36,6 @@ import 'angular-chosen-localytics/dist/angular-chosen.js';
 
 import ngreact from 'ngreact';
 
-import 'angular-waypoints/dist/angular-waypoints.all';
-
 // eslint-disable-next-line angular/window-service
 const SENTRY_DSN = window.SENTRY_DSN;
 
@@ -66,7 +64,6 @@ const appModuleVendorDependencies = compact([
   'nemLogging',
   'ui-leaflet',
   ngFileUpload,
-  'zumba.angular-waypoints',
   'localytics.directives',
   'angular-loading-bar',
   trTrustpass,

--- a/modules/core/client/less/bootstrap/sidebar.less
+++ b/modules/core/client/less/bootstrap/sidebar.less
@@ -10,12 +10,6 @@
 .sidebar {
   .font-brand-regular();
 
-  // Using https://github.com/zumba/angular-waypoints
-  &.sidebar-sticky {
-    position: fixed;
-    top: (@navbar-height + @padding-large-horizontal);
-  }
-
   // Accordion directive + .list-group inside .sidebar
   // https://angular-ui.github.io/bootstrap/#/accordion
   // http://getbootstrap.com/components/#list-group

--- a/modules/pages/client/components/Faq.component.js
+++ b/modules/pages/client/components/Faq.component.js
@@ -30,11 +30,7 @@ export default function Faq({ category, invitationsEnabled, children }) {
       <section className="container">
         <div className="row">
           <div className="col-xs-12 col-sm-4 col-md-4">
-            <div
-              id="faq-sidebar"
-              className="sidebar"
-              // TODO make CSS 'position: sticky' work or toggle 'sidebar-sticky' class
-            >
+            <div id="faq-sidebar" className="sidebar">
               {/* <Site & Community */}
               <div className="panel panel-default">
                 <div className="panel-heading">

--- a/modules/pages/client/less/faq.less
+++ b/modules/pages/client/less/faq.less
@@ -14,9 +14,6 @@
 
 #faq-sidebar.sidebar {
   margin-top: (20px + @navbar-height);
-  &.sidebar-sticky {
-    margin-top: 0;
-  }
 }
 
 .faq-question {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6028,11 +6028,6 @@
         "angular": "^1.0.8"
       }
     },
-    "angular-waypoints": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/angular-waypoints/-/angular-waypoints-2.0.0.tgz",
-      "integrity": "sha1-N+d2K49YQV088YTOfyFQynkDKcs="
-    },
     "angulargrid": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/angulargrid/-/angulargrid-0.6.5.tgz",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "angular-trustpass": "0.4.0",
     "angular-ui-bootstrap": "2.5.6",
     "angular-ui-router": "0.4.3",
-    "angular-waypoints": "2.0.0",
     "angulargrid": "0.6.5",
     "angulartics": "1.6.0",
     "angulartics-google-analytics": "0.5.0",


### PR DESCRIPTION
This was needed for FAQ and maybe for messages, but those have since been migrated to React.

#### Proposed Changes

* Remove all traces of Angular-Waypoints module

#### Testing Instructions

* Smoke test everything works
