### PR TITLE
Profile & Experiences: simplify gender label

### DIFF
--- a/modules/core/client/utils/user_info.js
+++ b/modules/core/client/utils/user_info.js
@@ -1,20 +1,20 @@
 import { useTranslation } from 'react-i18next';
 
-/*
- * Functions passing strings to translation fuction for translation scripts
+/**
+ * Get label for profile gender options
  */
 export function getGender(genderCode) {
-  const { t } = useTranslation(['users', 'languages']);
+  const { t } = useTranslation('users');
 
   switch (genderCode) {
     case 'female':
-      return t('female');
+      return t('Female');
     case 'male':
-      return t('male');
+      return t('Male');
     case 'non-binary':
-      return t('non-binary');
+      return t('Non-binary');
     case 'other':
-      return t('other gender');
+      return t('Other gender');
     default:
       return undefined;
   }

--- a/modules/references/client/components/read-references/Reference.js
+++ b/modules/references/client/components/read-references/Reference.js
@@ -78,10 +78,10 @@ export default function Reference({ reference }) {
               <UserLink user={userFrom} />
             </strong>
             <span className="muted">
-              {t('Member since {{memberSince}}', {
-                memberSince: new Date(userFrom.created).getFullYear(),
+              {userFrom.gender && `${getGender(userFrom.gender)}. `}
+              {t('Member since {{date, YYYY}}.', {
+                date: new Date(userFrom.created),
               })}
-              {userFrom.gender && `, ${getGender(userFrom.gender)}`}
             </span>
           </UserMeta>
           <time dateTime={createdDate} className="text-color-links">

--- a/modules/users/client/components/ProfileViewBasics.js
+++ b/modules/users/client/components/ProfileViewBasics.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import classnames from 'classnames';
 import { Trans, useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 import * as languages from '@/config/languages/languages';
@@ -14,7 +13,7 @@ export default function ProfileViewBasics({ profile }) {
   const { t } = useTranslation(['users', 'languages']);
 
   const getBirthdate = birthdate =>
-    t('{{birthdate, age}} years', { birthdate: new Date(birthdate) });
+    t('{{birthdate, age}} years.', { birthdate: new Date(birthdate) });
 
   const getReplyRate = replyRate =>
     t('Reply rate {{replyRate}}.', { replyRate: replyRate });
@@ -50,15 +49,14 @@ export default function ProfileViewBasics({ profile }) {
     </div>
   );
 
-  const renderBirthdateAndGender = (birthdate, gender) => (
-    <div className="profile-sidebar-section">
-      {birthdate && getBirthdate(birthdate)}
-      {birthdate && gender && <span>, </span>}
-      <span className={classnames({ 'text-capitalize': !birthdate })}>
-        {getGender(gender)}.
-      </span>
-    </div>
-  );
+  const renderBirthdateAndGender = (birthdate, gender) => {
+    return (
+      <div className="profile-sidebar-section">
+        {birthdate && `${getBirthdate(birthdate)} `}
+        {gender && `${getGender(gender)}.`}
+      </div>
+    );
+  };
 
   const renderMemberSince = created => (
     <div className="profile-sidebar-section">{getMemberSince(created)}</div>


### PR DESCRIPTION
Instead of trying to handle comma and lowercase/Sentence-case in different scenarios, I figured we can simplify this a lot and just use natural sentences. Should be easier to translate, too.

#### Proposed Changes

* Change gender labels to Sentence case from lowercase
* Instead of structuring sentences with a comma, split to separate sentences.
* Swap "member since" and "gender" the other way around; makes it easier to skim the list of experiences to stop if they're all from the same gender.

#### Testing Instructions

* Check profile with and without gender or birthdate
* Check experiences list

