### PR TITLE
Experiences: always show report toggle

### DIFF
--- a/modules/core/client/components/Switch.js
+++ b/modules/core/client/components/Switch.js
@@ -2,13 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-export default function Switch({ checked, children, onChange, small }) {
-  // Angular Directive supports also these CSS classes:
-  // tr-switch-right
+export default function Switch({ checked, children, onChange, isSmall }) {
+  // Angular Directive supports also `tr-switch-right` CSS class
   return (
     <label
       className={classnames('tr-switch', {
-        'tr-switch-sm': small,
+        'tr-switch-sm': isSmall,
       })}
     >
       <input type="checkbox" checked={checked} onChange={onChange} />
@@ -21,5 +20,5 @@ Switch.propTypes = {
   checked: PropTypes.bool.isRequired,
   children: PropTypes.node.isRequired,
   onChange: PropTypes.func.isRequired,
-  small: PropTypes.bool,
+  isSmall: PropTypes.bool,
 };

--- a/modules/core/client/components/Switch.js
+++ b/modules/core/client/components/Switch.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+export default function Switch({ checked, children, onChange, small }) {
+  // Angular Directive supports also these CSS classes:
+  // tr-switch-right
+  return (
+    <label
+      className={classnames('tr-switch', {
+        'tr-switch-sm': small,
+      })}
+    >
+      <input type="checkbox" checked={checked} onChange={onChange} />
+      <div className="toggle"></div> {children}
+    </label>
+  );
+}
+
+Switch.propTypes = {
+  checked: PropTypes.bool.isRequired,
+  children: PropTypes.node.isRequired,
+  onChange: PropTypes.func.isRequired,
+  small: PropTypes.bool,
+};

--- a/modules/core/client/less/directives/switch.less
+++ b/modules/core/client/less/directives/switch.less
@@ -18,6 +18,7 @@
 
 /* The switch - the box around the slider */
 .tr-switch {
+  cursor: pointer;
   position: relative;
   display: inline-block;
   padding-left: (@switch-md-width + @switch-space-to-label);

--- a/modules/references/client/components/create-reference/Recommend.js
+++ b/modules/references/client/components/create-reference/Recommend.js
@@ -1,9 +1,17 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+// External dependencies
 import { ToggleButton, ToggleButtonGroup } from 'react-bootstrap';
-import '@/config/client/i18n';
 import { useTranslation } from 'react-i18next';
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'styled-components';
+
+// Internal dependencies
+import '@/config/client/i18n';
 import Report from './Report';
+
+const SadNotice = styled.div`
+  margin: 30px 0;
+`;
 
 export default function Recommend({
   primaryInteraction,
@@ -65,13 +73,23 @@ export default function Recommend({
           </ToggleButton>
         </ToggleButtonGroup>
         {recommend === 'no' && (
-          <Report
-            onChangeReport={onChangeReport}
-            onChangeReportMessage={onChangeReportMessage}
-            report={report}
-            reportMessage={reportMessage}
-          />
+          <SadNotice className="lead">
+            {t(
+              "We're sad to hear you didn't have a great experience using Trustroots!",
+            )}
+            {' 😞'}
+            <br />
+            {t(
+              "It's extremely important you report anyone behaving against rules to us.",
+            )}
+          </SadNotice>
         )}
+        <Report
+          onChangeReport={onChangeReport}
+          onChangeReportMessage={onChangeReportMessage}
+          report={report}
+          reportMessage={reportMessage}
+        />
       </div>
     </div>
   );

--- a/modules/references/client/components/create-reference/Report.js
+++ b/modules/references/client/components/create-reference/Report.js
@@ -1,34 +1,34 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import '@/config/client/i18n';
+// External dependencies
 import { useTranslation } from 'react-i18next';
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'styled-components';
+
+// Internal dependencies
+import '@/config/client/i18n';
+import Switch from '@/modules/core/client/components/Switch';
+
+const ReportContainer = styled.div`
+  margin-top: 50px;
+`;
 
 export default function Report({
-  report,
-  reportMessage,
   onChangeReport,
   onChangeReportMessage,
+  report,
+  reportMessage,
 }) {
   const { t } = useTranslation('references');
 
   return (
-    <div>
-      <br />
-      <br />
-      <p className="lead">
-        {t(
-          "We're sad to hear you didn't have a great experience using Trustroots!",
-        )}{' '}
-        😞
-      </p>
-      <div className="checkbox">
-        <label>
-          <input type="checkbox" checked={report} onChange={onChangeReport} />
-          {t('Report this person to moderators')}
-        </label>
-      </div>
+    <ReportContainer>
+      <Switch small checked={report} onChange={onChangeReport}>
+        {t('Report this person to moderators')}
+      </Switch>
       {report && (
-        <div>
+        <>
+          <br />
+          <br />
           <label htmlFor="report-message" className="control-label">
             {t('Message to moderators')}
           </label>
@@ -43,9 +43,9 @@ export default function Report({
             {t('Please write in English if possible.')}
             <br />
           </span>
-        </div>
+        </>
       )}
-    </div>
+    </ReportContainer>
   );
 }
 

--- a/modules/references/client/components/create-reference/Report.js
+++ b/modules/references/client/components/create-reference/Report.js
@@ -22,7 +22,7 @@ export default function Report({
 
   return (
     <ReportContainer>
-      <Switch small checked={report} onChange={onChangeReport}>
+      <Switch isSmall checked={report} onChange={onChangeReport}>
         {t('Report this person to moderators')}
       </Switch>
       {report && (

--- a/modules/references/client/components/create-reference/Report.js
+++ b/modules/references/client/components/create-reference/Report.js
@@ -23,7 +23,7 @@ export default function Report({
   return (
     <ReportContainer>
       <Switch isSmall checked={report} onChange={onChangeReport}>
-        {t('Report this person to moderators')}
+        {t('Privately report this person to moderators')}
       </Switch>
       {report && (
         <>

--- a/modules/references/tests/client/components/CreateReference.client.component.tests.js
+++ b/modules/references/tests/client/components/CreateReference.client.component.tests.js
@@ -153,7 +153,7 @@ describe('<CreateReference />', () => {
     ).toBeInTheDocument();
     fireEvent.click(getByText('No'));
 
-    fireEvent.click(getByText('Report this person to moderators'));
+    fireEvent.click(getByText('Privately report this person to moderators'));
     fireEvent.change(getByLabelText('Message to moderators'), {
       target: { value: 'they were mean to me' },
     });


### PR DESCRIPTION
#### Proposed Changes

* Add `Switch` component (there's a similar Angular Directive and these share CSS styles for now)
* Make report toggle always visible when writing an experience, not just when choosing "no" to the recommendation
* Elaborate a bit more in length that reporting is important

#### Testing Instructions

* Write an experience about someone

* Choose "no", text should appear:

    <img width="869" alt="Screenshot 2020-12-06 at 01 40 39" src="https://user-images.githubusercontent.com/87168/101267681-17c55e00-3764-11eb-918f-eb3ede098910.png">

* No matter if you choose yes/no/I don't know, you can see the toggle:

    <img width="879" alt="Screenshot 2020-12-06 at 01 40 27" src="https://user-images.githubusercontent.com/87168/101267699-5529eb80-3764-11eb-812f-1ab29ac0702b.png">

* Pressing the toggle shows the text field:

    <img width="880" alt="Screenshot 2020-12-06 at 01 40 31" src="https://user-images.githubusercontent.com/87168/101267703-5eb35380-3764-11eb-8a0d-dc377f1bd06f.png">
