### PR TITLE
Fix: profile description field height jumping

### DIFF
--- a/modules/users/client/less/profile-edit.less
+++ b/modules/users/client/less/profile-edit.less
@@ -11,7 +11,7 @@
   color: @text-color;
 }
 
-.profile-edit-description {
+.profile-edit-description.medium-editor-element {
   &,
   &:focus {
     min-height: 150px;


### PR DESCRIPTION
#### Proposed Changes

* Tiny fix to add CSS specificity on profile description element, to avoid underlying component CSS (min-heigh: 30px) overriding the profile description CSS (min-height: 150px).

#### Testing Instructions

* Have empty profile description
* Try to edit it

**Before**

![broken](https://user-images.githubusercontent.com/87168/101268336-755ca900-376a-11eb-9999-73df1775caa2.gif)

**After**

![works](https://user-images.githubusercontent.com/87168/101268341-7b528a00-376a-11eb-9e34-4632bf7f9f2b.gif)
