### PR TITLE
create a separate endpoint to retrieve logged-in user's reference given to `userTo`

### DIFF
--- a/modules/references/client/api/references.api.js
+++ b/modules/references/client/api/references.api.js
@@ -85,13 +85,18 @@ export async function read({ userFrom, userTo }) {
  */
 export async function readMine({ userTo }) {
   const params = { userTo };
-  const { data: reference } = await axios.get('/api/my-reference', {
-    params,
-  });
-
-  return reference !== null
-    ? mapObjectToObject(reference, referenceMapping, true)
-    : null;
+  try {
+    const { data: reference } = await axios.get('/api/my-reference', {
+      params,
+    });
+    return mapObjectToObject(reference, referenceMapping, true);
+  } catch (err) {
+    if (err.response?.status === 404) {
+      return null;
+    } else {
+      throw err;
+    }
+  }
 }
 
 /**

--- a/modules/references/client/api/references.api.js
+++ b/modules/references/client/api/references.api.js
@@ -84,7 +84,7 @@ export async function read({ userFrom, userTo }) {
  * @returns Promise<Reference[]> - array of the found references
  */
 export async function readMine({ userTo }) {
-  const params = { userTo: userTo };
+  const params = { userTo };
   const { data: reference } = await axios.get('/api/my-reference', {
     params,
   });

--- a/modules/references/client/api/references.api.js
+++ b/modules/references/client/api/references.api.js
@@ -77,6 +77,24 @@ export async function read({ userFrom, userTo }) {
 }
 
 /**
+ * API request: read references written by loggedIn user, filter them by userTo,
+ * and sort by 'created' field starting from the most recent date
+ *
+ * @param {string} userTo - id of user who received the reference
+ * @returns Promise<Reference[]> - array of the found references
+ */
+export async function readMine({ userTo }) {
+  const params = { userTo: userTo };
+  const { data: reference } = await axios.get('/api/my-reference', {
+    params,
+  });
+
+  return reference !== null
+    ? mapObjectToObject(reference, referenceMapping, true)
+    : null;
+}
+
+/**
  * API request: report a member
  * @TODO this request belongs to a different module
  * @param {object} user - member to report

--- a/modules/references/client/components/CreateReference.component.js
+++ b/modules/references/client/components/CreateReference.component.js
@@ -35,16 +35,13 @@ export default function CreateReference({ userFrom, userTo }) {
 
   useEffect(() => {
     (async () => {
-      const references = await api.references.read({
-        userFrom: userFrom._id,
+      const reference = await api.references.readMine({
         userTo: userTo._id,
       });
 
-      references.forEach(reference => {
-        if (reference.userFrom._id === userFrom._id) {
-          setIsDuplicate(true);
-        }
-      });
+      if (reference !== null) {
+        setIsDuplicate(true);
+      }
 
       setIsLoading(false);
     })();

--- a/modules/references/server/controllers/reference.server.controller.js
+++ b/modules/references/server/controllers/reference.server.controller.js
@@ -578,6 +578,11 @@ exports.readOne = function readOne(req, res) {
 };
 
 exports.readMine = async function readMine(req, res) {
+  if (!mongoose.Types.ObjectId.isValid(req.query.userTo)) {
+    return res
+      .status(400)
+      .send({ message: 'Missing or invalid `userTo` request param' });
+  }
   const reference = await findMyReference(req, req.query.userTo);
   if (reference === null) {
     return res.status(404).json({

--- a/modules/references/server/controllers/reference.server.controller.js
+++ b/modules/references/server/controllers/reference.server.controller.js
@@ -154,7 +154,7 @@ function formatReference(reference, isNonpublicFullyDisplayed) {
 async function findMyReference(req, userTo) {
   return await Reference.findOne({
     userFrom: req.user._id,
-    userTo: userTo,
+    userTo,
   }).exec();
 }
 

--- a/modules/references/server/controllers/reference.server.controller.js
+++ b/modules/references/server/controllers/reference.server.controller.js
@@ -151,15 +151,18 @@ function formatReference(reference, isNonpublicFullyDisplayed) {
   }
 }
 
+async function findMyReference(req, userTo) {
+  return await Reference.findOne({
+    userFrom: req.user._id,
+    userTo: userTo,
+  }).exec();
+}
+
 /**
  * Check if the reference already exists. If it exists, return an error in a callback.
  */
 async function checkDuplicate(req) {
-  const ref = await Reference.findOne({
-    userFrom: req.user._id,
-    userTo: req.body.userTo,
-  }).exec();
-
+  const ref = await findMyReference(req, req.body.userTo);
   if (ref === null) return;
 
   throw new ResponseError({ status: 409, body: { errType: 'conflict' } });
@@ -572,4 +575,9 @@ exports.referenceById = async function referenceById(req, res, next, id) {
  */
 exports.readOne = function readOne(req, res) {
   return res.status(200).json(req.reference);
+};
+
+exports.readMine = async function readMine(req, res) {
+  const reference = await findMyReference(req, req.query.userTo);
+  return res.status(200).json(reference);
 };

--- a/modules/references/server/controllers/reference.server.controller.js
+++ b/modules/references/server/controllers/reference.server.controller.js
@@ -579,5 +579,10 @@ exports.readOne = function readOne(req, res) {
 
 exports.readMine = async function readMine(req, res) {
   const reference = await findMyReference(req, req.query.userTo);
+  if (reference === null) {
+    return res.status(404).json({
+      message: errorService.getErrorMessageByKey('not-found'),
+    });
+  }
   return res.status(200).json(reference);
 };

--- a/modules/references/server/policies/references.server.policy.js
+++ b/modules/references/server/policies/references.server.policy.js
@@ -16,6 +16,10 @@ exports.invokeRolesPolicies = function () {
           permissions: ['get', 'post'],
         },
         {
+          resources: '/api/my-reference',
+          permissions: ['get'],
+        },
+        {
           resources: '/api/references/:referenceId',
           permissions: ['get'],
         },

--- a/modules/references/server/routes/reference.server.routes.js
+++ b/modules/references/server/routes/reference.server.routes.js
@@ -12,6 +12,11 @@ module.exports = function (app) {
       .get(references.readMany);
 
     app
+      .route('/api/my-reference')
+      .all(referencePolicy.isAllowed)
+      .get(references.readMine);
+
+    app
       .route('/api/references/:referenceId')
       .all(referencePolicy.isAllowed)
       .get(references.readOne);

--- a/modules/references/tests/client/components/CreateReference.client.component.tests.js
+++ b/modules/references/tests/client/components/CreateReference.client.component.tests.js
@@ -35,7 +35,7 @@ describe('<CreateReference />', () => {
 
   it('should not be possible to leave a reference to self', () => {
     const me = { _id: '123456', username: 'username' };
-    api.references.read.mockResolvedValueOnce([]);
+    api.references.readMine.mockResolvedValueOnce([]);
     const { queryByRole } = render(
       <CreateReference userFrom={me} userTo={me} />,
     );
@@ -45,18 +45,15 @@ describe('<CreateReference />', () => {
   });
 
   it('check whether the reference exists at the beginning', () => {
-    api.references.read.mockResolvedValueOnce([]);
+    api.references.readMine.mockResolvedValueOnce([]);
     render(<CreateReference userFrom={userFrom} userTo={userTo} />);
-    expect(api.references.read).toBeCalledWith({
-      userFrom: userFrom._id,
+    expect(api.references.readMine).toBeCalledWith({
       userTo: userTo._id,
     });
   });
 
   it('can not leave a second reference', async () => {
-    api.references.read.mockResolvedValueOnce([
-      { userFrom, userTo, public: false },
-    ]);
+    api.references.readMine.mockResolvedValueOnce([{ userTo, public: false }]);
     const { queryByRole } = render(
       <CreateReference userFrom={userFrom} userTo={userTo} />,
     );
@@ -64,14 +61,13 @@ describe('<CreateReference />', () => {
     expect(queryByRole('heading')).toHaveTextContent(
       `You already shared your experience with them`,
     );
-    expect(api.references.read).toBeCalledWith({
-      userFrom: userFrom._id,
+    expect(api.references.readMine).toBeCalledWith({
       userTo: userTo._id,
     });
   });
 
   it('can leave a reference (reference form is available)', async () => {
-    api.references.read.mockResolvedValueOnce([]);
+    api.references.readMine.mockResolvedValueOnce(null);
     const { queryByLabelText } = render(
       <CreateReference userFrom={userFrom} userTo={userTo} />,
     );
@@ -82,7 +78,7 @@ describe('<CreateReference />', () => {
   });
 
   it('submit a reference', async () => {
-    api.references.read.mockResolvedValueOnce([]);
+    api.references.readMine.mockResolvedValueOnce(null);
     api.references.create.mockResolvedValueOnce({ public: false });
 
     const {
@@ -138,7 +134,7 @@ describe('<CreateReference />', () => {
   });
 
   it('submit a report when recommend is no and user wants to send a report', async () => {
-    api.references.read.mockResolvedValueOnce([]);
+    api.references.readMine.mockResolvedValueOnce(null);
     api.references.create.mockResolvedValueOnce({ public: false });
 
     const {

--- a/modules/references/tests/server/reference-read-mine.server.routes.tests.js
+++ b/modules/references/tests/server/reference-read-mine.server.routes.tests.js
@@ -1,0 +1,207 @@
+const mongoose = require('mongoose');
+const path = require('path');
+const request = require('supertest');
+const should = require('should');
+const sinon = require('sinon');
+const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const express = require(path.resolve('./config/lib/express'));
+
+describe('Read my reference to userTo Id', () => {
+  // GET /my-reference&userTo=:UserId
+
+  const app = express.init(mongoose.connection);
+  const agent = request.agent(app);
+
+  let users;
+
+  const _usersPublic = utils.generateUsers(4, { public: true });
+  const _usersPrivate = utils.generateUsers(1, {
+    public: false,
+    username: 'nonpublic',
+    email: 'nonpublic@example.com',
+  });
+  const _users = [..._usersPublic, ..._usersPrivate];
+
+  beforeEach(() => {
+    sinon.useFakeTimers({ now: new Date('2018-01-12'), toFake: ['Date'] });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  beforeEach(async () => {
+    users = await utils.saveUsers(_users);
+  });
+
+  /**
+   * array of [userFrom, userTo, values]
+   *
+   * Overview of the referenceData
+   * - row: userFrom - index of user within array of users provided to utils.generateReferences()
+   * - column: userTo - same as row
+   * - T: reference exists and is public
+   * - F: reference exists and is not public
+   * - .: reference doesn't exist
+   *
+   *   0 1 2 3 4
+   * 0 . T T F .
+   * 1 T
+   * 2 .
+   * 3 .
+   * 4 .
+   */
+  const referenceData = [
+    [0, 1],
+    [0, 2],
+    [0, 3, { public: false }],
+    [1, 0],
+  ];
+
+  beforeEach(async () => {
+    const _references = utils.generateReferences(users, referenceData);
+
+    await utils.saveReferences(_references);
+  });
+
+  afterEach(utils.clearDatabase);
+
+  context('logged in as public user', () => {
+    beforeEach(utils.signIn.bind(this, _usersPublic[0], agent));
+    afterEach(utils.signOut.bind(this, agent));
+
+    it('[param userTo] 1: user who has also shared experience', async () => {
+      const { body } = await agent
+        .get(`/api/my-reference?userTo=${users[1]._id}`)
+        .expect(200);
+
+      should(body).have.propertyByPath('interactions', 'met').Boolean();
+      should(body).have.propertyByPath('interactions', 'hostedMe').Boolean();
+      should(body).have.propertyByPath('interactions', 'hostedThem').Boolean();
+      should(body).have.property('public', true);
+      should(body).have.property('created', new Date().toISOString());
+      should(body)
+        .have.property('recommend')
+        .which.is.equalOneOf(['no', 'yes', 'unknown']);
+      should(body)
+        .have.property('_id')
+        .String()
+        .match(/[0-9a-f]{24}/);
+      should(body)
+        .have.property('userFrom')
+        .String()
+        .match(/[0-9a-f]{24}/);
+      should(body)
+        .have.property('userTo')
+        .String()
+        .match(/[0-9a-f]{24}/);
+    });
+
+    it('[param userTo] 2: user who did not share experience', async () => {
+      const { body } = await agent
+        .get(`/api/my-reference?userTo=${users[2]._id}`)
+        .expect(200);
+
+      should(body).have.propertyByPath('interactions', 'met').Boolean();
+      should(body).have.propertyByPath('interactions', 'hostedMe').Boolean();
+      should(body).have.propertyByPath('interactions', 'hostedThem').Boolean();
+      should(body).have.property('public', true);
+      should(body).have.property('created', new Date().toISOString());
+      should(body)
+        .have.property('recommend')
+        .which.is.equalOneOf(['no', 'yes', 'unknown']);
+      should(body)
+        .have.property('_id')
+        .String()
+        .match(/[0-9a-f]{24}/);
+      should(body)
+        .have.property('userFrom')
+        .String()
+        .match(/[0-9a-f]{24}/);
+      should(body)
+        .have.property('userTo')
+        .String()
+        .match(/[0-9a-f]{24}/);
+    });
+
+    it('[param userTo] 3: experience is still private', async () => {
+      const { body } = await agent
+        .get(`/api/my-reference?userTo=${users[3]._id}`)
+        .expect(200);
+
+      should(body).have.propertyByPath('interactions', 'met').Boolean();
+      should(body).have.propertyByPath('interactions', 'hostedMe').Boolean();
+      should(body).have.propertyByPath('interactions', 'hostedThem').Boolean();
+      should(body).have.property('public', false);
+      should(body).have.property('created', new Date().toISOString());
+      should(body)
+        .have.property('recommend')
+        .which.is.equalOneOf(['no', 'yes', 'unknown']);
+      should(body)
+        .have.property('_id')
+        .String()
+        .match(/[0-9a-f]{24}/);
+      should(body)
+        .have.property('userFrom')
+        .String()
+        .match(/[0-9a-f]{24}/);
+      should(body)
+        .have.property('userTo')
+        .String()
+        .match(/[0-9a-f]{24}/);
+    });
+
+    it('[param userTo] 4: user with whom no experience shared', async () => {
+      const { body } = await agent
+        .get(`/api/my-reference?userTo=${users[4]._id}`)
+        .expect(404);
+
+      should(body).eql({
+        message: 'Not found.',
+      });
+    });
+
+    it('[param userTo] 0: myself', async () => {
+      const { body } = await agent
+        .get(`/api/my-reference?userTo=${users[4]._id}`)
+        .expect(404);
+
+      should(body).eql({
+        message: 'Not found.',
+      });
+    });
+
+    it('[no params] 400 and error', async () => {
+      const { body } = await agent.get('/api/my-reference').expect(400);
+
+      should(body).eql({
+        message: 'Missing or invalid `userTo` request param',
+      });
+    });
+
+    it('[invalid params] 400 and error', async () => {
+      const { body } = await agent
+        .get('/api/my-reference?userTo=asdf')
+        .expect(400);
+
+      should(body).eql({
+        message: 'Missing or invalid `userTo` request param',
+      });
+    });
+  });
+
+  context('logged in as non-public user', () => {
+    beforeEach(utils.signIn.bind(this, _usersPrivate[0], agent));
+    afterEach(utils.signOut.bind(this, agent));
+
+    it('403', async () => {
+      await agent.get(`/api/my-reference?userTo=${users[2]._id}`).expect(403);
+    });
+  });
+
+  context('not logged in', () => {
+    it('403', async () => {
+      await agent.get(`/api/my-reference?userTo=${users[2]._id}`).expect(403);
+    });
+  });
+});


### PR DESCRIPTION
#### Proposed changes

Add route *GET: /api/my-reference?userTo=\<userTo\>* and make client code call this route when checking if the currently auth user has already left a reference to `userTo` 

#### Testing instructions

1. Try exercising the route above
1. Log in; leave a reference to someone; try leaving reference one more time - should not be possible

TBA: 
- [x] tests
- [x] validation
- [x] remove obsolete`userFrom` param from `/api/references` which is now obsolete -- **will be done in a separate PR**

part of ongoing work on #1493 

related to #1667 and #1860 (untangles a bit changes that need to be done there)
