### PR TITLE
CI: exclude Weblate branch from CI checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 # run for only for pull requests or master branch
 if: 'type = pull_request OR branch = master'
+branches:
+  except:
+    - weblate:weblate-trustroots-translation
 matrix:
   fast_finish: true
   # Generally using active LTS versions here, see https://github.com/nodejs/Release


### PR DESCRIPTION
#### Proposed Changes

* Exclude Weblate PRs (example https://github.com/Trustroots/trustroots/pull/1920) from CI checks. These PRs just add a lot of additional load for Travis builds for no additional gain (these rebase commits were already tested in PRs and when merged to `master`, so this is just triple checking them for nothing)

https://docs.travis-ci.com/user/customizing-the-build/#safelisting-or-blocklisting-branches

#### Testing Instructions

* This branch should pass green in CI, and then we can test with next Weblate PR

Thoughts?

