### PR TITLE
Lint: add object-shorthand rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,7 @@ const rules = {
   'no-unused-expressions': 0,
   'no-use-before-define': [1, 'nofunc'],
   'object-curly-spacing': [2, 'always'],
+  'object-shorthand': 2,
   'one-var': [2, 'never'],
   'one-var-declaration-per-line': [2, 'always'],
   semi: [2, 'always'],

--- a/config/config.js
+++ b/config/config.js
@@ -155,7 +155,7 @@ const initGlobalConfig = function () {
 
   // Expose configuration utilities
   config.utils = {
-    getGlobbedPaths: getGlobbedPaths,
+    getGlobbedPaths,
   };
 
   return config;

--- a/config/lib/exponent-notifications.js
+++ b/config/lib/exponent-notifications.js
@@ -20,7 +20,7 @@ exports.sendToDevice = function sendToDevice(tokens, notification) {
   tokens.forEach(function (token) {
     if (!token || !Expo.isExpoPushToken(token)) {
       log('error', 'Invalid or missing Expo push notification token #mg9hwf', {
-        token: token,
+        token,
       });
       return;
     }

--- a/config/lib/express.js
+++ b/config/lib/express.js
@@ -116,7 +116,7 @@ module.exports.initMiddleware = function (app) {
   // Should be placed before express.static
   app.use(
     compress({
-      filter: function (req, res) {
+      filter(req, res) {
         return /json|text|javascript|css|font|svg/.test(
           res.getHeader('Content-Type'),
         );

--- a/config/lib/mongoose.js
+++ b/config/lib/mongoose.js
@@ -47,12 +47,12 @@ module.exports.loadModels = function (callback) {
     mongoose.model(model).on('index', function (error) {
       if (error) {
         log('error', 'Calling createIndex failed for Mongoose Schema.', {
-          error: error,
-          model: model,
+          error,
+          model,
         });
       } else {
         log('info', 'Calling createIndex succeeded for Mongoose Schema.', {
-          model: model,
+          model,
         });
       }
     });
@@ -173,7 +173,7 @@ module.exports.ensureIndexes = function (modelNames) {
           if (error) {
             log('error', 'Indexing Mongoose Schema failed', {
               model: modelName,
-              error: error,
+              error,
             });
             callback(error);
           } else {
@@ -188,7 +188,7 @@ module.exports.ensureIndexes = function (modelNames) {
           // One of the iterations produced an error.
           // All processing will now stop.
           log('error', 'A Schema failed to index.', {
-            error: error,
+            error,
           });
           reject(error);
         } else {

--- a/modules/contacts/client/config/contacts.client.routes.js
+++ b/modules/contacts/client/config/contacts.client.routes.js
@@ -17,11 +17,11 @@ function ContactsRoutes($stateProvider) {
         ContactByService: 'ContactByService',
         UsersMini: 'UsersMini',
 
-        existingContact: function (ContactByService, $stateParams) {
+        existingContact(ContactByService, $stateParams) {
           return ContactByService.get({ userId: $stateParams.userId });
         },
 
-        friend: function (UsersMini, $stateParams) {
+        friend(UsersMini, $stateParams) {
           return UsersMini.get({
             userId: $stateParams.userId,
           });
@@ -41,7 +41,7 @@ function ContactsRoutes($stateProvider) {
         // A string value resolves to a service
         Contact: 'Contact',
 
-        contact: function (Contact, $stateParams) {
+        contact(Contact, $stateParams) {
           return Contact.get({ contactId: $stateParams.contactId });
         },
       },

--- a/modules/contacts/client/directives/tr-contact-remove.client.directive.js
+++ b/modules/contacts/client/directives/tr-contact-remove.client.directive.js
@@ -14,13 +14,13 @@ function trContactRemoveDirective($uibModal) {
     scope: {
       contactToRemove: '=trContactRemove',
     },
-    link: function (scope, element) {
+    link(scope, element) {
       function openModal() {
         $uibModal.open({
           templateUrl,
           controllerAs: 'removeContactModal',
           controller: 'ContactRemoveController',
-          scope: scope,
+          scope,
         });
       }
 

--- a/modules/contacts/tests/client/remove-contact.client.controller.tests.js
+++ b/modules/contacts/tests/client/remove-contact.client.controller.tests.js
@@ -58,9 +58,9 @@ describe('ContactRemoveController', function () {
       inject(function ($controller) {
         Authentication.user = user1;
         ContactRemoveController = $controller('ContactRemoveController', {
-          $scope: $scope,
-          $uibModalInstance: $uibModalInstance,
-          messageCenterService: messageCenterService,
+          $scope,
+          $uibModalInstance,
+          messageCenterService,
         });
         done();
       });

--- a/modules/core/client/components/StepNavigation.js
+++ b/modules/core/client/components/StepNavigation.js
@@ -102,8 +102,8 @@ export default function StepNavigation({
    * https://reactjs.org/docs/react-api.html#cloneelement
    */
   const backProps = { onClick: onBack };
-  const nextProps = { onClick: onNext, disabled: disabled };
-  const submitProps = { onClick: onSubmit, disabled: disabled };
+  const nextProps = { onClick: onNext, disabled };
+  const submitProps = { onClick: onSubmit, disabled };
   const tooltipProps = {
     tooltip: disabledReason,
     id: 'tooltip-disabled-button',

--- a/modules/core/client/config/core.client.config.js
+++ b/modules/core/client/config/core.client.config.js
@@ -10,7 +10,7 @@ function CoreConfig($httpProvider) {
 /* @ngInject */
 function CoreServiceUnavailable($q, $rootScope) {
   return {
-    responseError: function (rejection) {
+    responseError(rejection) {
       if (rejection.status === 503) {
         $rootScope.$broadcast('serviceUnavailable');
       }

--- a/modules/core/client/directives/message-center.client.directive.js
+++ b/modules/core/client/directives/message-center.client.directive.js
@@ -36,7 +36,7 @@ function mcMessages($rootScope, messageCenterService) {
   return {
     restrict: 'EA',
     template: templateString,
-    link: function (scope, element, attrs) {
+    link(scope, element, attrs) {
       // Bind the messages from the service to the root scope.
       messageCenterService.flush();
       const changeReaction = function () {

--- a/modules/core/client/directives/tr-boards.client.directive.js
+++ b/modules/core/client/directives/tr-boards.client.directive.js
@@ -23,7 +23,7 @@ function trBoardsDirective($window) {
     scope: {
       trBoards: '=',
     },
-    link: function (scope, elem, attrs) {
+    link(scope, elem, attrs) {
       // Don't set background images for mobile screens if defined so via attribute
       if (
         angular.isDefined(attrs.trBoardsIgnoreSmall) &&

--- a/modules/core/client/directives/tr-date-select.client.directive.js
+++ b/modules/core/client/directives/tr-date-select.client.directive.js
@@ -40,7 +40,7 @@ angular
       return {
         restrict: 'A',
         replace: true,
-        templateUrl: function ($element, $attrs) {
+        templateUrl($element, $attrs) {
           return $attrs.templateUrl || 'tr-date-select.html';
         },
         require: 'ngModel',
@@ -49,7 +49,7 @@ angular
           selectClass: '@trSelectClass',
         },
 
-        link: function (scope, elem, attrs, ngModel) {
+        link(scope, elem, attrs, ngModel) {
           scope.val = {};
 
           const min = (scope.min = moment(attrs.min || '1900-01-01'));

--- a/modules/core/client/directives/tr-editor.client.directive.js
+++ b/modules/core/client/directives/tr-editor.client.directive.js
@@ -68,7 +68,7 @@ function trEditorDirective($parse) {
     scope: {
       trEditorOptions: '=',
     },
-    link: function (scope, iElement, iAttrs, ngModel) {
+    link(scope, iElement, iAttrs, ngModel) {
       const angularIElement = angular.element(iElement);
 
       angularIElement.addClass('tr-editor');

--- a/modules/core/client/directives/tr-flashcards.client.directive.js
+++ b/modules/core/client/directives/tr-flashcards.client.directive.js
@@ -21,7 +21,7 @@ function trFlashcardsDirective() {
       '  <p class="tr-flashcards-title" ng-bind="::flashTitle"></p>' +
       '  <p class="tr-flashcards-content" ng-bind="::flashContent"></p>' +
       '</a>',
-    link: function (scope) {
+    link(scope) {
       const flashcards = [
         {
           title: 'Make sure your profile is complete',

--- a/modules/core/client/directives/tr-focustip.client.directive.js
+++ b/modules/core/client/directives/tr-focustip.client.directive.js
@@ -16,7 +16,7 @@ function trFocustipDirective($compile) {
     scope: {
       trFocustip: '=',
     },
-    link: function (scope, element) {
+    link(scope, element) {
       // Compiled template
       // after() requires jQuery
       const template = $compile(

--- a/modules/core/client/directives/tr-highlight-on-focus.client.directive.js
+++ b/modules/core/client/directives/tr-highlight-on-focus.client.directive.js
@@ -13,7 +13,7 @@ angular.module('core').directive('trSelectOnClick', trSelectOnClickDirective);
 function trSelectOnClickDirective($window) {
   return {
     restrict: 'A',
-    link: function (scope, element) {
+    link(scope, element) {
       element.on('click', function () {
         if (!$window.getSelection().toString()) {
           // Required for mobile Safari

--- a/modules/core/client/directives/tr-languages.client.directive.js
+++ b/modules/core/client/directives/tr-languages.client.directive.js
@@ -89,7 +89,7 @@ function trLanguagesDirective() {
         $scope.output.forEach(function (key) {
           if (angular.isString(key)) {
             this.push({
-              key: key,
+              key,
               name: vm.languages[key],
             });
           }

--- a/modules/core/client/directives/tr-location.client.directive.js
+++ b/modules/core/client/directives/tr-location.client.directive.js
@@ -36,7 +36,7 @@ function trLocationDirective($compile, $timeout, LocationService) {
       trLocationBounds: '=?',
     },
     replace: false,
-    link: function (scope, element, attr, ngModel) {
+    link(scope, element, attr, ngModel) {
       // Event handler to stop submitting the surrounding form
       element.bind('keydown keypress focus', function ($event) {
         scope.trLocationNotfound = false;
@@ -91,7 +91,7 @@ function trLocationDirective($compile, $timeout, LocationService) {
       });
     },
     controllerAs: 'trLocation',
-    controller: function ($scope, $timeout) {
+    controller($scope, $timeout) {
       // View Model
       const vm = this;
 

--- a/modules/core/client/directives/tr-page-title.client.directive.js
+++ b/modules/core/client/directives/tr-page-title.client.directive.js
@@ -4,7 +4,7 @@ angular.module('core').directive('trPageTitle', trPageTitle);
 function trPageTitle($rootScope, $interpolate, $state, $window) {
   const directive = {
     restrict: 'A',
-    link: link,
+    link,
   };
 
   return directive;

--- a/modules/core/client/directives/tr-spinner.client.directive.js
+++ b/modules/core/client/directives/tr-spinner.client.directive.js
@@ -3,7 +3,7 @@ angular.module('core').directive('trSpinner', trSpinnerDirective);
 function trSpinnerDirective() {
   return {
     restrict: 'E',
-    link: function (scope, element, attrs) {
+    link(scope, element, attrs) {
       // @link https://haltersweb.github.io/Accessibility/svg.html
       function generateSVGMarkup(size, square, stroke) {
         return (

--- a/modules/core/client/directives/tr-switch.client.directive.js
+++ b/modules/core/client/directives/tr-switch.client.directive.js
@@ -15,7 +15,7 @@ angular.module('core').directive('trSwitch', trSwitchDirective);
 function trSwitchDirective() {
   return {
     restrict: 'A',
-    link: function (scope, elem, attrs) {
+    link(scope, elem, attrs) {
       elem.addClass('tr-switch');
 
       // Small size

--- a/modules/core/client/directives/tr-time.client.directive.js
+++ b/modules/core/client/directives/tr-time.client.directive.js
@@ -41,7 +41,7 @@ function trTimeDirective($log, $rootScope, $parse, locker) {
       trTimeTooltipPlacement: '@',
       trTimeFormat: '=?', // `?` makes it optional
     },
-    link: function (scope, element, attrs) {
+    link(scope, element, attrs) {
       if (!scope.trTime) {
         $log.warn('No time passed for tr-time directive.');
         return;

--- a/modules/core/client/services/facebook.client.service.js
+++ b/modules/core/client/services/facebook.client.service.js
@@ -11,7 +11,7 @@ function FacebookFactory(
   Authentication,
 ) {
   const service = {
-    init: init,
+    init,
   };
 
   return service;

--- a/modules/core/client/services/firebase-messaging.client.service.js
+++ b/modules/core/client/services/firebase-messaging.client.service.js
@@ -17,12 +17,12 @@ function firebaseMessaging($window, $q, $timeout, SettingsService) {
   const firebaseMessaging = {
     name: 'fcm',
     shouldInitialize: !!SENDER_ID,
-    getToken: getToken,
-    requestPermission: requestPermission,
-    deleteToken: deleteToken,
-    onTokenRefresh: onTokenRefresh,
-    onMessage: onMessage,
-    removeServiceWorker: removeServiceWorker,
+    getToken,
+    requestPermission,
+    deleteToken,
+    onTokenRefresh,
+    onMessage,
+    removeServiceWorker,
   };
 
   function getToken() {

--- a/modules/core/client/services/languages.client.service.js
+++ b/modules/core/client/services/languages.client.service.js
@@ -3,7 +3,7 @@ angular.module('core').factory('Languages', LanguagesFactory);
 /* @ngInject */
 function LanguagesFactory($window) {
   const service = {
-    get: get,
+    get,
   };
 
   return service;
@@ -15,7 +15,7 @@ function LanguagesFactory($window) {
       angular.forEach(
         $window.languages,
         function (value, key) {
-          this.push({ key: key, name: value });
+          this.push({ key, name: value });
         },
         langsArr,
       );

--- a/modules/core/client/services/location.client.service.js
+++ b/modules/core/client/services/location.client.service.js
@@ -15,11 +15,11 @@ function LocationService($log, $http, SettingsFactory) {
   };
 
   const service = {
-    getDefaultLocation: getDefaultLocation,
-    getBounds: getBounds,
-    getCenter: getCenter,
-    shortTitle: shortTitle,
-    suggestions: suggestions,
+    getDefaultLocation,
+    getBounds,
+    getCenter,
+    shortTitle,
+    suggestions,
   };
 
   /**

--- a/modules/core/client/services/maplayers.client.service.js
+++ b/modules/core/client/services/maplayers.client.service.js
@@ -23,7 +23,7 @@ function MapLayersFactory(SettingsFactory, LocationService) {
   const location = LocationService.getDefaultLocation(3);
 
   const service = {
-    getLayers: getLayers,
+    getLayers,
   };
 
   return service;

--- a/modules/core/client/services/mapmarkers.client.service.js
+++ b/modules/core/client/services/mapmarkers.client.service.js
@@ -15,9 +15,9 @@ function MapMarkersFactory($window) {
   const Leaflet = $window.L;
 
   const service = {
-    getIconConfig: getIconConfig,
-    getIcon: getIcon,
-    getOfferCircle: getOfferCircle,
+    getIconConfig,
+    getIcon,
+    getOfferCircle,
   };
 
   return service;

--- a/modules/core/client/services/message-center-client.service.js
+++ b/modules/core/client/services/message-center-client.service.js
@@ -58,7 +58,7 @@ function MessageCenterService(
       /** @var Do not delete this message automatically. */
       permanent: 'permanent',
     },
-    add: function (type, message, options) {
+    add(type, message, options) {
       const availableTypes = ['info', 'warning', 'danger', 'success'];
       const service = this;
       options = options || {};
@@ -68,10 +68,10 @@ function MessageCenterService(
         throw 'Invalid message type';
       }
       const messageObject = {
-        type: type,
+        type,
         status: options.status || this.status.unseen,
         processed: false,
-        close: function () {
+        close() {
           return service.remove(this);
         },
       };
@@ -87,21 +87,21 @@ function MessageCenterService(
       this.mcMessages.push(messageObject);
       return messageObject;
     },
-    remove: function (message) {
+    remove(message) {
       const index = this.mcMessages.indexOf(message);
       this.mcMessages.splice(index, 1);
     },
-    reset: function () {
+    reset() {
       this.mcMessages = [];
     },
-    removeShown: function () {
+    removeShown() {
       for (let index = this.mcMessages.length - 1; index >= 0; index--) {
         if (this.mcMessages[index].status === this.status.shown) {
           this.remove(this.mcMessages[index]);
         }
       }
     },
-    markShown: function () {
+    markShown() {
       for (let index = this.mcMessages.length - 1; index >= 0; index--) {
         if (!this.mcMessages[index].processed) {
           if (this.mcMessages[index].status === this.status.unseen) {
@@ -113,7 +113,7 @@ function MessageCenterService(
         }
       }
     },
-    flush: function () {
+    flush() {
       $rootScope.mcMessages = this.mcMessages;
     },
   };

--- a/modules/core/client/services/native-app-bridge.client.service.js
+++ b/modules/core/client/services/native-app-bridge.client.service.js
@@ -16,11 +16,11 @@ function trNativeAppBridgeFactory(
   $location,
 ) {
   const service = {
-    activate: activate,
-    getAppInfo: getAppInfo,
-    isNativeMobileApp: isNativeMobileApp,
-    signalUnAuthenticated: signalUnAuthenticated,
-    signalAuthenticated: signalAuthenticated,
+    activate,
+    getAppInfo,
+    isNativeMobileApp,
+    signalUnAuthenticated,
+    signalAuthenticated,
   };
 
   return service;
@@ -118,7 +118,7 @@ function trNativeAppBridgeFactory(
             if (url) {
               e.preventDefault();
               postMessageToApp('openUrl', {
-                url: url,
+                url,
               });
             }
           });
@@ -193,7 +193,7 @@ function trNativeAppBridgeFactory(
 
     const message = angular.extend(
       {
-        action: action,
+        action,
       },
       data,
     );

--- a/modules/core/client/services/push.client.service.js
+++ b/modules/core/client/services/push.client.service.js
@@ -21,7 +21,7 @@ function push(
     isEnabled: loadEnabled(),
     isBlocked: getIsBlocked(),
 
-    init: function () {
+    init() {
       if (firebaseMessaging.shouldInitialize) {
         return setup();
       } else {
@@ -32,7 +32,7 @@ function push(
     /**
      * Enable local browser push notifications
      */
-    enable: function () {
+    enable() {
       if (!push.isSupported) return $q.reject(new Error('push is unsupported'));
       saveEnabled(true);
       return enable();
@@ -41,7 +41,7 @@ function push(
     /**
      * Disable local browser push notifications
      */
-    disable: function () {
+    disable() {
       if (!push.isSupported) return $q.reject(new Error('push is unsupported'));
       saveEnabled(false);
       return disable();
@@ -112,7 +112,7 @@ function push(
 
     $uibModal.open({
       templateUrl: questionModalTemplateUrl,
-      controller: function ($scope, $uibModalInstance) {
+      controller($scope, $uibModalInstance) {
         const vm = this;
 
         // Yes! Turn push notifications on
@@ -214,7 +214,7 @@ function push(
 
   function addTokenToServer(token) {
     return $http
-      .post('/api/users/push/registrations', { token: token, platform: 'web' })
+      .post('/api/users/push/registrations', { token, platform: 'web' })
       .then(function (res) {
         Authentication.user = res.data.user;
       })

--- a/modules/core/client/services/settings.client.service.js
+++ b/modules/core/client/services/settings.client.service.js
@@ -4,8 +4,8 @@ angular.module('core').factory('SettingsService', SettingsService);
 function SettingsService($window) {
   let settings = {};
   const service = {
-    get: get,
-    settings: settings,
+    get,
+    settings,
   };
   return service;
 
@@ -26,8 +26,8 @@ angular.module('core').factory('SettingsFactory', SettingsFactory);
 function SettingsFactory($window) {
   let settings = {};
   const service = {
-    get: get,
-    settings: settings,
+    get,
+    settings,
   };
   return service;
 

--- a/modules/core/server/controllers/analytics.server.controller.js
+++ b/modules/core/server/controllers/analytics.server.controller.js
@@ -58,7 +58,7 @@ exports.appendUTMParams = function (trackUrl, utmParams) {
     !utmParams.campaign
   ) {
     log('error', 'utmTrackify() missing one of the required variables.', {
-      trackUrl: trackUrl,
+      trackUrl,
       utmParamsSource: utmParams.source,
       utmParamsMedium: utmParams.medium,
       utmParamsCampaign: utmParams.campaign,

--- a/modules/core/server/controllers/core.server.controller.js
+++ b/modules/core/server/controllers/core.server.controller.js
@@ -42,13 +42,13 @@ exports.renderIndex = function (req, res) {
  */
 exports.renderNotFound = function (req, res) {
   res.status(404).format({
-    'text/html': function () {
+    'text/html'() {
       res.render('404.server.view.html');
     },
-    'application/json': function () {
+    'application/json'() {
       res.json({ message: errorService.getErrorMessageByKey('not-found') });
     },
-    default: function () {
+    default() {
       res.send(errorService.getErrorMessageByKey('not-found'));
     },
   });

--- a/modules/core/server/jobs/send-email.server.job.js
+++ b/modules/core/server/jobs/send-email.server.job.js
@@ -12,7 +12,7 @@ module.exports = function (job, done) {
   const jobId = _.get(job, 'attrs._id').toString();
 
   // Log that we're sending an email
-  log('debug', 'Starting `send email` job #wGcxmQ', { jobId: jobId });
+  log('debug', 'Starting `send email` job #wGcxmQ', { jobId });
 
   smtpTransport.sendMail(job.attrs.data, function (err) {
     smtpTransport.close(); // close the connection pool
@@ -20,7 +20,7 @@ module.exports = function (job, done) {
     if (err) {
       // Log the failure to send the message
       log('error', 'The `send email` job failed #VDKMbr', {
-        jobId: jobId,
+        jobId,
         error: err,
       });
 
@@ -28,7 +28,7 @@ module.exports = function (job, done) {
     } else {
       // Log the successful delivery of the message
       log('info', 'Successfully finished `send email` job #4vO5Vt', {
-        jobId: jobId,
+        jobId,
       });
 
       return done();

--- a/modules/core/server/jobs/send-facebook-notification.server.job.js
+++ b/modules/core/server/jobs/send-facebook-notification.server.job.js
@@ -10,7 +10,7 @@ module.exports = function (job, done) {
 
   // Log that we're sending an email
   log('debug', 'Starting `send facebook notification` job #jdjh73', {
-    jobId: jobId,
+    jobId,
   });
 
   // Collect parameters for FB notification object
@@ -46,7 +46,7 @@ module.exports = function (job, done) {
       if (err) {
         // Log the failure to send the notification
         log('error', 'The `send facebook notification` job failed #38hgsj', {
-          jobId: jobId,
+          jobId,
           error: err,
         });
         return done(
@@ -58,7 +58,7 @@ module.exports = function (job, done) {
           'info',
           'Successfully finished `send facebook notification` job #39jjjd',
           {
-            jobId: jobId,
+            jobId,
           },
         );
 

--- a/modules/core/server/jobs/send-push-message.server.job.js
+++ b/modules/core/server/jobs/send-push-message.server.job.js
@@ -26,7 +26,7 @@ module.exports = function (job, done) {
   const notification = data.notification;
 
   // Log that we're sending a notification
-  log('debug', 'Starting `send push notification` job', { jobId: jobId });
+  log('debug', 'Starting `send push notification` job', { jobId });
 
   // Validate notification
   if (!notification.body || !notification.click_action) {
@@ -34,7 +34,7 @@ module.exports = function (job, done) {
       'error',
       '`send push notification` job cannot send notification due missing required `body` or `click_action` values #zqo8bf',
       {
-        jobId: jobId,
+        jobId,
       },
     );
 
@@ -63,7 +63,7 @@ module.exports = function (job, done) {
           'error',
           'The `send push notification` job cannot process notification due missing platform value. #f932hf',
           {
-            jobId: jobId,
+            jobId,
           },
         );
     }
@@ -76,7 +76,7 @@ module.exports = function (job, done) {
       log(
         'debug',
         '`send push notification` job could not find Firebase tokens.',
-        { jobId: jobId },
+        { jobId },
       );
       // if not, mark as done
       resolve();
@@ -84,7 +84,7 @@ module.exports = function (job, done) {
     }
     // push to Firebase
     firebaseMessaging
-      .sendToDevice(firebaseTokens, { notification: notification })
+      .sendToDevice(firebaseTokens, { notification })
       .then(function (response) {
         const unregisteredTokens = [];
         response.results.forEach(function (result, idx) {
@@ -124,7 +124,7 @@ module.exports = function (job, done) {
     .then(function () {
       process.nextTick(function () {
         log('info', 'Successfully finished `send push message` job', {
-          jobId: jobId,
+          jobId,
         });
         return done();
       });
@@ -132,7 +132,7 @@ module.exports = function (job, done) {
     .catch(function (err) {
       process.nextTick(function () {
         log('error', 'The `send push notification` job failed', {
-          jobId: jobId,
+          jobId,
           error: err,
         });
         return done(new Error('Failed to send push message.'));
@@ -161,7 +161,7 @@ function removeUserPushTokens(userId, tokens, callback) {
         'error',
         'The `send push notification` job failed to remove invalid tokens from user. #gj932f',
         {
-          err: err,
+          err,
         },
       );
     }

--- a/modules/core/server/services/email.server.service.js
+++ b/modules/core/server/services/email.server.service.js
@@ -63,14 +63,14 @@ exports.sendMessagesUnread = function (
     urlReply: analyticsHandler.appendUTMParams(urlReply, {
       source: 'transactional-email',
       medium: 'email',
-      campaign: campaign,
+      campaign,
       content: 'reply-to',
     }),
     urlUserFromProfilePlainText: urlUserFromProfile,
     urlUserFromProfile: analyticsHandler.appendUTMParams(urlUserFromProfile, {
       source: 'transactional-email',
       medium: 'email',
-      campaign: campaign,
+      campaign,
       content: 'profile',
     }),
     utmCampaign: campaign,
@@ -96,21 +96,21 @@ exports.sendConfirmContact = function (
     subject: 'Confirm contact',
     name: friend.displayName,
     email: friend.email,
-    messageHTML: messageHTML,
-    messageText: messageText,
+    messageHTML,
+    messageText,
     meName: user.displayName,
     meURLPlainText: meURL,
     meURL: analyticsHandler.appendUTMParams(meURL, {
       source: 'transactional-email',
       medium: 'email',
-      campaign: campaign,
+      campaign,
       content: 'profile',
     }),
     urlConfirmPlainText: urlConfirm,
     urlConfirm: analyticsHandler.appendUTMParams(urlConfirm, {
       source: 'transactional-email',
       medium: 'email',
-      campaign: campaign,
+      campaign,
       content: 'confirm-contact',
     }),
     utmCampaign: campaign,
@@ -137,7 +137,7 @@ exports.sendRemoveProfile = function (user, callback) {
     urlConfirm: analyticsHandler.appendUTMParams(urlConfirm, {
       source: 'transactional-email',
       medium: 'email',
-      campaign: campaign,
+      campaign,
     }),
   });
   exports.renderEmailAndSend('remove-profile', params, callback);
@@ -173,7 +173,7 @@ exports.sendResetPassword = function (user, callback) {
     urlConfirm: analyticsHandler.appendUTMParams(urlConfirm, {
       source: 'transactional-email',
       medium: 'email',
-      campaign: campaign,
+      campaign,
     }),
   });
   exports.renderEmailAndSend('reset-password', params, callback);
@@ -193,7 +193,7 @@ exports.sendResetPasswordConfirm = function (user, callback) {
     urlResetPassword: analyticsHandler.appendUTMParams(urlResetPassword, {
       source: 'transactional-email',
       medium: 'email',
-      campaign: campaign,
+      campaign,
     }),
   });
   exports.renderEmailAndSend('reset-password-confirm', params, callback);
@@ -211,7 +211,7 @@ exports.sendChangeEmailConfirmation = function (user, callback) {
     urlConfirm: analyticsHandler.appendUTMParams(urlConfirm, {
       source: 'transactional-email',
       medium: 'email',
-      campaign: campaign,
+      campaign,
     }),
     utmCampaign: campaign,
     sparkpostCampaign: campaign,
@@ -232,7 +232,7 @@ exports.sendSignupEmailConfirmation = function (user, callback) {
     urlConfirm: analyticsHandler.appendUTMParams(urlConfirm, {
       source: 'transactional-email',
       medium: 'email',
-      campaign: campaign,
+      campaign,
     }),
     utmCampaign: campaign,
     sparkpostCampaign: campaign,
@@ -256,8 +256,8 @@ exports.sendSupportRequest = function (replyTo, supportRequest, callback) {
     from: 'Trustroots Support <' + config.supportEmail + '>',
     name: 'Trustroots Support', // `To:`
     email: config.supportEmail, // `To:`
-    replyTo: replyTo,
-    subject: subject,
+    replyTo,
+    subject,
     request: supportRequest,
     skipHtmlTemplate: true, // Don't render html template for this email
     sparkpostCampaign: 'support-request',
@@ -285,11 +285,11 @@ exports.sendSignupEmailReminder = function (user, callback) {
     urlConfirm: analyticsHandler.appendUTMParams(urlConfirm, {
       source: 'transactional-email',
       medium: 'email',
-      campaign: campaign,
+      campaign,
     }),
     utmCampaign: campaign,
     sparkpostCampaign: campaign,
-    reminderCount: reminderCount, // This email is a reminder number `n` to this user
+    reminderCount, // This email is a reminder number `n` to this user
     reminderCountMax: config.limits.maxSignupReminders, // Max n of reminders system sends
     timeAgo: moment(user.created).fromNow(), // A string, e.g. `3 days ago`
   });
@@ -308,7 +308,7 @@ exports.sendReactivateHosts = function (user, callback) {
   const utmParams = {
     source: 'transactional-email',
     medium: 'email',
-    campaign: campaign,
+    campaign,
   };
 
   const params = exports.addEmailBaseTemplateParams({
@@ -342,7 +342,7 @@ exports.sendWelcomeSequenceFirst = function (user, callback) {
   const utmParams = {
     source: 'transactional-email',
     medium: 'email',
-    campaign: campaign,
+    campaign,
   };
 
   const params = exports.addEmailBaseTemplateParams({
@@ -374,7 +374,7 @@ exports.sendWelcomeSequenceSecond = function (user, callback) {
   const utmParams = {
     source: 'transactional-email',
     medium: 'email',
-    campaign: campaign,
+    campaign,
   };
 
   const params = exports.addEmailBaseTemplateParams({
@@ -415,7 +415,7 @@ exports.sendWelcomeSequenceThird = function (user, callback) {
   const utmParams = {
     source: 'transactional-email',
     medium: 'email',
-    campaign: campaign,
+    campaign,
   };
 
   const params = exports.addEmailBaseTemplateParams({
@@ -446,8 +446,8 @@ exports.sendReferenceNotificationFirst = function (userFrom, userTo, callback) {
     subject: 'New reference from ' + userFrom.username,
     email: userTo.email,
     username: userTo.username, // data needed for link to profile in footer
-    userFrom: userFrom,
-    userTo: userTo,
+    userFrom,
+    userTo,
     userFromProfileUrl: url + '/profile/' + userFrom.username,
     giveReferenceUrl: url + '/profile/' + userFrom.username + '/references/new',
   });
@@ -468,8 +468,8 @@ exports.sendReferenceNotificationSecond = function (
     subject: 'New reference from ' + userFrom.username,
     email: userTo.email,
     username: userTo.username, // data needed for link to profile in footer
-    userFrom: userFrom,
-    userTo: userTo,
+    userFrom,
+    userTo,
     userFromProfileUrl: url + '/profile/' + userFrom.username,
     seeReferencesUrl: url + '/profile/' + userTo.username + '/references',
     recommend: reference.recommend,
@@ -506,7 +506,7 @@ exports.addEmailBaseTemplateParams = function (params) {
       source: 'transactional-email',
       medium: 'email',
       campaign: params.utmCampaign || 'transactional-email',
-      content: content,
+      content,
     });
   };
 
@@ -570,7 +570,7 @@ exports.renderEmail = function (templateName, params, callback) {
         mention: false,
         hashtag: false,
         stripPrefix: false,
-        replaceFn: function (match) {
+        replaceFn(match) {
           return '<' + match.getAnchorHref() + '>';
         },
       });

--- a/modules/core/server/services/error.server.service.js
+++ b/modules/core/server/services/error.server.service.js
@@ -81,13 +81,13 @@ exports.errorResponse = function (err, req, res, next) {
 
   // Do content negotiation and return a message
   return res.status(err.status || 500).format({
-    'text/html': function () {
+    'text/html'() {
       res.render('500.server.view.html');
     },
-    'application/json': function () {
+    'application/json'() {
       res.json(errorResponse);
     },
-    default: function () {
+    default() {
       res.send(errorResponse.message);
     },
   });

--- a/modules/core/server/services/push.server.service.js
+++ b/modules/core/server/services/push.server.service.js
@@ -74,7 +74,7 @@ exports.notifyMessagesUnread = function (userFrom, userTo, data, callback) {
 
   const notification = {
     title: 'Trustroots',
-    body: body,
+    body,
     click_action: analyticsHandler.appendUTMParams(messagesUrl, {
       source: 'push-notification',
       medium: 'fcm',
@@ -122,7 +122,7 @@ exports.sendUserNotification = function (user, notification, callback) {
   const data = {
     userId: user._id,
     pushServices: user.pushRegistration,
-    notification: notification,
+    notification,
   };
 
   agenda.now('send push message', data, callback);

--- a/modules/core/server/services/text.server.service.js
+++ b/modules/core/server/services/text.server.service.js
@@ -43,7 +43,7 @@ exports.sanitizeOptions = {
     strong: 'b',
     em: 'i',
   },
-  exclusiveFilter: function (frame) {
+  exclusiveFilter(frame) {
     // Don't allow empty <a> tags, such as:
     // - `<a href="http://trustroots.org"></a>`
     // - `<a>http://trustroots.org</a>`

--- a/modules/core/tests/client/app.client.controller.tests.js
+++ b/modules/core/tests/client/app.client.controller.tests.js
@@ -37,7 +37,7 @@ describe('App Controller Tests', function () {
 
     // Mock settings
     SettingsFactory = {
-      get: function () {
+      get() {
         return {};
       },
     };
@@ -45,7 +45,7 @@ describe('App Controller Tests', function () {
 
     // Mock languages
     Languages = {
-      get: function () {
+      get() {
         return {};
       },
     };
@@ -56,9 +56,9 @@ describe('App Controller Tests', function () {
 
     // Initialize the App controller.
     $controller('AppController as vm', {
-      $scope: $scope,
-      SettingsFactory: SettingsFactory,
-      Languages: Languages,
+      $scope,
+      SettingsFactory,
+      Languages,
     });
   }));
 

--- a/modules/core/tests/client/push.client.service.tests.js
+++ b/modules/core/tests/client/push.client.service.tests.js
@@ -33,7 +33,7 @@ describe('Push Service Tests', function () {
     notifications.length = 0;
     firebaseMessaging.shouldInitialize = false;
     $window.Notification = function (title, options) {
-      notifications.push({ title: title, options: options });
+      notifications.push({ title, options });
     };
   }));
 
@@ -54,14 +54,12 @@ describe('Push Service Tests', function () {
 
     $httpBackend
       .expect('POST', '/api/users/push/registrations', {
-        token: token,
+        token,
         platform: 'web',
       })
       .respond(200, {
         user: {
-          pushRegistration: [
-            { token: token, platform: 'web', created: Date.now() },
-          ],
+          pushRegistration: [{ token, platform: 'web', created: Date.now() }],
         },
       });
 
@@ -85,14 +83,14 @@ describe('Push Service Tests', function () {
 
     $httpBackend
       .expect('POST', '/api/users/push/registrations', {
-        token: token,
+        token,
         platform: 'web',
       })
       .respond(200, {
         user: {
           pushRegistration: [
             {
-              token: token,
+              token,
               platform: 'web',
               created: Date.now(),
             },
@@ -133,7 +131,7 @@ describe('Push Service Tests', function () {
     firebase.token = token;
     firebase.permissionGranted = true;
     Authentication.user.pushRegistration.push({
-      token: token,
+      token,
       platform: 'web',
     });
 
@@ -181,7 +179,7 @@ describe('Push Service Tests', function () {
     firebase.token = token;
     firebase.permissionGranted = true;
     Authentication.user.pushRegistration.push({
-      token: token,
+      token,
       platform: 'web',
     });
     push.enable();
@@ -213,17 +211,17 @@ function createFirebaseMock() {
 
   const firebase = {
     deletedTokens: [],
-    reset: reset,
+    reset,
     moduleName: 'firebaseMessagingMock',
 
-    triggerOnMessage: function () {
+    triggerOnMessage() {
       const args = arguments;
       onMessageCallbacks.forEach(function (fn) {
         fn.apply(null, args);
       });
     },
 
-    triggerOnTokenRefresh: function () {
+    triggerOnTokenRefresh() {
       const args = arguments;
       onTokenRefreshCallbacks.forEach(function (fn) {
         fn.apply(null, args);
@@ -251,29 +249,29 @@ function createFirebaseMock() {
     return {
       name: 'fcm-mock',
       shouldInitialize: false, // means core does not set it up for us
-      getToken: function () {
+      getToken() {
         if (firebase.permissionGranted) {
           return $q.resolve(firebase.token);
         } else {
           return $q.resolve(null);
         }
       },
-      requestPermission: function () {
+      requestPermission() {
         firebase.permissionGranted = true;
         firebase.requestPermissionCalled++;
         return $q.resolve();
       },
-      deleteToken: function (token) {
+      deleteToken(token) {
         firebase.deletedTokens.push(token);
         return $q.resolve();
       },
-      onTokenRefresh: function (fn) {
+      onTokenRefresh(fn) {
         onTokenRefreshCallbacks.push(fn);
       },
-      onMessage: function (fn) {
+      onMessage(fn) {
         onMessageCallbacks.push(fn);
       },
-      removeServiceWorker: function () {
+      removeServiceWorker() {
         firebase.removeServiceWorkerCalled++;
       },
     };

--- a/modules/core/tests/server/jobs/send-push-message.server.job.tests.js
+++ b/modules/core/tests/server/jobs/send-push-message.server.job.tests.js
@@ -33,7 +33,7 @@ describe('job: send push message', function () {
             { platform: 'web', token: '123' },
             { platform: 'web', token: '456' },
           ],
-          notification: notification,
+          notification,
         },
       },
     };
@@ -42,7 +42,7 @@ describe('job: send push message', function () {
       messages.length.should.equal(1);
       const message = messages[0];
       message.tokens.should.deepEqual(['123', '456']);
-      message.payload.should.deepEqual({ notification: notification });
+      message.payload.should.deepEqual({ notification });
       done();
     });
   });
@@ -60,7 +60,7 @@ describe('job: send push message', function () {
           // eslint-disable-next-line new-cap
           userId: mongoose.Types.ObjectId().toString(),
           pushServices: [{ platform: 'web', token: '123' }],
-          notification: notification,
+          notification,
         },
       },
     };
@@ -84,7 +84,7 @@ describe('job: send push message', function () {
           // eslint-disable-next-line new-cap
           userId: mongoose.Types.ObjectId().toString(),
           pushServices: [{ platform: 'web', token: '123' }],
-          notification: notification,
+          notification,
         },
       },
     };
@@ -109,7 +109,7 @@ describe('job: send push message', function () {
           // eslint-disable-next-line new-cap
           userId: mongoose.Types.ObjectId().toString(),
           pushServices: [{ token: '123' }, { token: '456' }],
-          notification: notification,
+          notification,
         },
       },
     };
@@ -137,7 +137,7 @@ describe('job: send push message', function () {
             { platform: 'INVALID', token: '123' },
             { platform: 'INVALID', token: '456' },
           ],
-          notification: notification,
+          notification,
         },
       },
     };
@@ -155,7 +155,7 @@ describe('job: send push message', function () {
       lastName: 'Name',
       displayName: 'Full Name',
       email: username + '@test.com',
-      username: username,
+      username,
       password: 'password123!',
       provider: 'local',
       pushRegistration: [
@@ -207,7 +207,7 @@ describe('job: send push message', function () {
               { platform: 'web', token: '456' },
               { platform: 'web', token: 'toberemoved' },
             ],
-            notification: notification,
+            notification,
           },
         },
       };
@@ -216,7 +216,7 @@ describe('job: send push message', function () {
         messages.length.should.equal(1);
         const message = messages[0];
         message.tokens.should.deepEqual(['123', '456', 'toberemoved']);
-        message.payload.should.deepEqual({ notification: notification });
+        message.payload.should.deepEqual({ notification });
         User.findOne(user._id, function (err, updatedUser) {
           if (err) return done(err);
           user.pushRegistration.length.should.equal(3);
@@ -249,8 +249,8 @@ describe('job: send push message', function () {
 
   function createFirebaseMessagingStub(shouldResponseWithError) {
     return {
-      sendToDevice: function (tokens, payload) {
-        messages.push({ tokens: tokens, payload: payload });
+      sendToDevice(tokens, payload) {
+        messages.push({ tokens, payload });
         const results = tokens.map(function (token) {
           if (shouldResponseWithError(token)) {
             return {
@@ -260,7 +260,7 @@ describe('job: send push message', function () {
             return {};
           }
         });
-        return Promise.resolve({ results: results });
+        return Promise.resolve({ results });
       },
     };
   }

--- a/modules/core/tests/server/worker.tests.js
+++ b/modules/core/tests/server/worker.tests.js
@@ -39,11 +39,11 @@ describe('Worker tests', function () {
     // Collect calls to agenda.define() and agenda.every()
 
     sinon.stub(agenda, 'define').callsFake(function (name, options, fn) {
-      definedJobs.push({ name: name, options: options, fn: fn });
+      definedJobs.push({ name, options, fn });
     });
 
     sinon.stub(agenda, 'every').callsFake(function (repeat, name) {
-      scheduledJobs.push({ repeat: repeat, name: name });
+      scheduledJobs.push({ repeat, name });
     });
 
     // Allow for easily maths for nextRunAt calculations
@@ -67,7 +67,7 @@ describe('Worker tests', function () {
         name: 'jobname',
         failCount: 0,
       },
-      save: function () {},
+      save() {},
     };
     const err = new Error('some regular error');
     const mock = sinon.mock(job).expects('save').never();
@@ -82,7 +82,7 @@ describe('Worker tests', function () {
         name: 'jobname',
         failCount: workerOptions.maxAttempts - 1,
       },
-      save: function () {},
+      save() {},
     };
     const err = new Error('ECONNREFUSED');
     const mock = sinon.mock(job).expects('save').once();
@@ -101,7 +101,7 @@ describe('Worker tests', function () {
         name: 'jobname',
         failCount: workerOptions.maxAttempts - 1,
       },
-      save: function () {},
+      save() {},
     };
     const err = new Error('ECONNRESET');
     const mock = sinon.mock(job).expects('save').once();
@@ -120,7 +120,7 @@ describe('Worker tests', function () {
         name: 'jobname',
         failCount: workerOptions.maxAttempts,
       },
-      save: function () {},
+      save() {},
     };
     const err = new Error('ECONNRESET');
     const mock = sinon.mock(job).expects('save').never();

--- a/modules/messages/client/directives/unread-count.client.directive.js
+++ b/modules/messages/client/directives/unread-count.client.directive.js
@@ -19,7 +19,7 @@ function messagesUnreadCountDirective(PollMessagesCount, Authentication) {
     scope: true,
     template:
       '<span class="notification-badge" ng-show="unread > 0" ng-bind="unread" aria-label="{{unread}} unread messages" tabindex="0"></span>',
-    link: link,
+    link,
   };
 
   return directive;

--- a/modules/messages/server/jobs/message-unread.server.job.js
+++ b/modules/messages/server/jobs/message-unread.server.job.js
@@ -307,7 +307,7 @@ function sendUnreadMessageReminders(reminder, callback) {
           // After both are done, calls `notificationCallback(err, res)`
           async.series(
             {
-              email: function (callback) {
+              email(callback) {
                 emailService.sendMessagesUnread(
                   userFrom,
                   userTo,
@@ -315,7 +315,7 @@ function sendUnreadMessageReminders(reminder, callback) {
                   callback,
                 );
               },
-              facebook: function (callback) {
+              facebook(callback) {
                 facebookNotificationService.notifyMessagesUnread(
                   userFrom,
                   userTo,
@@ -323,7 +323,7 @@ function sendUnreadMessageReminders(reminder, callback) {
                   callback,
                 );
               },
-              push: function (callback) {
+              push(callback) {
                 pushService.notifyMessagesUnread(
                   userFrom,
                   userTo,

--- a/modules/messages/server/services/message-stat.server.service.js
+++ b/modules/messages/server/services/message-stat.server.service.js
@@ -326,7 +326,7 @@ exports.readMessageStatsOfUser = function (userId, timeNow, callback) {
             replyTime = replyTimeCumulated / repliedCount;
           }
 
-          return { replyRate: replyRate, replyTime: replyTime };
+          return { replyRate, replyTime };
         })(chosenStats);
 
         return done(null, stats);
@@ -370,7 +370,7 @@ exports.formatStats = function (stats) {
     ? moment.duration(stats.replyTime).humanize()
     : '';
 
-  return { replyRate: replyRate, replyTime: replyTime };
+  return { replyRate, replyTime };
 };
 
 /**

--- a/modules/messages/server/services/message-to-stats.server.service.js
+++ b/modules/messages/server/services/message-to-stats.server.service.js
@@ -147,8 +147,8 @@ module.exports.process = function (message, callback) {
         return Message.findOne({
           $or: [
             {
-              userTo: userTo,
-              userFrom: userFrom,
+              userTo,
+              userFrom,
             },
             {
               userTo: userFrom,
@@ -231,7 +231,7 @@ module.exports.process = function (message, callback) {
           },
           values: {},
           tags: {
-            position: position, // position (first|firstReply|other)
+            position, // position (first|firstReply|other)
             messageLengthType: msgLenType, // (short|long) content (shortness defined in a config)
           },
           meta: {

--- a/modules/messages/tests/server/message-stat.server.routes.tests.js
+++ b/modules/messages/tests/server/message-stat.server.routes.tests.js
@@ -35,7 +35,7 @@ describe('Display Message Statistics in User Route', function () {
           displayName: 'displayName',
           email: 'user' + i + '@example.com',
           username: 'username' + i,
-          password: password,
+          password,
           provider: 'local',
           public: true,
         }),
@@ -130,7 +130,7 @@ describe('Display Message Statistics in User Route', function () {
 
   // Sign in
   beforeEach(function (done) {
-    const credentials = { username: users[4].username, password: password };
+    const credentials = { username: users[4].username, password };
 
     agent
       .post('/api/auth/signin')

--- a/modules/offers/client/config/offers.client.routes.js
+++ b/modules/offers/client/config/offers.client.routes.js
@@ -24,7 +24,7 @@ function OffersRoutes($stateProvider, $urlRouterProvider) {
         LocationService: 'LocationService',
 
         // Initial default location for all offer maps
-        defaultLocation: function (LocationService) {
+        defaultLocation(LocationService) {
           // Returns `{lat: Float, lng: Float, zoom: 4}`
           return LocationService.getDefaultLocation(4);
         },
@@ -41,7 +41,7 @@ function OffersRoutes($stateProvider, $urlRouterProvider) {
         // A string value resolves to a service
         OffersByService: 'OffersByService',
 
-        offers: function (OffersByService, Authentication) {
+        offers(OffersByService, Authentication) {
           return OffersByService.query({
             userId: Authentication.user._id,
             types: 'host',
@@ -81,7 +81,7 @@ function OffersRoutes($stateProvider, $urlRouterProvider) {
         // A string value resolves to a service
         OffersByService: 'OffersByService',
 
-        offers: function (OffersByService, Authentication) {
+        offers(OffersByService, Authentication) {
           return OffersByService.query({
             userId: Authentication.user._id,
             types: 'meet',

--- a/modules/offers/client/directives/tr-offer-valid-until.client.directive.js
+++ b/modules/offers/client/directives/tr-offer-valid-until.client.directive.js
@@ -98,9 +98,7 @@ function trOfferValidUntilDirective() {
 
       // Defaults to max
       // @link https://momentjs.com/docs/#/manipulating/add/
-      const add = days
-        ? { days: days }
-        : appSettings.limits.maxOfferValidFromNow;
+      const add = days ? { days } : appSettings.limits.maxOfferValidFromNow;
 
       vm.validUntil = moment().endOf('day').add(add).toDate();
     }

--- a/modules/offers/client/services/offers.client.service.js
+++ b/modules/offers/client/services/offers.client.service.js
@@ -26,7 +26,7 @@ function OffersService($resource) {
   );
 
   angular.extend(Offer.prototype, {
-    createOrUpdate: function () {
+    createOrUpdate() {
       const offer = this;
       return createOrUpdate(offer);
     },

--- a/modules/pages/client/config/pages.client.routes.js
+++ b/modules/pages/client/config/pages.client.routes.js
@@ -133,11 +133,10 @@ function PagesRoutes($stateProvider) {
     .state('about', {
       url: '/about',
       footerHidden: true,
-      controller:
-        /* @ngInject */
-        function ($state) {
-          $state.go('home');
-        },
+      /* @ngInject */
+      controller($state) {
+        $state.go('home');
+      },
       controllerAs: 'about',
     });
 

--- a/modules/search/client/config/search.client.routes.js
+++ b/modules/search/client/config/search.client.routes.js
@@ -18,7 +18,7 @@ function SearchRoutes($stateProvider) {
       resolve: {
         // A string value resolves to a service
         OffersService: 'OffersService',
-        offer: function ($stateParams, OffersService) {
+        offer($stateParams, OffersService) {
           if ($stateParams.offer && $stateParams.offer.length === 24) {
             return OffersService.get({
               offerId: $stateParams.offer,
@@ -30,7 +30,7 @@ function SearchRoutes($stateProvider) {
 
         // A string value resolves to a service
         TribeService: 'TribeService',
-        tribe: function (TribeService, $stateParams) {
+        tribe(TribeService, $stateParams) {
           if ($stateParams.tribe && $stateParams.tribe.length) {
             return TribeService.get({
               tribeSlug: $stateParams.tribe,

--- a/modules/search/client/services/filters.client.service.js
+++ b/modules/search/client/services/filters.client.service.js
@@ -32,8 +32,8 @@ function FiltersService($log, Authentication, locker) {
   filters = angular.extend(defaultFilters, filters);
 
   const service = {
-    set: set,
-    get: get,
+    set,
+    get,
   };
 
   return service;

--- a/modules/search/client/services/search-map.client.service.js
+++ b/modules/search/client/services/search-map.client.service.js
@@ -15,8 +15,8 @@ function SearchMapService($q, $log, Authentication, LocationService, locker) {
     : 'search.mapCenter';
 
   const service = {
-    getMapCenter: getMapCenter,
-    cacheMapCenter: cacheMapCenter,
+    getMapCenter,
+    cacheMapCenter,
   };
 
   return service;

--- a/modules/sparkpost/server/controllers/sparkpost-webhooks.server.controller.js
+++ b/modules/sparkpost/server/controllers/sparkpost-webhooks.server.controller.js
@@ -156,8 +156,8 @@ exports.processAndSendMetrics = function (event, callback) {
     counts: {
       count: 1,
     },
-    tags: tags,
-    meta: meta,
+    tags,
+    meta,
   };
 
   // Set `time` field to event's timestamp

--- a/modules/statistics/client/config/statistics.client.routes.js
+++ b/modules/statistics/client/config/statistics.client.routes.js
@@ -13,7 +13,7 @@ function StatisticsRoutes($stateProvider) {
     resolve: {
       // A string value resolves to a service
       SettingsService: 'Statistics',
-      statisticsData: function (Statistics) {
+      statisticsData(Statistics) {
         return Statistics.get();
       },
     },

--- a/modules/statistics/client/controllers/statistics.client.controller.js
+++ b/modules/statistics/client/controllers/statistics.client.controller.js
@@ -42,8 +42,8 @@ function StatisticsController($scope, $interval, Statistics, statisticsData) {
     vm.connections = [];
     angular.forEach(data.connected, function (count, network) {
       vm.connections.push({
-        network: network,
-        count: count,
+        network,
+        count,
       });
     });
   }

--- a/modules/statistics/server/jobs/daily-statistics.server.job.js
+++ b/modules/statistics/server/jobs/daily-statistics.server.job.js
@@ -39,7 +39,7 @@ module.exports = function (job, agendaDone) {
             {
               namespace: 'members',
               values: {
-                count: count,
+                count,
               },
               tags: {
                 members: 'members',
@@ -67,7 +67,7 @@ module.exports = function (job, agendaDone) {
             {
               namespace: 'pushRegistrations',
               values: {
-                count: count,
+                count,
               },
               tags: {
                 type: 'all',
@@ -143,7 +143,7 @@ module.exports = function (job, agendaDone) {
                 {
                   namespace: 'offers',
                   values: {
-                    count: count,
+                    count,
                     percentage: (count / totalUserCount) * 100,
                   },
                   tags: {
@@ -172,7 +172,7 @@ module.exports = function (job, agendaDone) {
             {
               namespace: 'offers',
               values: {
-                count: count,
+                count,
               },
               tags: {
                 type: 'meet',
@@ -216,7 +216,7 @@ module.exports = function (job, agendaDone) {
                 {
                   namespace: 'membersInNetworks',
                   values: {
-                    count: count,
+                    count,
                     percentage: (count / totalUserCount) * 100,
                   },
                   tags: {
@@ -330,9 +330,9 @@ function collectLastSeen(seenSinceDays, namespace, totalUserCount, callback) {
     }
     writeDailyStat(
       {
-        namespace: namespace,
+        namespace,
         values: {
-          count: count,
+          count,
           percentage: (count / totalUserCount) * 100,
         },
         tags: {

--- a/modules/stats/server/services/influx.server.service.js
+++ b/modules/stats/server/services/influx.server.service.js
@@ -80,8 +80,8 @@ const writeMeasurement = function (measurementName, fields, tags, callback) {
 
   // the point is the IPoint we'll send to node-influx's writeMeasurement
   const point = {
-    fields: fields,
-    tags: tags,
+    fields,
+    tags,
   };
 
   // deal with the time
@@ -123,8 +123,8 @@ const writeMeasurement = function (measurementName, fields, tags, callback) {
           {
             error: err,
             measurement: measurementName,
-            fields: fields,
-            tags: tags,
+            fields,
+            tags,
           },
         );
 

--- a/modules/stats/server/services/stats.server.service.js
+++ b/modules/stats/server/services/stats.server.service.js
@@ -102,7 +102,7 @@ function count(name, count, time, callback) {
   const statObject = {
     namespace: name,
     counts: {
-      count: count,
+      count,
     },
   };
 
@@ -134,7 +134,7 @@ function value(name, value, time, callback) {
   const statObject = {
     namespace: name,
     values: {
-      value: value,
+      value,
     },
   };
 

--- a/modules/tribes/client/config/tribes.client.routes.js
+++ b/modules/tribes/client/config/tribes.client.routes.js
@@ -33,7 +33,7 @@ function TribesRoutes($stateProvider) {
       resolve: {
         // A string value resolves to a service
         TribeService: 'TribeService',
-        tribe: function (TribeService, $stateParams) {
+        tribe(TribeService, $stateParams) {
           return TribeService.get({
             tribeSlug: $stateParams.circle,
           });

--- a/modules/tribes/client/directives/tr-tribe-styles.client.directive.js
+++ b/modules/tribes/client/directives/tr-tribe-styles.client.directive.js
@@ -14,7 +14,7 @@ function trTribeStylesDirective() {
     restrict: 'A',
     replace: false,
     scope: false,
-    link: function (scope, elem, attrs) {
+    link(scope, elem, attrs) {
       if (
         !angular.isDefined(attrs.trTribeStyles) ||
         attrs.trTribeStyles === '' ||

--- a/modules/tribes/client/services/tribe.client.service.js
+++ b/modules/tribes/client/services/tribe.client.service.js
@@ -18,9 +18,9 @@ function TribeService($resource, $q, $log) {
   let cachedTribe;
 
   const service = {
-    fillCache: fillCache,
-    clearCache: clearCache,
-    get: get,
+    fillCache,
+    clearCache,
+    get,
   };
 
   return service;

--- a/modules/tribes/server/controllers/tribes.server.controller.js
+++ b/modules/tribes/server/controllers/tribes.server.controller.js
@@ -85,7 +85,7 @@ exports.tribeBySlug = function (req, res, next, slug) {
   Tribe.findOne(
     {
       public: true,
-      slug: slug,
+      slug,
     },
     exports.tribeFields,
   ).exec(function (err, tribe) {

--- a/modules/tribes/server/models/tribe.server.model.js
+++ b/modules/tribes/server/models/tribe.server.model.js
@@ -167,7 +167,7 @@ TribeSchema.virtual('new').get(function () {
 TribeSchema.plugin(
   urlslugs('label', {
     field: 'slug',
-    generator: function (string) {
+    generator(string) {
       return speakingurl(string, {
         separator: '-', // char that replaces the whitespaces
         maintainCase: false, // maintain case (true, convert all chars to lower case (false)

--- a/modules/users/client/components/ProfileViewBasics.js
+++ b/modules/users/client/components/ProfileViewBasics.js
@@ -17,10 +17,10 @@ export default function ProfileViewBasics({ profile }) {
     t('{{birthdate, age}} years', { birthdate: new Date(birthdate) });
 
   const getReplyRate = replyRate =>
-    t('Reply rate {{replyRate}}.', { replyRate: replyRate });
+    t('Reply rate {{replyRate}}.', { replyRate });
 
   const getReplyTime = replyTime =>
-    t('Replies within {{replyTime, fromNow}}.', { replyTime: replyTime });
+    t('Replies within {{replyTime, fromNow}}.', { replyTime });
 
   const getMemberSince = created =>
     t('Member since {{date, MMM Do, YYYY}}', { date: new Date(created) });

--- a/modules/users/client/config/users.client.config.js
+++ b/modules/users/client/config/users.client.config.js
@@ -10,7 +10,7 @@ function UsersConfig($httpProvider) {
     'Authentication',
     function ($q, $location, Authentication) {
       return {
-        responseError: function (rejection) {
+        responseError(rejection) {
           if (rejection.config.url.startsWith('/api/')) {
             switch (rejection.status) {
               case 401:

--- a/modules/users/client/config/users.client.routes.js
+++ b/modules/users/client/config/users.client.routes.js
@@ -30,11 +30,10 @@ function UsersRoutes($stateProvider) {
     // Invite route deprecated in 11-2018
     .state('invite', {
       url: '/invite',
-      controller:
-        /* @ngInject */
-        function ($state) {
-          $state.go('signup');
-        },
+      /* @ngInject */
+      controller($state) {
+        $state.go('signup');
+      },
       controllerAs: 'invite',
       requiresAuth: false,
       data: {
@@ -77,7 +76,7 @@ function UsersRoutes($stateProvider) {
       resolve: {
         // A string value resolves to a service
         SettingsService: 'SettingsService',
-        appSettings: function (SettingsService) {
+        appSettings(SettingsService) {
           return SettingsService.get();
         },
       },
@@ -94,7 +93,7 @@ function UsersRoutes($stateProvider) {
       resolve: {
         // A string value resolves to a service
         SettingsService: 'SettingsService',
-        appSettings: function (SettingsService) {
+        appSettings(SettingsService) {
           return SettingsService.get();
         },
       },
@@ -136,11 +135,11 @@ function UsersRoutes($stateProvider) {
         SettingsService: 'SettingsService',
         ContactsListService: 'ContactsListService',
 
-        appSettings: function (SettingsService) {
+        appSettings(SettingsService) {
           return SettingsService.get();
         },
 
-        profile: function (UserProfilesService, $stateParams, $q) {
+        profile(UserProfilesService, $stateParams, $q) {
           return UserProfilesService.get({
             username: $stateParams.username,
           }).$promise.catch(function (e) {
@@ -154,7 +153,7 @@ function UsersRoutes($stateProvider) {
         },
 
         // Contact is loaded only after profile is loaded, because we need the profile ID
-        contact: function (ContactByService, profile, Authentication) {
+        contact(ContactByService, profile, Authentication) {
           return profile.$promise.then(
             function (profile) {
               // when user doesn't exist, no need to load contact
@@ -181,7 +180,7 @@ function UsersRoutes($stateProvider) {
         },
 
         // Contacts list is loaded only after profile is loaded, because we need the profile ID
-        contacts: function (ContactsListService, profile) {
+        contacts(ContactsListService, profile) {
           return profile.$promise.then(function (profile) {
             // when user doesn't exist, no need to load contacts
             if (!profile._id) {
@@ -270,7 +269,7 @@ function UsersRoutes($stateProvider) {
         // A string value resolves to a service
         SettingsService: 'SettingsService',
 
-        appSettings: function (SettingsService) {
+        appSettings(SettingsService) {
           return SettingsService.get();
         },
       },
@@ -289,7 +288,7 @@ function UsersRoutes($stateProvider) {
         // A string value resolves to a service
         SettingsService: 'SettingsService',
 
-        appSettings: function (SettingsService) {
+        appSettings(SettingsService) {
           return SettingsService.get();
         },
       },

--- a/modules/users/client/directives/tr-avatar.client.directive.js
+++ b/modules/users/client/directives/tr-avatar.client.directive.js
@@ -153,7 +153,7 @@ angular.module('users').directive('trAvatar', [
           });
         },
       ],
-      link: function (scope, element, attr) {
+      link(scope, element, attr) {
         // Make sure source won't change dynamicly when user changes
         if (attr.source) {
           scope.source = attr.source;

--- a/modules/users/client/directives/tr-confirm-password.client.directive.js
+++ b/modules/users/client/directives/tr-confirm-password.client.directive.js
@@ -20,7 +20,7 @@ function trConfirmPasswordDirective() {
     scope: {
       comparisonValue: '=trConfirmPassword',
     },
-    link: function (scope, element, attributes, ngModel) {
+    link(scope, element, attributes, ngModel) {
       ngModel.$validators.confirmPassword = function (modelValue) {
         return modelValue === scope.comparisonValue;
       };

--- a/modules/users/client/directives/tr-validate-username.client.directive.js
+++ b/modules/users/client/directives/tr-validate-username.client.directive.js
@@ -22,7 +22,7 @@ function trValidateUsernameDirective($q, $timeout, SignupValidation) {
   return {
     restrict: 'A',
     require: 'ngModel',
-    link: function (scope, elem, attr, ngModel) {
+    link(scope, elem, attr, ngModel) {
       const minlength = angular.isDefined(attr.minlength) ? attr.minlength : 1;
 
       ngModel.$asyncValidators.username = function (modelValue) {

--- a/modules/users/client/services/users.client.service.js
+++ b/modules/users/client/services/users.client.service.js
@@ -24,13 +24,13 @@ function UsersFactory($resource) {
   );
 
   angular.extend(Users, {
-    deleteWithToken: function (token) {
+    deleteWithToken(token) {
       return this.deleteConfirm(
         {
-          token: token, // api expects token as a parameter (i.e. /:token)
+          token, // api expects token as a parameter (i.e. /:token)
         },
         {
-          token: token,
+          token,
         },
       ).$promise;
     },

--- a/modules/users/server/config/strategies/facebook.js
+++ b/modules/users/server/config/strategies/facebook.js
@@ -32,9 +32,9 @@ module.exports = function (config) {
   passport.use(
     new FacebookStrategy(
       {
-        clientID: clientID,
-        clientSecret: clientSecret,
-        callbackURL: callbackURL,
+        clientID,
+        clientSecret,
+        callbackURL,
         // Available fields:
         // @link https://developers.facebook.com/docs/graph-api/reference/user/
         // Validate fields using Graph explorer (`/me?fields=id,name,...`):
@@ -71,7 +71,7 @@ module.exports = function (config) {
           email: _.get(profile, 'email', undefined),
           provider: 'facebook',
           providerIdentifierField: 'id',
-          providerData: providerData,
+          providerData,
         };
 
         // Save the user OAuth profile

--- a/modules/users/server/config/strategies/github.js
+++ b/modules/users/server/config/strategies/github.js
@@ -21,9 +21,9 @@ module.exports = function (config) {
   passport.use(
     new GithubStrategy(
       {
-        clientID: clientID,
-        clientSecret: clientSecret,
-        callbackURL: callbackURL,
+        clientID,
+        clientSecret,
+        callbackURL,
         passReqToCallback: true,
       },
       function (req, accessToken, refreshToken, profile, done) {
@@ -39,7 +39,7 @@ module.exports = function (config) {
           username: profile.username || undefined,
           provider: 'github',
           providerIdentifierField: 'id',
-          providerData: providerData,
+          providerData,
         };
 
         // Save the user OAuth profile

--- a/modules/users/server/config/strategies/twitter.js
+++ b/modules/users/server/config/strategies/twitter.js
@@ -23,7 +23,7 @@ module.exports = function (config) {
       {
         consumerKey: clientID,
         consumerSecret: clientSecret,
-        callbackURL: callbackURL,
+        callbackURL,
         passReqToCallback: true,
       },
       function (req, token, tokenSecret, profile, done) {
@@ -38,7 +38,7 @@ module.exports = function (config) {
           username: _.get(profile, 'username', undefined),
           provider: 'twitter',
           providerIdentifierField: 'id_str',
-          providerData: providerData,
+          providerData,
         };
 
         // Save the user OAuth profile

--- a/modules/users/server/controllers/users.authentication.server.controller.js
+++ b/modules/users/server/controllers/users.authentication.server.controller.js
@@ -191,7 +191,7 @@ exports.signupValidation = function (req, res) {
       function (done) {
         User.findOne(
           {
-            username: username,
+            username,
           },
           function (err, user) {
             if (user) {
@@ -342,15 +342,15 @@ exports.oauthCallback = function (strategy) {
     passport.authenticate(strategy, function (err, user, redirectURL) {
       if (err) {
         log('error', 'oAuth callback error #h3hg82', {
-          strategy: strategy,
-          err: err,
+          strategy,
+          err,
         });
         return res.redirect(defaultRedirectUrl);
       }
 
       if (!user) {
         log('error', 'oAuth callback requires authenticated user #g82bff', {
-          strategy: strategy,
+          strategy,
         });
         return res.redirect('/signin');
       }
@@ -358,7 +358,7 @@ exports.oauthCallback = function (strategy) {
       req.login(user, function (err) {
         if (err) {
           log('error', 'oAuth callback failed to login user #h2bgff', {
-            strategy: strategy,
+            strategy,
           });
           return res.redirect('/signin');
         }

--- a/modules/users/server/controllers/users.password.server.controller.js
+++ b/modules/users/server/controllers/users.password.server.controller.js
@@ -350,7 +350,7 @@ exports.changePassword = function (req, res) {
         emailService.sendResetPasswordConfirm(user, function (err) {
           if (err) return done(err);
           return res.send({
-            user: user,
+            user,
             message: 'Password changed successfully!',
           });
         });

--- a/modules/users/server/controllers/users.profile.server.controller.js
+++ b/modules/users/server/controllers/users.profile.server.controller.js
@@ -993,7 +993,7 @@ exports.joinTribe = function (req, res) {
             res.send({
               message: 'Joined tribe.',
               tribe: pickedTribe,
-              user: user,
+              user,
             });
 
             done();
@@ -1107,7 +1107,7 @@ exports.leaveTribe = function (req, res) {
             res.send({
               message: 'Left tribe.',
               tribe: pickedTribe,
-              user: user,
+              user,
             });
 
             done();
@@ -1175,7 +1175,7 @@ exports.removePushRegistration = function (req, res) {
   const query = {
     $pull: {
       pushRegistration: {
-        token: token,
+        token,
       },
     },
   };
@@ -1241,7 +1241,7 @@ exports.addPushRegistration = function (req, res) {
         User.findByIdAndUpdate(user._id, {
           $pull: {
             pushRegistration: {
-              token: token,
+              token,
             },
           },
         }).exec(function (err) {
@@ -1253,8 +1253,8 @@ exports.addPushRegistration = function (req, res) {
 
       function (done) {
         const registration = {
-          platform: platform,
-          token: token,
+          platform,
+          token,
           created: Date.now(),
         };
 

--- a/modules/users/server/controllers/users.suspended.server.controller.js
+++ b/modules/users/server/controllers/users.suspended.server.controller.js
@@ -30,13 +30,13 @@ exports.invalidateSuspendedSessions = function (req, res, next) {
       // https://expressjs.com/en/api.html#res.format
       res.status(403).format({
         // For HTML calls send "suspended" html view
-        'text/html': function () {
+        'text/html'() {
           res.render('suspended.server.view.html', {
             message: suspendedMessage,
           });
         },
         // For API calls send "suspended" json message
-        'application/json': function () {
+        'application/json'() {
           res.json({
             message: suspendedMessage,
           });

--- a/modules/users/tests/client/authentication.client.controller.tests.js
+++ b/modules/users/tests/client/authentication.client.controller.tests.js
@@ -40,8 +40,8 @@ describe('AuthenticationController', function () {
 
       // Initialize the Authentication controller
       AuthenticationController = $controller('AuthenticationController', {
-        $scope: $scope,
-        appSettings: appSettings,
+        $scope,
+        appSettings,
       });
 
       $scope.vm = AuthenticationController;
@@ -111,8 +111,8 @@ describe('AuthenticationController', function () {
         };
 
         AuthenticationController = $controller('AuthenticationController', {
-          $scope: $scope,
-          appSettings: appSettings,
+          $scope,
+          appSettings,
         });
       }));
 

--- a/modules/users/tests/client/password-forgot.client.controller.tests.js
+++ b/modules/users/tests/client/password-forgot.client.controller.tests.js
@@ -36,7 +36,7 @@ describe('ForgotPasswordController', function () {
 
       // Initialize the Authentication controller
       $controller('ForgotPasswordController as vm', {
-        $scope: $scope,
+        $scope,
       });
     }));
 

--- a/modules/users/tests/client/password-reset.client.controller.tests.js
+++ b/modules/users/tests/client/password-reset.client.controller.tests.js
@@ -41,7 +41,7 @@ describe('ResetPasswordController', function () {
 
       // Initialize the Authentication controller
       $controller('ResetPasswordController as vm', {
-        $scope: $scope,
+        $scope,
       });
     }));
 

--- a/modules/users/tests/client/profile-edit-account.client.controller.tests.js
+++ b/modules/users/tests/client/profile-edit-account.client.controller.tests.js
@@ -41,7 +41,7 @@ describe('ProfileEditAccountController', function () {
         ProfileEditAccountController = $controller(
           'ProfileEditAccountController',
           {
-            messageCenterService: messageCenterService,
+            messageCenterService,
             $scope: $rootScope.$new(),
             push: {}, // this ends up trying to load firebaseMessaging service otherwise
           },

--- a/modules/users/tests/server/user-lastseen.server.tests.js
+++ b/modules/users/tests/server/user-lastseen.server.tests.js
@@ -130,7 +130,7 @@ describe('User last seen CRUD tests', function () {
         .expect(200)
         .end(function () {
           // read user from database
-          User.findOne({ username: username }, function (err, user) {
+          User.findOne({ username }, function (err, user) {
             try {
               should(user.seen).eql(originalTime);
 
@@ -141,7 +141,7 @@ describe('User last seen CRUD tests', function () {
                 .expect(200)
                 .end(function () {
                   // and the User.seen should not be updated (too early)
-                  User.findOne({ username: username }, function (err, user) {
+                  User.findOne({ username }, function (err, user) {
                     try {
                       should(user.seen).eql(originalTime);
 
@@ -153,10 +153,7 @@ describe('User last seen CRUD tests', function () {
                         .expect(200)
                         .end(function () {
                           // and the User.seen should be updated now
-                          User.findOne({ username: username }, function (
-                            err,
-                            user,
-                          ) {
+                          User.findOne({ username }, function (err, user) {
                             should(user.seen).eql(new Date());
 
                             return done();

--- a/testutils/server/server.testutil.js
+++ b/testutils/server/server.testutil.js
@@ -20,7 +20,7 @@ exports.catchJobs = function () {
     originalNow = agenda.now;
     agenda.now = function (type, data, callback) {
       // ensure it is plain data by serializing to json and back
-      jobs.push(JSON.parse(JSON.stringify({ type: type, data: data })));
+      jobs.push(JSON.parse(JSON.stringify({ type, data })));
 
       // run in nextTick() to simulate async action that real agenda would do
       process.nextTick(function () {
@@ -53,7 +53,7 @@ exports.catchEmails = function () {
     config.mailer.options = {
       name: 'testsend',
       version: '1',
-      send: function (data, callback) {
+      send(data, callback) {
         sentEmails.push(data);
         callback();
       },


### PR DESCRIPTION
#### Proposed Changes

* Add [`object-shorthand`](https://eslint.org/docs/rules/object-shorthand) Eslint rule. Works in both backend and frontend code.
* Run `eslint --fix` to automatically handle all the existing rule violations in codebase 

#### Testing Instructions

Should complain:
```js
const foo = 1;
const bar = { foo: foo };
```

![image](https://user-images.githubusercontent.com/87168/101985845-154a9300-3c93-11eb-8339-a472dfb69c93.png)


Should work:
```js
const foo = 1;
const bar = { foo };
```

