### PR TITLE
Fix: circle images on homepage

### DIFF
--- a/modules/pages/client/components/Home.component.js
+++ b/modules/pages/client/components/Home.component.js
@@ -234,7 +234,7 @@ export default function Home({ user, isNativeMobileApp, photoCredits }) {
                     key={tribe._id}
                     href={`/circles/${tribe.slug}`}
                     className="img-circle tribe-xs tribe-image"
-                    style={getCircleBackgroundStyle(tribe, '520x520')}
+                    style={getCircleBackgroundStyle(tribe, '742x496')}
                   >
                     {!tribe.image && <span>{tribe.label.charAt(0)}</span>}
                   </a>
@@ -249,7 +249,7 @@ export default function Home({ user, isNativeMobileApp, photoCredits }) {
                 >
                   <div
                     className="img-circle tribe tribe-image"
-                    style={getCircleBackgroundStyle(tribe, '1024x768')}
+                    style={getCircleBackgroundStyle(tribe, '742x496')}
                   >
                     <a href={`/circles/${tribe.slug}`} className="tribe-link">
                       <h3 className="tribe-label">{tribe.label}</h3>


### PR DESCRIPTION
#### Proposed Changes

* Fix circle images on homepage not working:

<img width="1262" alt="Screenshot 2020-12-12 at 19 20 24" src="https://user-images.githubusercontent.com/87168/101990373-5a7cbe00-3caf-11eb-94bd-bef7f8857129.png">

To avoid generating a ton of images, only these values are accepted:

https://github.com/Trustroots/trustroots/blob/bb33b1801705468845f97e61d1a99022a4deae8c/bin/generate-circle-images.js#L19-L24

I left invalid values when migrating from externally hosted images to self-hosted ones some weeks ago.

#### Testing Instructions

- Have images with circle slugs at `public/uploads-circle`
- Run `npm run generate-circle-images` to generate correct sizes
- Load homepage, and circle should have images loading

Or just confirm image size looks correct :-) 