### PR TITLE
Compare references on the client based on the id rather than username

### DIFF
--- a/modules/references/client/components/CreateReference.component.js
+++ b/modules/references/client/components/CreateReference.component.js
@@ -41,7 +41,7 @@ export default function CreateReference({ userFrom, userTo }) {
       });
 
       references.forEach(reference => {
-        if (reference.userFrom.username === userFrom.username) {
+        if (reference.userFrom._id === userFrom._id) {
           setIsDuplicate(true);
         }
       });

--- a/modules/references/client/components/ListReferences.component.js
+++ b/modules/references/client/components/ListReferences.component.js
@@ -19,20 +19,19 @@ export default function ListReferences({ profile, authenticatedUser }) {
   const [isLoading, setIsLoading] = useState(true);
 
   function pairUpExperiences(experiences) {
-    /* TODO: compare by ids (couldn't make it work, so I used usernames to compare for now) */
     const experiencePairsDict = experiences
-      .filter(experience => experience.userTo.username === profile.username)
+      .filter(experience => experience.userTo._id === profile._id)
       .reduce(
         (a, exp) => ({
           ...a,
-          [exp.userFrom.username]: { sharedWithUser: exp },
+          [exp.userFrom._id]: { sharedWithUser: exp },
         }),
         {},
       );
 
     experiences.forEach(experience => {
-      if (experience.userFrom.username === profile.username) {
-        const userTo = experience.userTo.username;
+      if (experience.userFrom._id === profile._id) {
+        const userTo = experience.userTo._id;
         if (experiencePairsDict[userTo] === undefined) {
           experiencePairsDict[userTo] = {};
         }

--- a/modules/references/server/controllers/reference.server.controller.js
+++ b/modules/references/server/controllers/reference.server.controller.js
@@ -418,7 +418,7 @@ exports.readMany = async function readMany(req, res, next) {
 
     // Aggregate projection for User in reference
     const userKeys = {
-      id: 1,
+      _id: 1,
       updated: 1,
       displayName: 1,
       username: 1,


### PR DESCRIPTION
#### Proposed Changes

* use `_id` field to compare experiences instead of `username`.

as discussed here: https://github.com/Trustroots/trustroots/pull/1667#discussion_r537352161

#### Testing Instructions

* Go to a profile with many experiences among which there are ones with replies. Check that they are displayed properly and that the replies are present.
* Share an experience with someone. It should not be possible to share another experience with the same person. 


Ongoing work on #1493 
