### PR TITLE
Add experience list indentation

### DIFF
--- a/modules/references/client/components/read-references/Reference.js
+++ b/modules/references/client/components/read-references/Reference.js
@@ -55,6 +55,16 @@ const FeedbackPublic = styled.div`
   max-width: 600px;
 `;
 
+const ReferenceContainer = styled.div`
+  margin-left: 0;
+
+  ${props =>
+    props.inCreatorProfile &&
+    `
+      margin-left: 20px;
+    `}
+`;
+
 export default function Reference({ reference, inRecipientProfile }) {
   const { t } = useTranslation('references');
 
@@ -84,10 +94,13 @@ export default function Reference({ reference, inRecipientProfile }) {
   const inCreatorProfile = !inRecipientProfile;
 
   return (
-    <div className="panel panel-default" id={_id}>
+    <ReferenceContainer
+      className="panel panel-default"
+      id={_id}
+      inCreatorProfile={inCreatorProfile}
+    >
       <div className="panel-body reference">
         <ReferenceHeading>
-          {inCreatorProfile && <div>{t('their reply')}</div>}
           <Avatar user={userFrom} size={36} />
           <UserMeta>
             <strong>
@@ -102,14 +115,14 @@ export default function Reference({ reference, inRecipientProfile }) {
               </span>
             )}
           </UserMeta>
-          {inRecipientProfile && (
-            <a
-              className="reference-time"
-              href={`/profile/${userTo.username}/experiences#${_id}`}
-            >
-              <TimeAgo date={createdDate} />
-            </a>
-          )}
+          <a
+            className="reference-time"
+            href={`/profile/${
+              inRecipientProfile ? userTo.username : userFrom.username
+            }/references#${_id}`}
+          >
+            <TimeAgo date={createdDate} />
+          </a>
         </ReferenceHeading>
 
         {!isPublicReference && (
@@ -146,7 +159,7 @@ export default function Reference({ reference, inRecipientProfile }) {
         />
         {feedbackPublic && <FeedbackPublic>{feedbackPublic}</FeedbackPublic>}
       </div>
-    </div>
+    </ReferenceContainer>
   );
 }
 

--- a/modules/references/client/components/read-references/Reference.js
+++ b/modules/references/client/components/read-references/Reference.js
@@ -12,33 +12,6 @@ import Meta from './Meta';
 import TimeAgo from '@/modules/core/client/components/TimeAgo';
 import UserLink from '@/modules/users/client/components/UserLink';
 
-const ReferenceHeading = styled.div`
-  display: flex;
-  flex-wrap: wrap-reverse;
-  line-height: 1.3em;
-
-  .avatar {
-    margin-right: 10px;
-  }
-
-  .reference-time {
-    margin-left: auto;
-    color: #333;
-  }
-
-  @media (max-width: 480px) {
-   .reference-time {
-     width: 100%;
-     margin-left: 0;
-     margin-bottom: 10px;
-   }
-`;
-
-const UserMeta = styled.div`
-  display: flex;
-  flex-direction: column;
-`;
-
 const PendingNotice = styled.div`
   font-style: italic;
   padding: 20px 0;
@@ -55,17 +28,50 @@ const FeedbackPublic = styled.div`
   max-width: 600px;
 `;
 
-const ReferenceContainer = styled.div`
-  margin-left: 0;
+const Response = styled.div`
+  border-top: 1px solid #ccc;
+  margin: 20px 0 0 20px;
+  padding: 20px 0 0 0;
 
-  ${({ inRecipientProfile }) =>
-    !inRecipientProfile &&
-    `
-      margin-left: 20px;
-    `}
+  @media (max-width: 480px) {
+    margin-left: 10px;
+  }
 `;
 
-export default function Reference({ reference, inRecipientProfile }) {
+const Header = styled.div`
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap-reverse;
+  line-height: 1.3em;
+
+  .avatar {
+    margin-right: 10px;
+  }
+`;
+
+const UserMeta = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const ReferenceLink = styled.a`
+  align-self: start;
+  margin-left: auto;
+  color: #333;
+
+  @media (max-width: 480px) {
+    width: 100%;
+    margin-left: 0;
+    margin-bottom: 10px;
+  }
+`;
+
+const UserLinkStyled = styled(UserLink)`
+  font-weight: bold;
+  margin-right: 5px;
+`;
+
+export default function Reference({ reference, response }) {
   const { t } = useTranslation('references');
 
   const {
@@ -92,37 +98,24 @@ export default function Reference({ reference, inRecipientProfile }) {
     );
 
   return (
-    <ReferenceContainer
-      className="panel panel-default"
-      id={_id}
-      inRecipientProfile={inRecipientProfile}
-    >
+    <div className="panel panel-default" id={_id}>
       <div className="panel-body">
-        <ReferenceHeading>
+        <Header>
           <Avatar user={userFrom} size={36} />
           <UserMeta>
-            <strong>
-              <UserLink user={userFrom} />
-            </strong>
-            {inRecipientProfile && (
-              <span className="muted">
-                {userFrom.gender && `${getGender(userFrom.gender)}. `}
-                {t('Member since {{date, YYYY}}.', {
+            <UserLinkStyled user={userFrom} />
+            <span className="muted">
+              {userFrom?.gender && `${getGender(userFrom.gender)}. `}
+              {userFrom?.created &&
+                t('Member since {{date, YYYY}}.', {
                   date: new Date(userFrom.created),
                 })}
-              </span>
-            )}
+            </span>
           </UserMeta>
-          <a
-            className="reference-time"
-            href={`/profile/${
-              inRecipientProfile ? userTo.username : userFrom.username
-            }/references#${_id}`}
-          >
+          <ReferenceLink href={`/profile/${userTo.username}/references#${_id}`}>
             <TimeAgo date={createdDate} />
-          </a>
-        </ReferenceHeading>
-
+          </ReferenceLink>
+        </Header>
         {!isPublicReference && (
           <>
             <PendingNotice>
@@ -156,12 +149,30 @@ export default function Reference({ reference, inRecipientProfile }) {
           recommend={recommend}
         />
         {feedbackPublic && <FeedbackPublic>{feedbackPublic}</FeedbackPublic>}
+        {response && (
+          <Response>
+            <Header>
+              <Avatar user={response.userFrom} size={24} />
+              <UserLinkStyled user={response.userFrom} />
+              (<TimeAgo date={new Date(response.created)} />)
+            </Header>
+            <Meta
+              hostedMe={response.hostedMe}
+              hostedThem={response.hostedThem}
+              met={response.met}
+              recommend={response.recommend}
+            />
+            {response.feedbackPublic && (
+              <FeedbackPublic>{response.feedbackPublic}</FeedbackPublic>
+            )}
+          </Response>
+        )}
       </div>
-    </ReferenceContainer>
+    </div>
   );
 }
 
 Reference.propTypes = {
   reference: PropTypes.object.isRequired,
-  inRecipientProfile: PropTypes.bool.isRequired,
+  response: PropTypes.object,
 };

--- a/modules/references/client/components/read-references/Reference.js
+++ b/modules/references/client/components/read-references/Reference.js
@@ -58,8 +58,8 @@ const FeedbackPublic = styled.div`
 const ReferenceContainer = styled.div`
   margin-left: 0;
 
-  ${props =>
-    props.inCreatorProfile &&
+  ${({ inRecipientProfile }) =>
+    !inRecipientProfile &&
     `
       margin-left: 20px;
     `}
@@ -91,15 +91,13 @@ export default function Reference({ reference, inRecipientProfile }) {
         Math.round((Date.now() - date.getTime()) / 3600 / 24 / 1000),
     );
 
-  const inCreatorProfile = !inRecipientProfile;
-
   return (
     <ReferenceContainer
       className="panel panel-default"
       id={_id}
-      inCreatorProfile={inCreatorProfile}
+      inRecipientProfile={inRecipientProfile}
     >
-      <div className="panel-body reference">
+      <div className="panel-body">
         <ReferenceHeading>
           <Avatar user={userFrom} size={36} />
           <UserMeta>

--- a/modules/references/client/components/read-references/ReferencesSection.js
+++ b/modules/references/client/components/read-references/ReferencesSection.js
@@ -1,14 +1,24 @@
 // External dependencies
+import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 import React from 'react';
+import styled from 'styled-components';
 
 // Internal dependencies
 import Reference from './Reference';
+
+const PlaceholderReference = styled.div`
+  padding: 10px;
+  background: transparent;
+  font-style: italic;
+`;
 
 /**
  * List of user's references
  */
 export default function ReferencesSection({ title, referencePairs }) {
+  const { t } = useTranslation('references');
+
   return (
     <section>
       {title && (
@@ -18,29 +28,24 @@ export default function ReferencesSection({ title, referencePairs }) {
           </div>
         </div>
       )}
-      {referencePairs.map(referencePair => (
-        <div
-          key={
-            referencePair.sharedWithUser
-              ? referencePair.sharedWithUser._id
-              : referencePair.writtenByUser._id
-          }
-        >
-          {referencePair.sharedWithUser && (
-            <div className="row">
-              <div className="col-xs-12">
-                <Reference
-                  reference={referencePair.sharedWithUser}
-                  inRecipientProfile={true}
-                />
-              </div>
+      {referencePairs.map(({ sharedWithUser, writtenByUser }) => (
+        <div key={sharedWithUser?._id || writtenByUser._id}>
+          <div className="row">
+            <div className="col-xs-12">
+              {sharedWithUser ? (
+                <Reference reference={sharedWithUser} inRecipientProfile />
+              ) : (
+                <PlaceholderReference className="panel panel-default">
+                  {t('They did not share their experience yet.')}
+                </PlaceholderReference>
+              )}
             </div>
-          )}
-          {referencePair.writtenByUser && (
+          </div>
+          {writtenByUser && (
             <div className="row">
               <div className="col-xs-12">
                 <Reference
-                  reference={referencePair.writtenByUser}
+                  reference={writtenByUser}
                   inRecipientProfile={false}
                 />
               </div>

--- a/modules/references/client/components/read-references/ReferencesSection.js
+++ b/modules/references/client/components/read-references/ReferencesSection.js
@@ -18,20 +18,19 @@ export default function ReferencesSection({ title, referencePairs }) {
           </div>
         </div>
       )}
-      {referencePairs.map(({ sharedWithUser, writtenByUser }) => (
-        <div key={sharedWithUser?._id || writtenByUser._id}>
-          <div className="row">
-            <div className="col-xs-12">
-              {sharedWithUser && (
+      {referencePairs.map(
+        ({ sharedWithUser, writtenByUser }) =>
+          sharedWithUser && (
+            <div className="row" key={sharedWithUser._id}>
+              <div className="col-xs-12">
                 <Reference
                   reference={sharedWithUser}
                   response={writtenByUser}
                 />
-              )}
+              </div>
             </div>
-          </div>
-        </div>
-      ))}
+          ),
+      )}
     </section>
   );
 }

--- a/modules/references/client/components/read-references/ReferencesSection.js
+++ b/modules/references/client/components/read-references/ReferencesSection.js
@@ -1,24 +1,14 @@
 // External dependencies
-import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 import React from 'react';
-import styled from 'styled-components';
 
 // Internal dependencies
 import Reference from './Reference';
-
-const PlaceholderReference = styled.div`
-  padding: 10px;
-  background: transparent;
-  font-style: italic;
-`;
 
 /**
  * List of user's references
  */
 export default function ReferencesSection({ title, referencePairs }) {
-  const { t } = useTranslation('references');
-
   return (
     <section>
       {title && (
@@ -32,25 +22,14 @@ export default function ReferencesSection({ title, referencePairs }) {
         <div key={sharedWithUser?._id || writtenByUser._id}>
           <div className="row">
             <div className="col-xs-12">
-              {sharedWithUser ? (
-                <Reference reference={sharedWithUser} inRecipientProfile />
-              ) : (
-                <PlaceholderReference className="panel panel-default">
-                  {t('They did not share their experience yet.')}
-                </PlaceholderReference>
+              {sharedWithUser && (
+                <Reference
+                  reference={sharedWithUser}
+                  response={writtenByUser}
+                />
               )}
             </div>
           </div>
-          {writtenByUser && (
-            <div className="row">
-              <div className="col-xs-12">
-                <Reference
-                  reference={writtenByUser}
-                  inRecipientProfile={false}
-                />
-              </div>
-            </div>
-          )}
         </div>
       ))}
     </section>

--- a/modules/users/client/components/UserLink.js
+++ b/modules/users/client/components/UserLink.js
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -7,14 +8,21 @@ import React from 'react';
  * @param {string} user.displayName
  * @param {string} user.username
  */
-export default function UserLink({ user }) {
+export default function UserLink({ user, className }) {
+  const { t } = useTranslation('users');
+
+  if (!user?.username) {
+    return <span className={className}>{t('Anonymous member')}</span>;
+  }
+
   return (
-    <a href={`/profile/${user.username}`}>
-      {user.displayName || user.username}
+    <a className={className} href={`/profile/${user?.username}`}>
+      {user?.displayName || user?.username}
     </a>
   );
 }
 
 UserLink.propTypes = {
+  className: PropTypes.string,
   user: PropTypes.object.isRequired,
 };


### PR DESCRIPTION
I'm playing with the "reply" visuals a bit.

- Does it make sense to include "reply" in cases where there isn't experience shared yet? Does it bring any value?
- If the above does make sense, we would probably need to pull at least the name+picture of that person, or otherwise, it's out of context since it's unclear who "Zita" is writing about in the below screenshots.
- It might make sense to show "pending" references in this way nevertheless? The more you see in that case the clearer it is.

Other:
- Thoughts on list indentation? I was thinking to add some other indicator that the two experiences are related: either by visually having them both in the same container/panel, having some kind of arrow, playing with left/right alignment kinda like in some chat apps, or something else...
- Thoughts on keeping dates visible both ways? I'm not sure what value there is to hide it, since the two experiences could be written at fairly different times.

#### Proposed Changes

* Make time always visible on each experience

<img width="739" alt="Screenshot 2020-12-13 at 19 21 10" src="https://user-images.githubusercontent.com/87168/102018836-68e2dc80-3d78-11eb-8405-dd1492590904.png">


* Add indentation in experience pairs
  
![image](https://user-images.githubusercontent.com/87168/102018825-5c5e8400-3d78-11eb-9853-0eaa29aa015b.png)

* Add empty placeholder experience when one doesn't exist but "reply" exists

<img width="767" alt="Screenshot 2020-12-13 at 19 21 37" src="https://user-images.githubusercontent.com/87168/102018843-78622580-3d78-11eb-8fc2-cc9b35f697be.png">

No "reply" looks like such:

<img width="787" alt="Screenshot 2020-12-13 at 19 22 39" src="https://user-images.githubusercontent.com/87168/102018864-9fb8f280-3d78-11eb-86f2-876ea6056c08.png">
 

#### Testing Instructions

* WIP