### PR TITLE
Rename references route to experiences

### DIFF
--- a/modules/core/server/services/email.server.service.js
+++ b/modules/core/server/services/email.server.service.js
@@ -449,7 +449,8 @@ exports.sendReferenceNotificationFirst = function (userFrom, userTo, callback) {
     userFrom: userFrom,
     userTo: userTo,
     userFromProfileUrl: url + '/profile/' + userFrom.username,
-    giveReferenceUrl: url + '/profile/' + userFrom.username + '/references/new',
+    giveReferenceUrl:
+      url + '/profile/' + userFrom.username + '/experiences/new',
   });
 
   exports.renderEmailAndSend('reference-notification-first', params, callback);
@@ -471,7 +472,7 @@ exports.sendReferenceNotificationSecond = function (
     userFrom: userFrom,
     userTo: userTo,
     userFromProfileUrl: url + '/profile/' + userFrom.username,
-    seeReferencesUrl: url + '/profile/' + userTo.username + '/references',
+    seeReferencesUrl: url + '/profile/' + userTo.username + '/experiences',
     recommend: reference.recommend,
   });
 

--- a/modules/core/server/services/push.server.service.js
+++ b/modules/core/server/services/push.server.service.js
@@ -95,8 +95,9 @@ exports.notifyMessagesUnread = function (userFrom, userTo, data, callback) {
  */
 exports.notifyNewReference = function (userFrom, userTo, data, callback) {
   const giveReferenceUrl =
-    url + '/profile/' + userFrom.username + '/references/new';
-  const readReferencesUrl = url + '/profile/' + userTo.username + '/references';
+    url + '/profile/' + userFrom.username + '/experiences/new';
+  const readReferencesUrl =
+    url + '/profile/' + userTo.username + '/experiences';
 
   // When the reference is first, reply reference can be given.
   // Otherwise both references are public now and can be seen.

--- a/modules/references/client/components/ListReferences.component.js
+++ b/modules/references/client/components/ListReferences.component.js
@@ -89,7 +89,7 @@ export default function ListReferences({ profile, authenticatedUser }) {
         <i className="icon-3x icon-users"></i>
         <h4>{t('No references yet.')}</h4>
         {authenticatedUser._id !== profile._id && (
-          <a href={`/profile/${profile.username}/references/new`}>
+          <a href={`/profile/${profile.username}/experiences/new`}>
             {t('Write one!')}
           </a>
         )}

--- a/modules/references/client/components/create-reference/DuplicateInfo.js
+++ b/modules/references/client/components/create-reference/DuplicateInfo.js
@@ -16,7 +16,10 @@ export default function DuplicateInfo({ username }) {
     <SuccessMessage
       title={t('You already shared your experience with them')}
       cta={
-        <a href={`/profile/${username}/references`} className="btn btn-primary">
+        <a
+          className="btn btn-primary"
+          href={`/profile/${username}/experiences`}
+        >
           {t('See their experiences')}
         </a>
       }

--- a/modules/references/client/components/create-reference/SubmittedInfo.js
+++ b/modules/references/client/components/create-reference/SubmittedInfo.js
@@ -23,7 +23,10 @@ export default function SubmittedInfo({
     <SuccessMessage
       title={t('Thank you for sharing your experience!')}
       cta={
-        <a href={`/profile/${username}/references`} className="btn btn-primary">
+        <a
+          className="btn btn-primary"
+          href={`/profile/${username}/experiences`}
+        >
           {t('See their experiences')}
         </a>
       }

--- a/modules/references/client/components/read-references/Reference.js
+++ b/modules/references/client/components/read-references/Reference.js
@@ -105,7 +105,7 @@ export default function Reference({ reference, inRecipientProfile }) {
           {inRecipientProfile && (
             <a
               className="reference-time"
-              href={`/profile/${userTo.username}/references#${_id}`}
+              href={`/profile/${userTo.username}/experiences#${_id}`}
             >
               <TimeAgo date={createdDate} />
             </a>
@@ -130,7 +130,7 @@ export default function Reference({ reference, inRecipientProfile }) {
               <p>
                 <a
                   className="btn btn-primary"
-                  href={`/profile/${userFrom.username}/references/new`}
+                  href={`/profile/${userFrom.username}/experiences/new`}
                 >
                   {t('Write about your experience with them')}
                 </a>

--- a/modules/references/tests/server/reference-create.server.routes.tests.js
+++ b/modules/references/tests/server/reference-create.server.routes.tests.js
@@ -282,10 +282,10 @@ describe('Create a reference', () => {
           should(job.data.to.address).equal(user2.email);
           // @TODO add the right link
           should(job.data.text).containEql(
-            `/profile/${user1.username}/references/new`,
+            `/profile/${user1.username}/experiences/new`,
           );
           should(job.data.html).containEql(
-            `/profile/${user1.username}/references/new`,
+            `/profile/${user1.username}/experiences/new`,
           );
         });
 
@@ -314,7 +314,7 @@ describe('Create a reference', () => {
             `${user1.username} gave you a new reference. Give a reference back.`,
           );
           should(job.data.notification.click_action).containEql(
-            `/profile/${user1.username}/references/new`,
+            `/profile/${user1.username}/experiences/new`,
           );
         });
       });
@@ -451,10 +451,10 @@ describe('Create a reference', () => {
           // this is a link to the own references - see my references
           // because I already gave a reference
           should(job.data.text).containEql(
-            `/profile/${user2.username}/references`,
+            `/profile/${user2.username}/experiences`,
           );
           should(job.data.html).containEql(
-            `/profile/${user2.username}/references`,
+            `/profile/${user2.username}/experiences`,
           );
         });
 
@@ -497,7 +497,7 @@ describe('Create a reference', () => {
             `${user1.username} gave you a new reference. You can see it.`,
           );
           should(job.data.notification.click_action).containEql(
-            `/profile/${user2.username}/references`,
+            `/profile/${user2.username}/experiences`,
           );
         });
       });

--- a/modules/users/client/components/TopNavigationSmall.component.js
+++ b/modules/users/client/components/TopNavigationSmall.component.js
@@ -50,7 +50,7 @@ export default function TopNavigationSmall({
       links.push({
         id: 'write-reference',
         label: t('Write a reference'),
-        link: `/profile/${username}/references/new`,
+        link: `/profile/${username}/experiences/new`,
       });
     }
 

--- a/modules/users/client/config/users.client.routes.js
+++ b/modules/users/client/config/users.client.routes.js
@@ -365,8 +365,8 @@ function UsersRoutes($stateProvider) {
         pageTitle: 'Remove profile',
       },
     })
-    .state('profile.references', {
-      url: '/references',
+    .state('profile.experiences', {
+      url: '/experiences',
       templateUrl: profileReferencesTemplateUrl,
       requiresAuth: true,
       noScrollingTop: true,
@@ -375,7 +375,7 @@ function UsersRoutes($stateProvider) {
         pageTitle: 'Profile references',
       },
     })
-    .state('profile.references.list', {
+    .state('profile.experiences.list', {
       url: '',
       template:
         '<list-references ng-if="app.appSettings.referencesEnabled" profile="profileCtrl.profile" authenticatedUser="app.user"></list-references>',
@@ -385,7 +385,7 @@ function UsersRoutes($stateProvider) {
         pageTitle: 'Profile references',
       },
     })
-    .state('profile.references.new', {
+    .state('profile.experiences.new', {
       url: '/new',
       template:
         '<create-reference ng-if="app.appSettings.referencesEnabled" userTo="profileCtrl.profile" userFrom="app.user"></create-reference>',

--- a/modules/users/client/views/profile/profile-view.client.view.html
+++ b/modules/users/client/views/profile/profile-view.client.view.html
@@ -169,7 +169,7 @@ this is a fallback when the contacts are loading
               </li>
               <li ng-if="app.appSettings.referencesEnabled">
                 <a
-                  ui-sref="profile.references.new({username: profileCtrl.profile.username})"
+                  ui-sref="profile.experiences.new({username: profileCtrl.profile.username})"
                 >
                   <i class="icon-plus-squared-alt"></i>
                   Write a reference
@@ -243,7 +243,7 @@ this is a fallback when the contacts are loading
                   role="presentation"
                   ng-if="app.appSettings.referencesEnabled"
                 >
-                  <a ui-sref="profile.references.list" role="tab">
+                  <a ui-sref="profile.experiences.list" role="tab">
                     References
                   </a>
                 </li>


### PR DESCRIPTION
#### Proposed Changes

* Rename `.../references/*` route to `.../experiences/*`

#### Testing Instructions

* Open profile, open references tab
* Click on "write a reference" button

<img width="724" alt="Screenshot 2020-12-21 at 20 47 10" src="https://user-images.githubusercontent.com/87168/102811432-fe601b00-43cd-11eb-8495-d6c1fd006558.png">
