### PR TITLE
Experiences: update email copy

### DIFF
--- a/modules/core/server/services/email.server.service.js
+++ b/modules/core/server/services/email.server.service.js
@@ -442,6 +442,10 @@ exports.sendWelcomeSequenceThird = function (user, callback) {
  * Reference Notification (First between users)
  */
 exports.sendReferenceNotificationFirst = function (userFrom, userTo, callback) {
+  const campaign = 'reference-notification-first';
+  const userFromProfileUrl = `${url}/profile/${userFrom.username}`;
+  const giveReferenceUrl = `${url}/profile/${userFrom.username}/experiences/new`;
+
   const params = exports.addEmailBaseTemplateParams({
     subject: `${userFrom.displayName} shared their experience with you`,
     email: userTo.email,
@@ -449,9 +453,20 @@ exports.sendReferenceNotificationFirst = function (userFrom, userTo, callback) {
     username: userTo.username, // data needed for link to profile in footer
     userFrom,
     userTo,
-    userFromProfileUrl: url + '/profile/' + userFrom.username,
-    giveReferenceUrl:
-      url + '/profile/' + userFrom.username + '/experiences/new',
+    userFromProfileUrlPlainText: userFromProfileUrl,
+    userFromProfileUrl: analyticsHandler.appendUTMParams(userFromProfileUrl, {
+      source: 'transactional-email',
+      medium: 'email',
+      campaign,
+      content: 'from-profile',
+    }),
+    giveReferenceUrlPlainText: giveReferenceUrl,
+    giveReferenceUrl: analyticsHandler.appendUTMParams(giveReferenceUrl, {
+      source: 'transactional-email',
+      medium: 'email',
+      campaign,
+      content: 'give-reference',
+    }),
   });
 
   exports.renderEmailAndSend('reference-notification-first', params, callback);
@@ -466,15 +481,30 @@ exports.sendReferenceNotificationSecond = function (
   reference,
   callback,
 ) {
+  const campaign = 'reference-notification-second';
+  const seeReferencesUrl = `${url}/profile/${userTo.username}/experiences#${reference._id}`;
+  const userFromProfileUrl = `${url}/profile/${userFrom.username}`;
+
   const params = exports.addEmailBaseTemplateParams({
     subject: `${userFrom.displayName} shared also their experience with you`,
     email: userTo.email,
     username: userTo.username, // data needed for link to profile in footer
     userFrom,
     userTo,
-    userFromProfileUrl: url + '/profile/' + userFrom.username,
-    seeReferencesUrl:
-      url + '/profile/' + userTo.username + '/experiences#' + reference._id,
+    userFromProfileUrlPlainText: userFromProfileUrl,
+    userFromProfileUrl: analyticsHandler.appendUTMParams(userFromProfileUrl, {
+      source: 'transactional-email',
+      medium: 'email',
+      campaign,
+      content: 'from-profile',
+    }),
+    seeReferencesUrlPlainText: seeReferencesUrl,
+    seeReferencesUrl: analyticsHandler.appendUTMParams(seeReferencesUrl, {
+      source: 'transactional-email',
+      medium: 'email',
+      campaign,
+      content: 'see-references',
+    }),
   });
 
   exports.renderEmailAndSend('reference-notification-second', params, callback);

--- a/modules/core/server/services/email.server.service.js
+++ b/modules/core/server/services/email.server.service.js
@@ -473,7 +473,8 @@ exports.sendReferenceNotificationSecond = function (
     userFrom,
     userTo,
     userFromProfileUrl: url + '/profile/' + userFrom.username,
-    seeReferencesUrl: url + '/profile/' + userTo.username + '/experiences',
+    seeReferencesUrl:
+      url + '/profile/' + userTo.username + '/experiences#' + reference._id,
   });
 
   exports.renderEmailAndSend('reference-notification-second', params, callback);

--- a/modules/core/server/services/email.server.service.js
+++ b/modules/core/server/services/email.server.service.js
@@ -445,6 +445,7 @@ exports.sendReferenceNotificationFirst = function (userFrom, userTo, callback) {
   const params = exports.addEmailBaseTemplateParams({
     subject: 'New reference from ' + userFrom.username,
     email: userTo.email,
+    days: config.limits.timeToReplyReference.days,
     username: userTo.username, // data needed for link to profile in footer
     userFrom,
     userTo,

--- a/modules/core/server/services/email.server.service.js
+++ b/modules/core/server/services/email.server.service.js
@@ -443,7 +443,7 @@ exports.sendWelcomeSequenceThird = function (user, callback) {
  */
 exports.sendReferenceNotificationFirst = function (userFrom, userTo, callback) {
   const params = exports.addEmailBaseTemplateParams({
-    subject: 'New reference from ' + userFrom.username,
+    subject: `${userFrom.displayName} shared their experience with you`,
     email: userTo.email,
     days: config.limits.timeToReplyReference.days,
     username: userTo.username, // data needed for link to profile in footer
@@ -467,7 +467,7 @@ exports.sendReferenceNotificationSecond = function (
   callback,
 ) {
   const params = exports.addEmailBaseTemplateParams({
-    subject: 'New reference from ' + userFrom.username,
+    subject: `${userFrom.displayName} shared their experience with you`,
     email: userTo.email,
     username: userTo.username, // data needed for link to profile in footer
     userFrom,

--- a/modules/core/server/services/email.server.service.js
+++ b/modules/core/server/services/email.server.service.js
@@ -467,14 +467,13 @@ exports.sendReferenceNotificationSecond = function (
   callback,
 ) {
   const params = exports.addEmailBaseTemplateParams({
-    subject: `${userFrom.displayName} shared their experience with you`,
+    subject: `${userFrom.displayName} shared also their experience with you`,
     email: userTo.email,
     username: userTo.username, // data needed for link to profile in footer
     userFrom,
     userTo,
     userFromProfileUrl: url + '/profile/' + userFrom.username,
     seeReferencesUrl: url + '/profile/' + userTo.username + '/experiences',
-    recommend: reference.recommend,
   });
 
   exports.renderEmailAndSend('reference-notification-second', params, callback);

--- a/modules/core/server/services/push.server.service.js
+++ b/modules/core/server/services/push.server.service.js
@@ -91,30 +91,45 @@ exports.notifyMessagesUnread = function (userFrom, userTo, data, callback) {
  * @param {User} userFrom - user who gave the reference
  * @param {User} userTo - user who received the reference
  * @param {Object} data - notification config
- * @param {boolean} data.isFirst - is it the first reference between users?
  */
-exports.notifyNewReference = function (userFrom, userTo, data, callback) {
-  const giveReferenceUrl =
-    url + '/profile/' + userFrom.username + '/experiences/new';
-  const readReferencesUrl =
-    url + '/profile/' + userTo.username + '/experiences';
-
-  // When the reference is first, reply reference can be given.
-  // Otherwise both references are public now and can be seen.
-  const actionText = data.isFirst
-    ? 'Share your experience, too.'
-    : 'Have a look!';
-  const actionUrl = data.isFirst ? giveReferenceUrl : readReferencesUrl;
+exports.notifyNewReferenceFirst = function (userFrom, userTo, callback) {
+  const giveReferenceUrl = `${url}/profile/${userFrom.username}/experiences/new`;
 
   const notification = {
     title: 'Trustroots',
-    body:
-      userFrom.username + ' shared their experience with you. ' + actionText,
-    click_action: analyticsHandler.appendUTMParams(actionUrl, {
+    body: `${userFrom.displayName} shared their experience with you. Share your experience, too.`,
+    click_action: analyticsHandler.appendUTMParams(giveReferenceUrl, {
       source: 'push-notification',
       medium: 'fcm',
       campaign: 'new-reference',
-      content: 'reply-to', // @TODO what are the correct parameters here? What do they mean?
+      content: 'respond',
+    }),
+  };
+  exports.sendUserNotification(userTo, notification, callback);
+};
+
+/**
+ * Send a push notification about a new reference, to the receiver of the reference
+ * @param {User} userFrom - user who gave the reference
+ * @param {User} userTo - user who received the reference
+ * @param {string} referenceId - ID of the reference
+ */
+exports.notifyNewReferenceSecond = function (
+  userFrom,
+  userTo,
+  referenceId,
+  callback,
+) {
+  const readReferencesUrl = `${url}/profile/${userTo.username}/experiences#${referenceId}`;
+
+  const notification = {
+    title: 'Trustroots',
+    body: `${userFrom.displayName} shared their experience with you. Both experiences are now published.`,
+    click_action: analyticsHandler.appendUTMParams(readReferencesUrl, {
+      source: 'push-notification',
+      medium: 'fcm',
+      campaign: 'new-reference',
+      content: 'read',
     }),
   };
   exports.sendUserNotification(userTo, notification, callback);

--- a/modules/core/server/views/email-templates-text/reference-notification-first.server.view.html
+++ b/modules/core/server/views/email-templates-text/reference-notification-first.server.view.html
@@ -3,7 +3,7 @@
 {% block content %}
 Hello {{userTo.firstName}},
 
-Great news! {{userFrom.firstName}} ({{userFromProfileUrl}}) has shared their experience with you on Trustroots.
+{{userFrom.displayName}} ({{userFromProfileUrl}}) has shared their experience with you on Trustroots.
 
 Would you like to share yours as well? You can write about your experience at {{giveReferenceUrl}} and both experiences will become public right after that.
 

--- a/modules/core/server/views/email-templates-text/reference-notification-first.server.view.html
+++ b/modules/core/server/views/email-templates-text/reference-notification-first.server.view.html
@@ -1,15 +1,15 @@
 {% extends './email.server.view.html' %}
 
 {% block content %}
-Hello {{userTo.firstName}}!
+Hello {{userTo.firstName}},
 
-Great news! {{userFrom.firstName}} ({{userFromProfileUrl}}) left you a reference on Trustroots.
+Great news! {{userFrom.firstName}} ({{userFromProfileUrl}}) has shared their experience with you on Trustroots.
 
-You will be able to see their reference after you leave them a reference as well, at which point both references will become public
+Would you like to share yours as well? You can write about your experience at {{giveReferenceUrl}} and both experiences will become public right after that.
 
-Go to {{giveReferenceUrl}} and give them a reference right now!
+Not in the mood to do it now? You have {{days}} days to share your experience with them. After that their experience will become public and you will only be able to share your experience with limited choices.
 
-You have two weeks to do this.
-After two weeks, their reference for you will become public
-and you will only be able to give them a positive reference.
+If you think this message is an error or if you don’t know this person, let us know ({{urlSupportPlainText}}) so our Trust & Safety team can look into it.
+
+Thanks!
 {% endblock content %}

--- a/modules/core/server/views/email-templates-text/reference-notification-first.server.view.html
+++ b/modules/core/server/views/email-templates-text/reference-notification-first.server.view.html
@@ -3,7 +3,7 @@
 {% block content %}
 Hello {{userTo.firstName}},
 
-{{userFrom.displayName}} ({{userFromProfileUrPlainTextl}}) has shared their experience with you on Trustroots.
+{{userFrom.displayName}} ({{userFromProfileUrlPlainText}}) has shared their experience with you on Trustroots.
 
 Would you like to share yours as well? You can write about your experience here and both experiences will become public right after that:
 

--- a/modules/core/server/views/email-templates-text/reference-notification-first.server.view.html
+++ b/modules/core/server/views/email-templates-text/reference-notification-first.server.view.html
@@ -3,9 +3,11 @@
 {% block content %}
 Hello {{userTo.firstName}},
 
-{{userFrom.displayName}} ({{userFromProfileUrl}}) has shared their experience with you on Trustroots.
+{{userFrom.displayName}} ({{userFromProfileUrPlainTextl}}) has shared their experience with you on Trustroots.
 
-Would you like to share yours as well? You can write about your experience at {{giveReferenceUrl}} and both experiences will become public right after that.
+Would you like to share yours as well? You can write about your experience here and both experiences will become public right after that:
+
+{{giveReferenceUrlPlainText}}
 
 Not in the mood to do it now? You have {{days}} days to share your experience with them. After that their experience will become public and you will only be able to share your experience with limited choices.
 

--- a/modules/core/server/views/email-templates-text/reference-notification-second.server.view.html
+++ b/modules/core/server/views/email-templates-text/reference-notification-second.server.view.html
@@ -3,7 +3,7 @@
 {% block content %}
 Hi {{userTo.firstName}}!
 
-Good news, {{userFrom.firstName}} ({{userFromProfileUrl}}) has shared also their experience with you. Both of your experiences are now public.
+{{userFrom.firstName}} ({{userFromProfileUrl}}) has shared also their experience with you. Both of your experiences are now public.
 
 See the experience at {{seeReferencesUrl}}
 {% endblock content %}

--- a/modules/core/server/views/email-templates-text/reference-notification-second.server.view.html
+++ b/modules/core/server/views/email-templates-text/reference-notification-second.server.view.html
@@ -3,10 +3,7 @@
 {% block content %}
 Hi {{userTo.firstName}}!
 
-Good news, {{userFrom.firstName}} ({{userFromProfileUrl}}) has left you a reference as well.
+Good news, {{userFrom.firstName}} ({{userFromProfileUrl}}) has shared also their experience with you. Both of your experiences are now public.
 
-Their recommendation was {{recommend}}.
-
-You can see your own references at {{seeReferencesUrl}}.
-
+See the experience at {{seeReferencesUrl}}
 {% endblock content %}

--- a/modules/core/server/views/email-templates-text/reference-notification-second.server.view.html
+++ b/modules/core/server/views/email-templates-text/reference-notification-second.server.view.html
@@ -3,7 +3,7 @@
 {% block content %}
 Hi {{userTo.firstName}}!
 
-{{userFrom.firstName}} ({{userFromProfileUrl}}) has shared also their experience with you. Both of your experiences are now public.
+{{userFrom.firstName}} ({{userFromProfileUrlPlainText}}) has shared also their experience with you. Both of your experiences are now public.
 
-See the experience at {{seeReferencesUrl}}
+See the experience at {{seeReferencesUrlPlainText}}
 {% endblock content %}

--- a/modules/core/server/views/email-templates/reference-notification-first.server.view.html
+++ b/modules/core/server/views/email-templates/reference-notification-first.server.view.html
@@ -27,5 +27,5 @@
   {{button(giveReferenceUrl, 'Share your experience now')}}
 
   {% from "./partials/copypasteurl.server.view.html" import copyPasteUrl %}
-  {{copyPasteUrl(giveReferenceUrl)}}
+  {{copyPasteUrl(giveReferenceUrlPlainText)}}
 {% endblock actionbutton %}

--- a/modules/core/server/views/email-templates/reference-notification-first.server.view.html
+++ b/modules/core/server/views/email-templates/reference-notification-first.server.view.html
@@ -2,29 +2,30 @@
 
 {% block textcontent %}
   <p>
-    Hello {{userTo.firstName}}!
+    Hello {{userTo.firstName}},
   </p>
 
   <p>
     Great news! <a href="{{userFromProfileUrl}}">{{userFrom.firstName}}</a>
-    left you a reference on Trustroots.
+    has shared their experience with you on Trustroots.
   </p>
 
   <p>
-    You will be able to see their reference after you leave them a reference
-    as well, at which poit both references will become public
+    Would you like to share yours as well? You can <a href="{{giveReferenceUrl}}">write about your experience</a> and both experiences will become public right after that.
   </p>
 
   <p>
-    You have two weeks to do this.
-    After two weeks, their reference for you will become public
-    and you will only be able to give them a positive reference.
+    Not in the mood to do it now? You have {{days}} days to share your experience with them. After that their experience will become public and you will only be able to share your experience with limited choices.
+  </p>
+
+  <p>
+    If you think this message is an error or if you don’t know this person, <a href="{{urlSupport}}">let us know</a> so our Trust & Safety team can look into it.
   </p>
 {% endblock textcontent %}
 
 {% block actionbutton %}
   {% from "./partials/button.server.view.html" import button %}
-  {{button(giveReferenceUrl, 'Give a reference to ' + userFrom.firstName + ' now')}}
+  {{button(giveReferenceUrl, 'Share your experience now')}}
 
   {% from "./partials/copypasteurl.server.view.html" import copyPasteUrl %}
   {{copyPasteUrl(giveReferenceUrl)}}

--- a/modules/core/server/views/email-templates/reference-notification-first.server.view.html
+++ b/modules/core/server/views/email-templates/reference-notification-first.server.view.html
@@ -18,7 +18,7 @@
   </p>
 
   <p>
-    If you think this message is an error or if you don’t know this person, <a href="{{urlSupport}}">let us know</a> so our Trust & Safety team can look into it.
+    If you think this message is an error or if you don’t know this person, <a href="{{supportUrl}}">let us know</a> so our Trust & Safety team can look into it.
   </p>
 {% endblock textcontent %}
 

--- a/modules/core/server/views/email-templates/reference-notification-first.server.view.html
+++ b/modules/core/server/views/email-templates/reference-notification-first.server.view.html
@@ -6,8 +6,7 @@
   </p>
 
   <p>
-    Great news! <a href="{{userFromProfileUrl}}">{{userFrom.firstName}}</a>
-    has shared their experience with you on Trustroots.
+    <a href="{{userFromProfileUrl}}">{{userFrom.displayName}}</a> has shared their experience with you on Trustroots.
   </p>
 
   <p>

--- a/modules/core/server/views/email-templates/reference-notification-second.server.view.html
+++ b/modules/core/server/views/email-templates/reference-notification-second.server.view.html
@@ -14,5 +14,5 @@
   {{button(seeReferencesUrl, 'See the experience')}}
 
   {% from "./partials/copypasteurl.server.view.html" import copyPasteUrl %}
-  {{copyPasteUrl(seeReferencesUrl)}}
+  {{copyPasteUrl(seeReferencesUrlPlainText)}}
 {% endblock actionbutton %}

--- a/modules/core/server/views/email-templates/reference-notification-second.server.view.html
+++ b/modules/core/server/views/email-templates/reference-notification-second.server.view.html
@@ -5,7 +5,7 @@
     Hi {{userTo.firstName}}!
   </p>
   <p>
-    Good news, <a href="{{userFromProfileUrl}}">{{userFrom.firstName}}</a> has shared also their experience with you. Both of your experiences are now public.
+    <a href="{{userFromProfileUrl}}">{{userFrom.firstName}}</a> has shared also their experience with you. Both of your experiences are now public.
   </p>
 {% endblock textcontent %}
 

--- a/modules/core/server/views/email-templates/reference-notification-second.server.view.html
+++ b/modules/core/server/views/email-templates/reference-notification-second.server.view.html
@@ -4,21 +4,15 @@
   <p>
     Hi {{userTo.firstName}}!
   </p>
-
   <p>
-    Good news, <a href="{{userFromProfileUrl}}">{{userFrom.firstName}}</a> has left you a reference as well.
-  </p>
-
-  <p>
-    Their recommendation was {{recommend}}. <!-- yes, no, unknown -->
+    Good news, <a href="{{userFromProfileUrl}}">{{userFrom.firstName}}</a> has shared also their experience with you. Both of your experiences are now public.
   </p>
 {% endblock textcontent %}
 
 {% block actionbutton %}
   {% from "./partials/button.server.view.html" import button %}
-  {{button(seeReferencesUrl, 'See my references')}}
+  {{button(seeReferencesUrl, 'See the experience')}}
 
   {% from "./partials/copypasteurl.server.view.html" import copyPasteUrl %}
   {{copyPasteUrl(seeReferencesUrl)}}
-<!-- It's also possible to say if the other person said they hosted us or met us etc. -->
 {% endblock actionbutton %}

--- a/modules/references/tests/server/reference-create.server.routes.tests.js
+++ b/modules/references/tests/server/reference-create.server.routes.tests.js
@@ -277,12 +277,10 @@ describe('Create a reference', () => {
           should(emailJobs.length).equal(1);
 
           const [job] = emailJobs;
-          // @TODO design the email (subject, body, ...)
           should(job.data.subject).equal(
-            `New reference from ${user1.username}`,
+            `${user1.displayName} shared their experience with you`,
           );
           should(job.data.to.address).equal(user2.email);
-          // @TODO add the right link
           should(job.data.text).containEql(
             `/profile/${user1.username}/experiences/new`,
           );
@@ -311,7 +309,6 @@ describe('Create a reference', () => {
           const [job] = pushJobs;
           should(job.data.userId).equal(user2._id.toString());
           should(job.data.notification.title).equal('Trustroots');
-          // @TODO design the notification text
           should(job.data.notification.body).equal(
             `${user1.username} shared their experience with you. Share your experience, too.`,
           );
@@ -419,14 +416,14 @@ describe('Create a reference', () => {
           should(jobs.length).equal(0);
 
           // first create a reference in the opposite direction
-          const reference = new Reference({
+          const _reference = new Reference({
             userFrom: user2._id,
             userTo: user1._id,
             met: true,
             recommend: 'no',
           });
 
-          await reference.save();
+          const reference = await _reference.save();
 
           await agent
             .post('/api/references')
@@ -445,19 +442,15 @@ describe('Create a reference', () => {
           should(emailJobs.length).equal(1);
 
           const [job] = emailJobs;
-          // @TODO design the email (subject, body, ...)
           should(job.data.subject).equal(
-            `New reference from ${user1.username}`,
+            `${user1.displayName} shared their experience with you`,
           );
           should(job.data.to.address).equal(user2.email);
-          // @TODO add the right link
-          // this is a link to the own references - see my references
-          // because I already gave a reference
           should(job.data.text).containEql(
-            `/profile/${user2.username}/experiences`,
+            `/profile/${user2.username}/experiences#${reference._id}`,
           );
           should(job.data.html).containEql(
-            `/profile/${user2.username}/experiences`,
+            `/profile/${user2.username}/experiences#${reference._id}`,
           );
         });
 
@@ -495,7 +488,6 @@ describe('Create a reference', () => {
           const [job] = pushJobs;
           should(job.data.userId).equal(user2._id.toString());
           should(job.data.notification.title).equal('Trustroots');
-          // @TODO design the notification text
           should(job.data.notification.body).equal(
             `${user1.username} shared their experience with you. Have a look!`,
           );

--- a/modules/references/tests/server/reference-create.server.routes.tests.js
+++ b/modules/references/tests/server/reference-create.server.routes.tests.js
@@ -8,6 +8,7 @@ const Reference = mongoose.model('Reference');
 const testutils = require(path.resolve('./testutils/server/server.testutil'));
 const utils = require(path.resolve('./testutils/server/data.server.testutil'));
 const express = require(path.resolve('./config/lib/express'));
+const config = require(path.resolve('./config/config'));
 
 describe('Create a reference', () => {
   // user can leave a reference to anyone
@@ -451,6 +452,12 @@ describe('Create a reference', () => {
           );
           should(job.data.html).containEql(
             `/profile/${user2.username}/experiences#${reference._id}`,
+          );
+          should(job.data.text).containEql(
+            `${config.limits.timeToReplyReference.days} days`,
+          );
+          should(job.data.html).containEql(
+            `${config.limits.timeToReplyReference.days} days`,
           );
         });
 

--- a/modules/references/tests/server/reference-create.server.routes.tests.js
+++ b/modules/references/tests/server/reference-create.server.routes.tests.js
@@ -443,7 +443,7 @@ describe('Create a reference', () => {
 
           const [job] = emailJobs;
           should(job.data.subject).equal(
-            `${user1.displayName} shared their experience with you`,
+            `${user1.displayName} shared also their experience with you`,
           );
           should(job.data.to.address).equal(user2.email);
           should(job.data.text).containEql(


### PR DESCRIPTION
#### Proposed Changes

* New copy for emails and push notifications for experiences feature
* Append UTM params to URLs in emails, for analytics
* Split `notifyNewReference` function into two (`notifyNewReferenceFirst` & `notifyNewReferenceSecond`) for clarity. It was getting a bit unwieldy with lots of ternaries.

#### Testing Instructions

* Write experience
* See it from Maildev `localhost:1080` — test links in email work
* Respond with another user to experience
* Repeat Maildev

Resolves https://github.com/Trustroots/trustroots/issues/1954
