### PR TITLE
add gender when seeding users for test db

### DIFF
--- a/bin/fillTestData/Users.js
+++ b/bin/fillTestData/Users.js
@@ -244,6 +244,7 @@ function addUsers() {
           console.log(chalk.green('Trustroots test user data'));
           console.log(chalk.white('--'));
 
+          const genderValues = User.schema.path('gender').enumValues;
           while (index < max) {
             (function addNextUser() {
               const user = new User();
@@ -255,7 +256,8 @@ function addUsers() {
               }
 
               // Add mock data
-              user.firstName = faker.name.firstName();
+              user.gender = faker.random.arrayElement(genderValues);
+              user.firstName = faker.name.firstName(user.gender);
               user.lastName = faker.name.lastName();
               user.displayName = user.firstName + ' ' + user.lastName;
               user.provider = 'local';


### PR DESCRIPTION
#### Proposed Changes

* when seeding users for test Db, add also gender

#### Testing Instructions

* run `npm run dropdb` (warning, will remove all test data!), then `npm seed` to generate test data again. Most of the users should have gender specified in their profiles

