### PR TITLE
Fix experiences tab link on the profile page

### DIFF
--- a/modules/users/client/views/profile/profile-view.client.view.html
+++ b/modules/users/client/views/profile/profile-view.client.view.html
@@ -243,7 +243,7 @@ this is a fallback when the contacts are loading
                   role="presentation"
                   ng-if="app.appSettings.referencesEnabled"
                 >
-                  <a ui-sref="profile.references.list" role="tab">
+                  <a ui-sref="profile.experiences.list" role="tab">
                     Experiences
                   </a>
                 </li>


### PR DESCRIPTION
#### Proposed Changes

* Fix experiences tab link on the profile page

#### Testing Instructions

- Go to any profile page
- Click on the "Experiences" tab
- Experiences should be displayed