### PR TITLE
Tooling: replace non-allowed characters from newsletter export script

### DIFF
--- a/bin/export-newsletter-subscribers.js
+++ b/bin/export-newsletter-subscribers.js
@@ -67,7 +67,9 @@ mongooseService.connect(() => {
         users.forEach(user => {
           data += '\n';
           data += [user.email, user.firstName, user.lastName]
-            .map(string => string.trim().replace(',', ''))
+            .map(string =>
+              string.trim().replace("'", '').replace('"', '').replace(',', ''),
+            )
             .join(',');
         });
 


### PR DESCRIPTION
#### Proposed Changes

* Replace `"` and `'` from the export output

Live export revealed a few problematic characters that we need to clean out.
