### PR TITLE
Simplify /api/references endpoint by removing userFrom param

### DIFF
--- a/modules/references/client/api/references.api.js
+++ b/modules/references/client/api/references.api.js
@@ -55,22 +55,16 @@ export async function create(reference) {
 }
 
 /**
- * API request: read references, filter them by userFrom and userTo,
+ * API request: read references, filter them by userTo,
  * and sort by 'created' field starting from the most recent date
  *
- * @param {string} userFrom - id of user who gave the reference
  * @param {string} userTo - id of user who received the reference
  * @returns Promise<Reference[]> - array of the found references
  */
-export async function read({ userFrom, userTo }) {
-  const params = {};
-  if (userFrom) {
-    params.userFrom = userFrom;
-  }
-  if (userTo) {
-    params.userTo = userTo;
-  }
-  const { data: references } = await axios.get('/api/references', { params });
+export async function read({ userTo }) {
+  const { data: references } = await axios.get('/api/references', {
+    params: { userTo },
+  });
   return references.map(reference =>
     mapObjectToObject(reference, referenceMapping, true),
   );

--- a/modules/references/client/components/ListReferences.component.js
+++ b/modules/references/client/components/ListReferences.component.js
@@ -47,7 +47,6 @@ export default function ListReferences({ profile, authenticatedUser }) {
     try {
       const experiences = await readReferences({
         userTo: profile._id,
-        includeReplies: true,
       });
 
       const publicExperiences = experiences.filter(
@@ -56,9 +55,15 @@ export default function ListReferences({ profile, authenticatedUser }) {
       const publicExperiencePairs = pairUpExperiences(publicExperiences);
       setPublicExperiencePairs(publicExperiencePairs);
 
+      // TODO for now we add `experience.userTo._id.equals(profile._id)`
+      // condition to filter out the experiences written by the user,
+      // which are currently not displayed. Later, we will be showing also
+      // those: https://github.com/Trustroots/trustroots/pull/1860
       const pendingNewestFirst = experiences.filter(
-        experience => !experience.public,
+        experience =>
+          !experience.public && experience.userTo._id === profile._id,
       );
+
       const pendingOldestFirst = [...pendingNewestFirst].reverse();
       setPendingExperiences(
         pendingOldestFirst.map(experience => {

--- a/modules/references/tests/server/reference-read-many.server.routes.tests.js
+++ b/modules/references/tests/server/reference-read-many.server.routes.tests.js
@@ -105,7 +105,7 @@ describe('Read references by userFrom Id or userTo Id', () => {
 
     it('the references in response have expected structure, userFrom & userTo have miniProfile', async () => {
       const { body } = await agent
-        .get(`/api/references?userFrom=${users[2]._id}`)
+        .get(`/api/references?userTo=${users[2]._id}`)
         .expect(200);
 
       for (const ref of body) {
@@ -146,15 +146,6 @@ describe('Read references by userFrom Id or userTo Id', () => {
 
       // user2 has received 2 public and 1 non-public reference
       should(body).be.Array().of.length(2);
-    });
-
-    it('[params userFrom and userTo] respond with 1 or 0 public reference from userFrom to userTo', async () => {
-      const { body } = await agent
-        .get(`/api/references?userFrom=${users[2]._id}&userTo=${users[5]._id}`)
-        .expect(200);
-
-      // there is 1 public reference from user2 to user5
-      should(body).be.Array().of.length(1);
     });
 
     // skipping until the API is finalized
@@ -213,21 +204,17 @@ describe('Read references by userFrom Id or userTo Id', () => {
       should(body).eql({
         message: 'Bad request.',
         details: {
-          userFrom: 'missing',
           userTo: 'missing',
         },
       });
     });
 
     it('[invalid params] 400 and error', async () => {
-      const { body } = await agent
-        .get('/api/references?userFrom=asdf&userTo=1')
-        .expect(400);
+      const { body } = await agent.get('/api/references?userTo=1').expect(400);
 
       should(body).eql({
         message: 'Bad request.',
         details: {
-          userFrom: 'invalid',
           userTo: 'invalid',
         },
       });


### PR DESCRIPTION
#### Proposed Changes

* `userFrom` param for `/api/references` endpoint is not needed anymore and has been removed since `/api/references` is now only used for displaying experiences of `userTo` in their profile. Checking whether `userFrom` has shared experience with `userTo` has been moved to `/api/my-reference?userto=` endpoint 

#### Testing Instructions

* exercise `/api/references` endpoint with different `userTo` values and without it
* check nothing changed in the way experiences display on the UI (replies, pending experiences, etc. are still present)

This will be followed up by PRs implementing:
- pairing up experiences on the backend instead of frontend
- thorough coverage with tests
- renaming references -> experiences
