### PR TITLE
Profile: Reactify notification about email confirmation

### DIFF
--- a/modules/users/client/components/ConfirmEmailNotification.component.js
+++ b/modules/users/client/components/ConfirmEmailNotification.component.js
@@ -1,0 +1,26 @@
+import { Trans, useTranslation } from 'react-i18next';
+import React from 'react';
+
+export default function ConfirmEmailNotification() {
+  const { t } = useTranslation('users');
+
+  return (
+    <div className="row text-center">
+      <em className="lead">
+        {t(
+          'Note that your profile will not be visible to others until you confirm your email.',
+        )}
+      </em>
+      <p>
+        <Trans t={t} ns="users">
+          If you didn&quot;t receive the message, check your spam folder or
+          resend it via
+          <a href="/profile/edit/account">email settings</a>.
+        </Trans>
+      </p>
+      <hr />
+    </div>
+  );
+}
+
+ConfirmEmailNotification.propTypes = {};

--- a/modules/users/client/components/ConfirmEmailNotification.component.js
+++ b/modules/users/client/components/ConfirmEmailNotification.component.js
@@ -14,8 +14,7 @@ export default function ConfirmEmailNotification() {
       <p>
         <Trans t={t} ns="users">
           If you didn&quot;t receive the message, check your spam folder or
-          resend it via
-          <a href="/profile/edit/account">email settings</a>.
+          resend it via <a href="/profile/edit/account">email settings</a>.
         </Trans>
       </p>
       <hr />

--- a/modules/users/client/components/ConfirmEmailNotification.component.js
+++ b/modules/users/client/components/ConfirmEmailNotification.component.js
@@ -13,7 +13,7 @@ export default function ConfirmEmailNotification() {
       </em>
       <p>
         <Trans t={t} ns="users">
-          If you didn&quot;t receive the message, check your spam folder or
+          If you didn&rsquo;t receive the message, check your spam folder or
           resend it via <a href="/profile/edit/account">email settings</a>.
         </Trans>
       </p>

--- a/modules/users/client/views/profile/profile-view.client.view.html
+++ b/modules/users/client/views/profile/profile-view.client.view.html
@@ -60,21 +60,9 @@ this is a fallback when the contacts are loading
   ></user-does-not-exist>
 
   <!-- Own profile is non-public -->
-  <div
-    class="row text-center"
-    aria-role="alert"
+  <confirm-email-notification
     ng-if="app.user.username === profileCtrl.profile.username && profileCtrl.profile.$resolved && app.user.public === false"
-  >
-    <em class="lead"
-      >Note that your profile will not be visible to others until you confirm
-      your email.</em
-    >
-    <p>
-      If you didn't receive the message, check your spam folder or resend it via
-      <a ui-sref="profile-edit.account">email settings</a>.
-    </p>
-    <hr />
-  </div>
+  ></confirm-email-notification>
 
   <!-- Profile -->
   <div ng-if="profileCtrl.profile.username && profileCtrl.profile.$resolved">


### PR DESCRIPTION
#### Proposed Changes

* Simple Angular->React conversion for a bit of profile. 

Gets a few more strings into translation. 🎉 

#### Testing Instructions

* Create new account and don't confirm email
* Open profile and see notice:

![image](https://user-images.githubusercontent.com/87168/103041082-0bbc0780-457e-11eb-9bad-dbd083a05db9.png)
