### PR TITLE
Refactor: use flattened 'interaction' object only in react component

### DIFF
--- a/modules/references/client/api/references.api.js
+++ b/modules/references/client/api/references.api.js
@@ -1,44 +1,4 @@
 import axios from 'axios';
-import set from 'lodash/set';
-import get from 'lodash/get';
-import has from 'lodash/has';
-
-/**
- * Map one object to another and back given a mapping. If the original path doesn't exist, it is skipped.
- * @param {Object} object - object to map
- * @param {[string, string][]} mapping - (array of pairs of paths) map values from 'some.path' to 'other.path'
- * @param {boolean=false} backwards - map from the 2nd to 1st path, i.e. backwards
- * @returns {Object} - the result of mapping
- */
-function mapObjectToObject(object, mapping, backwards = false) {
-  const output = {};
-  mapping.forEach(([key1, key2]) => {
-    const pathFrom = backwards ? key2 : key1;
-    const pathTo = backwards ? key1 : key2;
-
-    if (has(object, pathFrom)) {
-      set(output, pathTo, get(object, pathFrom));
-    }
-  });
-
-  return output;
-}
-
-/**
- * mapping from flat references (react state) to nested ones (API requests and responses)
- */
-const referenceMapping = [
-  ['met', 'interactions.met'],
-  ['hostedMe', 'interactions.hostedMe'],
-  ['hostedThem', 'interactions.hostedThem'],
-  ['recommend', 'recommend'],
-  ['feedbackPublic', 'feedbackPublic'],
-  ['userTo', 'userTo'],
-  ['userFrom', 'userFrom'],
-  ['public', 'public'],
-  ['created', 'created'],
-  ['_id', '_id'],
-];
 
 /**
  * API request: create a reference
@@ -46,12 +6,11 @@ const referenceMapping = [
  * @returns Promise<Reference> - saved reference
  */
 export async function create(reference) {
-  const requestReference = mapObjectToObject(reference, referenceMapping);
   const { data: responseReference } = await axios.post(
     '/api/references',
-    requestReference,
+    reference,
   );
-  return mapObjectToObject(responseReference, referenceMapping, true);
+  return responseReference;
 }
 
 /**
@@ -65,9 +24,7 @@ export async function read({ userTo }) {
   const { data: references } = await axios.get('/api/references', {
     params: { userTo },
   });
-  return references.map(reference =>
-    mapObjectToObject(reference, referenceMapping, true),
-  );
+  return references;
 }
 
 /**
@@ -83,7 +40,7 @@ export async function readMine({ userTo }) {
     const { data: reference } = await axios.get('/api/my-reference', {
       params,
     });
-    return mapObjectToObject(reference, referenceMapping, true);
+    return reference;
   } catch (err) {
     if (err.response?.status === 404) {
       return null;

--- a/modules/references/client/components/CreateReference.component.js
+++ b/modules/references/client/components/CreateReference.component.js
@@ -65,7 +65,11 @@ export default function CreateReference({ userFrom, userTo }) {
   const handleSubmit = async () => {
     setIsSubmitting(true);
 
-    const reference = { met, hostedThem, hostedMe, recommend, feedbackPublic };
+    const reference = {
+      interactions: { met, hostedThem, hostedMe },
+      recommend,
+      feedbackPublic,
+    };
 
     // save the reference
     const [savedReference] = await Promise.all([

--- a/modules/references/client/components/read-references/Meta.js
+++ b/modules/references/client/components/read-references/Meta.js
@@ -13,7 +13,7 @@ const Labels = styled.div`
   }
 `;
 
-export default function Meta({ met, hostedMe, hostedThem, recommend }) {
+export default function Meta({ interactions, recommend }) {
   const { t } = useTranslation('references');
 
   return (
@@ -21,9 +21,9 @@ export default function Meta({ met, hostedMe, hostedThem, recommend }) {
       {[
         recommend === 'yes' && t('Recommend'),
         recommend === 'no' && t('Not recommend'),
-        hostedMe && t('Guest'),
-        hostedThem && t('Host'),
-        met && t('Met in person'),
+        interactions?.hostedMe && t('Guest'),
+        interactions?.hostedThem && t('Host'),
+        interactions?.met && t('Met in person'),
       ]
         .filter(label => !!label)
         .map(label => (
@@ -36,8 +36,6 @@ export default function Meta({ met, hostedMe, hostedThem, recommend }) {
 }
 
 Meta.propTypes = {
-  hostedMe: PropTypes.bool.isRequired,
-  hostedThem: PropTypes.bool.isRequired,
-  met: PropTypes.bool.isRequired,
+  interactions: PropTypes.object.isRequired,
   recommend: PropTypes.string.isRequired,
 };

--- a/modules/references/client/components/read-references/Reference.js
+++ b/modules/references/client/components/read-references/Reference.js
@@ -62,9 +62,7 @@ export default function Reference({ reference, inRecipientProfile }) {
     _id,
     created,
     feedbackPublic,
-    hostedMe,
-    hostedThem,
-    met,
+    interactions,
     public: isPublicReference,
     recommend,
     userFrom,
@@ -138,12 +136,7 @@ export default function Reference({ reference, inRecipientProfile }) {
             )}
           </>
         )}
-        <Meta
-          hostedMe={hostedMe}
-          hostedThem={hostedThem}
-          met={met}
-          recommend={recommend}
-        />
+        <Meta interactions={interactions} recommend={recommend} />
         {feedbackPublic && <FeedbackPublic>{feedbackPublic}</FeedbackPublic>}
       </div>
     </div>

--- a/modules/references/tests/client/components/CreateReference.client.component.tests.js
+++ b/modules/references/tests/client/components/CreateReference.client.component.tests.js
@@ -114,9 +114,11 @@ describe('<CreateReference />', () => {
     fireEvent.click(getAllByText('Finish')[0]);
 
     expect(api.references.create).toHaveBeenCalledWith({
-      met: false,
-      hostedMe: true,
-      hostedThem: false,
+      interactions: {
+        met: false,
+        hostedMe: true,
+        hostedThem: false,
+      },
       recommend: 'yes',
       feedbackPublic: 'they made a tasty pie',
       userTo: userTo._id,
@@ -166,9 +168,11 @@ describe('<CreateReference />', () => {
     fireEvent.click(getAllByText('Finish')[0]);
 
     expect(api.references.create).toHaveBeenCalledWith({
-      met: false,
-      hostedMe: true,
-      hostedThem: false,
+      interactions: {
+        met: false,
+        hostedMe: true,
+        hostedThem: false,
+      },
       recommend: 'no',
       feedbackPublic: '',
       userTo: userTo._id,


### PR DESCRIPTION
#### Proposed Changes

* Do not flatten-unflatten interactions objects (which is inside the experience object) back and forth. Unflatten it once when creating an experience in the react component and always use the unflattened structure after that.

Slack discussion:
https://trustroots.slack.com/archives/C0A3Q15SS/p1608857982047000?thread_ts=1608764438.035300&cid=C0A3Q15SS

#### Testing Instructions

* Check that the experiences tab in someone's profile loads without errors and that interaction labels 'met', 'hostedMe', 'hostedThem' are present. Check everything is fine with the labels also when creating an experience.

