### PR TITLE
Add LanguageList component and fill test users with random languages

### DIFF
--- a/bin/fillTestData/Users.js
+++ b/bin/fillTestData/Users.js
@@ -11,6 +11,7 @@ const moment = require('moment');
 const mongoose = require('mongoose');
 const config = require(path.resolve('./config/config'));
 const cities = require(path.resolve('./bin/fillTestData/data/Cities.json'));
+const languages = require(path.resolve('./config/languages/languages.json'));
 
 require(path.resolve('./modules/offers/server/models/offer.server.model'));
 
@@ -269,6 +270,10 @@ function addUsers() {
                 .subtract(Math.random() * 365, 'd')
                 .subtract(Math.random() * 24, 'h')
                 .subtract(Math.random() * 3600, 's');
+              // 0-4 random languages
+              user.languages = [...Array(random(4))].map(() =>
+                faker.random.objectElement(languages, 'key'),
+              );
 
               if (admin !== undefined) {
                 // admin user

--- a/modules/users/client/components/LanguageList.js
+++ b/modules/users/client/components/LanguageList.js
@@ -1,0 +1,31 @@
+// External dependencies
+import { useTranslation } from 'react-i18next';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+// Internal dependencies
+import * as languageNames from '@/config/languages/languages.json';
+
+export default function LanguageList({ languages = [], className }) {
+  const { t } = useTranslation(['languages']);
+
+  return (
+    <ul className={className}>
+      {languages.map(code => {
+        return (
+          <li key={code}>
+            {languageNames[code]
+              ? // i18next-extract-disable-next-line
+                t(languageNames[code], { ns: 'languages' })
+              : code}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+LanguageList.propTypes = {
+  className: PropTypes.string,
+  languages: PropTypes.array.isRequired,
+};

--- a/modules/users/client/components/Monkeybox.js
+++ b/modules/users/client/components/Monkeybox.js
@@ -1,9 +1,12 @@
+// External dependencies
 import React, { useEffect, useState } from 'react';
 import keyBy from 'lodash/keyBy';
 import { useTranslation } from 'react-i18next';
 
-import Avatar from '@/modules/users/client/components/Avatar.component';
+// Internal dependencies
 import { userType } from '@/modules/users/client/users.prop-types';
+import Avatar from '@/modules/users/client/components/Avatar.component';
+import LanguageList from './LanguageList';
 
 function TribesInCommon({ user, otherUser }) {
   const { t } = useTranslation('users');
@@ -60,11 +63,10 @@ export default function Monkeybox({ user, otherUser }) {
         {user.languages.length > 0 && (
           <div className="monkeybox-section">
             <h4>{t('Languages')}</h4>
-            <ul className="list-unstyled">
-              {user.languages.map(language => (
-                <li key={language.code}>{language.code}</li>
-              ))}
-            </ul>
+            <LanguageList
+              className="list-unstyled"
+              languages={user.languages}
+            />
           </div>
         )}
       </div>

--- a/modules/users/client/components/ProfileViewBasics.js
+++ b/modules/users/client/components/ProfileViewBasics.js
@@ -1,16 +1,19 @@
+// External dependencies
 import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
-import * as languages from '@/config/languages/languages';
+
+// Internal dependencies
 import {
   hasConnectedAdditionalSocialAccounts,
   isWarmshowersId,
   socialAccountLink,
 } from '../utils/networks';
 import { getGender } from '@/modules/core/client/utils/user_info';
+import LanguageList from './LanguageList';
 
 export default function ProfileViewBasics({ profile }) {
-  const { t } = useTranslation(['users', 'languages']);
+  const { t } = useTranslation(['users']);
 
   const getBirthdate = birthdate =>
     t('{{birthdate, age}} years.', { birthdate: new Date(birthdate) });
@@ -30,9 +33,6 @@ export default function ProfileViewBasics({ profile }) {
     }
     return t('Online long ago');
   };
-
-  // i18next-extract-disable-next-line
-  const getLanguage = code => t(languages[code], { ns: 'languages' });
 
   /*
    * Rendering functions
@@ -89,14 +89,10 @@ export default function ProfileViewBasics({ profile }) {
     </div>
   );
 
-  const renderLanguages = languagesList => (
+  const renderLanguages = languages => (
     <div className="profile-sidebar-section">
-      <h4 id="profile-languages">{t('Languages')}</h4>
-      <ul className="list-unstyled" aria-describedby="profile-languages">
-        {languagesList.map(code => (
-          <li key={code}>{getLanguage(code) || code}</li>
-        ))}
-      </ul>
+      <h4>{t('Languages')}</h4>
+      <LanguageList className="list-unstyled" languages={languages} />
     </div>
   );
 


### PR DESCRIPTION
#### Proposed Changes

* Adds simple `LanguageList` component to be re-used across two places.
* The profile next to message thread was showing just language codes previously, so this fixes that.
* Later on I can use this at search results as well once it's in React.

#### Testing Instructions

Component
* Open message thread, observe languages
* Open a profile, observe languages

Test data
- Run `npm run seed:users 5`
- Check latest users with `db.getCollection('users').find({},{languages:1}).sort({created:-1})`
- They should have random languages:

<img src="https://user-images.githubusercontent.com/87168/103135842-0537a800-46c4-11eb-9722-2abb553981c6.png" width="400"/>

