### PR TITLE
Experiences: add count to tab

### DIFF
--- a/modules/core/client/components/Badge.js
+++ b/modules/core/client/components/Badge.js
@@ -6,11 +6,11 @@ import styled from 'styled-components';
 const Dot = styled.div`
   background: #d9534f;
   border-radius: 50%;
-  height: 5px;
+  height: 7px;
   position: absolute;
-  right: 10px;
+  right: 9px;
   top: 6px;
-  width: 5px;
+  width: 7px;
 `;
 
 export default function Badge({ children, withNotification }) {

--- a/modules/core/client/components/Badge.js
+++ b/modules/core/client/components/Badge.js
@@ -1,0 +1,28 @@
+// External dependencies
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'styled-components';
+
+const Dot = styled.div`
+  background: #d9534f;
+  border-radius: 50%;
+  height: 5px;
+  position: absolute;
+  right: 10px;
+  top: 6px;
+  width: 5px;
+`;
+
+export default function Badge({ children, withNotification }) {
+  return (
+    <span className="badge">
+      {children}
+      {withNotification && <Dot />}
+    </span>
+  );
+}
+
+Badge.propTypes = {
+  children: PropTypes.node.isRequired,
+  withNotification: PropTypes.bool,
+};

--- a/modules/references/client/api/references.api.js
+++ b/modules/references/client/api/references.api.js
@@ -72,8 +72,11 @@ export async function getCount(userTo) {
     const { data } = await axios.get('/api/references/count', {
       params: { userTo },
     });
-    return parseInt(data, 10);
+    return data;
   } catch {
-    return 0;
+    return {
+      count: 0,
+      hasPending: false,
+    };
   }
 }

--- a/modules/references/client/api/references.api.js
+++ b/modules/references/client/api/references.api.js
@@ -60,3 +60,20 @@ export async function readMine({ userTo }) {
 export async function report(user, message) {
   await axios.post('/api/support', { message, reportMember: user.username });
 }
+
+/**
+ * API request: get count of references
+ *
+ * @param {string} userTo - id of user who received the reference
+ * @returns {int} Number of experiences
+ */
+export async function getCount(userTo) {
+  try {
+    const { data } = await axios.get('/api/references/count', {
+      params: { userTo },
+    });
+    return parseInt(data, 10);
+  } catch {
+    return 0;
+  }
+}

--- a/modules/references/client/api/references.api.js
+++ b/modules/references/client/api/references.api.js
@@ -18,7 +18,7 @@ export async function create(reference) {
  * and sort by 'created' field starting from the most recent date
  *
  * @param {string} userTo - id of user who received the reference
- * @returns Promise<Reference[]> - array of the found references
+ * @returns {array} - array of the found references
  */
 export async function read({ userTo }) {
   const { data: references } = await axios.get('/api/references', {
@@ -32,7 +32,7 @@ export async function read({ userTo }) {
  * and sort by 'created' field starting from the most recent date
  *
  * @param {string} userTo - id of user who received the reference
- * @returns Promise<Reference[]> - array of the found references
+ * @returns {object} - A reference
  */
 export async function readMine({ userTo }) {
   const params = { userTo };
@@ -65,7 +65,7 @@ export async function report(user, message) {
  * API request: get count of references
  *
  * @param {string} userTo - id of user who received the reference
- * @returns {int} Number of experiences
+ * @returns {object} - Number of experiences as `{count: Int, hasPending: Bool}`
  */
 export async function getCount(userTo) {
   try {
@@ -74,9 +74,6 @@ export async function getCount(userTo) {
     });
     return data;
   } catch {
-    return {
-      count: 0,
-      hasPending: false,
-    };
+    return { count: 0 };
   }
 }

--- a/modules/references/server/controllers/reference.server.controller.js
+++ b/modules/references/server/controllers/reference.server.controller.js
@@ -546,3 +546,32 @@ exports.readMine = async function readMine(req, res) {
   }
   return res.status(200).json(reference);
 };
+
+exports.getCount = async function getCount(req, res, next) {
+  console.log('getCount — userTo:', req.query.userTo); //eslint-disable-line
+  const { userTo } = req.query;
+
+  if (!mongoose.Types.ObjectId.isValid(userTo)) {
+    return res
+      .status(400)
+      .send({ message: 'Missing or invalid `userTo` request param' });
+  }
+
+  try {
+    const query = {
+      userTo: new mongoose.Types.ObjectId(userTo),
+    };
+
+    // Allow non-public references only when userTo is self
+    if (!req.user._id.equals(userTo)) {
+      query.public = true;
+    }
+
+    const count = await Reference.find(query).count();
+
+    console.log('getCount — count:', query, count); //eslint-disable-line
+    return res.status(200).json(count);
+  } catch (error) {
+    processResponses(res, next, error);
+  }
+};

--- a/modules/references/server/policies/references.server.policy.js
+++ b/modules/references/server/policies/references.server.policy.js
@@ -16,6 +16,10 @@ exports.invokeRolesPolicies = function () {
           permissions: ['get', 'post'],
         },
         {
+          resources: '/api/references/count',
+          permissions: ['get'],
+        },
+        {
           resources: '/api/my-reference',
           permissions: ['get'],
         },

--- a/modules/references/server/routes/reference.server.routes.js
+++ b/modules/references/server/routes/reference.server.routes.js
@@ -12,6 +12,11 @@ module.exports = function (app) {
       .get(references.readMany);
 
     app
+      .route('/api/references/count')
+      .all(referencePolicy.isAllowed)
+      .get(references.getCount);
+
+    app
       .route('/api/my-reference')
       .all(referencePolicy.isAllowed)
       .get(references.readMine);

--- a/modules/references/tests/server/reference-count.server.routes.tests.js
+++ b/modules/references/tests/server/reference-count.server.routes.tests.js
@@ -1,0 +1,124 @@
+const mongoose = require('mongoose');
+const path = require('path');
+const request = require('supertest');
+const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const express = require(path.resolve('./config/lib/express'));
+
+describe('Read count of references received by user', () => {
+  // GET /references/count?userTo=:UserId
+
+  const app = express.init(mongoose.connection);
+  const agent = request.agent(app);
+
+  let users;
+
+  const _usersPublic = utils.generateUsers(6, { public: true });
+  const _usersPrivate = utils.generateUsers(3, {
+    public: false,
+    username: 'nonpublic',
+    email: 'nonpublic@example.com',
+  });
+  const _users = [..._usersPublic, ..._usersPrivate];
+
+  /**
+   * array of [userFrom, userTo, values]
+   *
+   * Overview of the referenceData
+   * - row: userFrom - index of user within array of users provided to utils.generateReferences()
+   * - column: userTo - same as row
+   * - T: reference exists and is public
+   * - F: reference exists and is not public
+   * - .: reference doesn't exist
+   *
+   *   0 1 2 3 4 5
+   * 0 . T T F F T
+   * 1 T . T T . T
+   * 2 T . . T F T
+   * 3 T . F . . .
+   * 4 F . . . . .
+   * 5 T . . . . .
+   */
+  const referenceData = [
+    [0, 1],
+    [0, 2],
+    [0, 3, { public: false }],
+    [0, 4, { public: false }],
+    [0, 5],
+    [1, 0],
+    [1, 2],
+    [1, 3],
+    [1, 5],
+    [2, 0],
+    [2, 3],
+    [2, 4, { public: false }],
+    [2, 5],
+    [3, 0],
+    [3, 2, { public: false }],
+    [4, 0, { public: false }],
+    [5, 0],
+  ];
+
+  before(async () => {
+    users = await utils.saveUsers(_users);
+
+    const _references = utils.generateReferences(users, referenceData);
+    await utils.saveReferences(_references);
+  });
+
+  after(utils.clearDatabase);
+
+  context('logged in as public user', () => {
+    beforeEach(utils.signIn.bind(this, _usersPublic[0], agent));
+    afterEach(utils.signOut.bind(this, agent));
+
+    it('respond with all public references to userTo', async () => {
+      const { body } = await agent
+        .get(`/api/references/count?userTo=${users[2]._id}`)
+        .expect(200);
+
+      // user2 has received 2 public and 1 non-public reference
+      body.should.equal(2);
+    });
+
+    it('private references are included when own profile', async () => {
+      const { body } = await agent
+        .get(`/api/references/count?userTo=${users[0]._id}`)
+        .expect(200);
+
+      body.should.equal(5);
+    });
+
+    it('[no params] 400 and error', async () => {
+      const { body } = await agent.get('/api/references/count').expect(400);
+
+      body.message.should.equal('Missing or invalid `userTo` request param');
+    });
+
+    it('[invalid params] 400 and error', async () => {
+      const { body } = await agent
+        .get('/api/references/count?userTo=1')
+        .expect(400);
+
+      body.message.should.equal('Missing or invalid `userTo` request param');
+    });
+  });
+
+  context('logged in as non-public user', () => {
+    beforeEach(utils.signIn.bind(this, _usersPrivate[0], agent));
+    afterEach(utils.signOut.bind(this, agent));
+
+    it('403', async () => {
+      await agent
+        .get(`/api/references/count?userTo=${users[2]._id}`)
+        .expect(403);
+    });
+  });
+
+  context('not logged in', () => {
+    it('403', async () => {
+      await agent
+        .get(`/api/references/count?userTo=${users[2]._id}`)
+        .expect(403);
+    });
+  });
+});

--- a/modules/references/tests/server/reference-count.server.routes.tests.js
+++ b/modules/references/tests/server/reference-count.server.routes.tests.js
@@ -1,5 +1,6 @@
 const mongoose = require('mongoose');
 const path = require('path');
+const should = require('should');
 const request = require('supertest');
 const utils = require(path.resolve('./testutils/server/data.server.testutil'));
 const express = require(path.resolve('./config/lib/express'));
@@ -77,7 +78,8 @@ describe('Read count of references received by user', () => {
         .expect(200);
 
       // user2 has received 2 public and 1 non-public reference
-      body.should.equal(2);
+      body.count.should.equal(2);
+      should.not.exist(body.hasPending);
     });
 
     it('private references are included when own profile', async () => {
@@ -85,7 +87,8 @@ describe('Read count of references received by user', () => {
         .get(`/api/references/count?userTo=${users[0]._id}`)
         .expect(200);
 
-      body.should.equal(5);
+      body.count.should.equal(5);
+      body.hasPending.should.be.true();
     });
 
     it('[no params] 400 and error', async () => {

--- a/modules/users/client/components/ProfileTabs.component.js
+++ b/modules/users/client/components/ProfileTabs.component.js
@@ -7,6 +7,7 @@ import React, { useState, useEffect } from 'react';
 // Internal dependencies
 import { $on } from '@/modules/core/client/services/angular-compat';
 import { getCount as getExperiencesCount } from '@/modules/references/client/api/references.api';
+import Badge from '@/modules/core/client/components/Badge';
 
 export default function ProfileTabs({
   contactsCount,
@@ -18,11 +19,15 @@ export default function ProfileTabs({
 }) {
   const { t } = useTranslation('users');
   const [experiencesCount, setExperiencesCount] = useState(0);
+  const [hasPendingExperiences, setHasPendingExperiences] = useState(false);
   const [pathName, setPathName] = useState(initialPathName);
 
   useEffect(async () => {
-    const count = await getExperiencesCount(userId);
+    const { count, hasPending } = await getExperiencesCount(userId);
     setExperiencesCount(count);
+    if (hasPending) {
+      setHasPendingExperiences(true);
+    }
   }, []);
 
   // Handle tab changes from Angular UI router
@@ -65,11 +70,11 @@ export default function ProfileTabs({
               role="tab"
             >
               {t('Contacts')}
-              <span className="badge">{contactsCount}</span>
+              <Badge>{contactsCount}</Badge>
             </a>
           </li>
         )}
-        {isExperiencesEnabled && (experiencesCount > 0 || isOWnProfile) && (
+        {isExperiencesEnabled && (experiencesCount >= 0 || isOWnProfile) && (
           <li
             className={classnames({
               active: pathName === 'profile.experiences.list',
@@ -84,7 +89,9 @@ export default function ProfileTabs({
               role="tab"
             >
               {t('Experiences')}
-              <span className="badge">{experiencesCount}</span>
+              <Badge withNotification={hasPendingExperiences}>
+                {experiencesCount}
+              </Badge>
             </a>
           </li>
         )}

--- a/modules/users/client/components/ProfileTabs.component.js
+++ b/modules/users/client/components/ProfileTabs.component.js
@@ -1,0 +1,103 @@
+// External dependencies
+import { useTranslation } from 'react-i18next';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+import React, { useState, useEffect } from 'react';
+
+// Internal dependencies
+import { $on } from '@/modules/core/client/services/angular-compat';
+import { getCount as getExperiencesCount } from '@/modules/references/client/api/references.api';
+
+export default function ProfileTabs({
+  contactsCount,
+  initialPathName,
+  isExperiencesEnabled,
+  isOWnProfile,
+  userId,
+  username,
+}) {
+  const { t } = useTranslation('users');
+  const [experiencesCount, setExperiencesCount] = useState(0);
+  const [pathName, setPathName] = useState(initialPathName);
+
+  useEffect(async () => {
+    const count = await getExperiencesCount(userId);
+    setExperiencesCount(count);
+  }, []);
+
+  // Handle tab changes from Angular UI router
+  useEffect(
+    () =>
+      $on('$stateChangeSuccess', (event, { name }) => {
+        setPathName(name);
+      }),
+    [],
+  );
+
+  return (
+    <div className="profile-tabs hidden-xs" role="navigation">
+      <ul
+        className="nav panel panel-default nav-pills nav-narrow nav-underline"
+        role="tablist"
+      >
+        <li
+          className={classnames({
+            active: pathName === 'profile.about',
+          })}
+          role="presentation"
+        >
+          <a href={`/profile/${username}`} role="tab">
+            {t('About')}
+          </a>
+        </li>
+        {(contactsCount || isOWnProfile) && (
+          <li
+            className={classnames({
+              active: pathName === 'profile.contacts',
+            })}
+            role="presentation"
+          >
+            <a
+              aria-label={t('{{count}} contacts', {
+                count: contactsCount,
+              })}
+              href={`/profile/${username}/contacts`}
+              role="tab"
+            >
+              {t('Contacts')}
+              <span className="badge">{contactsCount}</span>
+            </a>
+          </li>
+        )}
+        {isExperiencesEnabled && (experiencesCount > 0 || isOWnProfile) && (
+          <li
+            className={classnames({
+              active: pathName === 'profile.experiences.list',
+            })}
+            role="presentation"
+          >
+            <a
+              aria-label={t('{{count}} experiences', {
+                count: experiencesCount,
+              })}
+              href={`/profile/${username}/experiences`}
+              role="tab"
+            >
+              {t('Experiences')}
+              <span className="badge">{experiencesCount}</span>
+            </a>
+          </li>
+        )}
+      </ul>
+    </div>
+  );
+}
+
+ProfileTabs.propTypes = {
+  contactsCount: PropTypes.number,
+  initialPathName: PropTypes.string.isRequired,
+  isExperiencesEnabled: PropTypes.bool.isRequired,
+  isOWnProfile: PropTypes.bool.isRequired,
+  username: PropTypes.string.isRequired,
+  userId: PropTypes.string.isRequired,
+};

--- a/modules/users/client/components/ProfileTabs.component.js
+++ b/modules/users/client/components/ProfileTabs.component.js
@@ -23,10 +23,12 @@ export default function ProfileTabs({
   const [pathName, setPathName] = useState(initialPathName);
 
   useEffect(async () => {
-    const { count, hasPending } = await getExperiencesCount(userId);
-    setExperiencesCount(count);
-    if (hasPending) {
-      setHasPendingExperiences(true);
+    if (isExperiencesEnabled) {
+      const { count, hasPending } = await getExperiencesCount(userId);
+      setExperiencesCount(count);
+      if (hasPending) {
+        setHasPendingExperiences(true);
+      }
     }
   }, []);
 

--- a/modules/users/client/controllers/profile.client.controller.js
+++ b/modules/users/client/controllers/profile.client.controller.js
@@ -22,6 +22,7 @@ function ProfileController(
   vm.profile = profile;
   vm.contact = contact;
   vm.contacts = contacts;
+  vm.initialPathName = $state.current.name;
 
   /**
    * Remove contact via React RemoveContact component

--- a/modules/users/client/views/profile/profile-view.client.view.html
+++ b/modules/users/client/views/profile/profile-view.client.view.html
@@ -201,42 +201,14 @@ this is a fallback when the contacts are loading
         <!-- Profile content tabs -->
         <div class="row">
           <div class="col-xs-12">
-            <div class="profile-tabs hidden-xs" role="navigation">
-              <ul
-                class="nav panel panel-default nav-pills nav-narrow nav-underline"
-                role="tablist"
-              >
-                <li ui-sref-active="active" role="presentation">
-                  <a ui-sref="profile.about" role="tab">About</a>
-                </li>
-                <li
-                  ui-sref-active="active"
-                  ng-if="profileCtrl.contacts.length || profileCtrl.profile._id === app.user._id"
-                  role="presentation"
-                >
-                  <a ui-sref="profile.contacts" role="tab">
-                    <span aria-hidden="true">Contacts</span>
-                    <span
-                      class="badge"
-                      aria-hidden="true"
-                      ng-bind="profileCtrl.contacts.length"
-                    ></span>
-                    <span class="sr-only">
-                      {{profileCtrl.contacts.length}} Contacts
-                    </span>
-                  </a>
-                </li>
-                <li
-                  ui-sref-active="active"
-                  role="presentation"
-                  ng-if="app.appSettings.referencesEnabled"
-                >
-                  <a ui-sref="profile.experiences.list" role="tab">
-                    Experiences
-                  </a>
-                </li>
-              </ul>
-            </div>
+            <profile-tabs
+              contacts-count="profileCtrl.contacts.length || 0"
+              initial-path-name="profileCtrl.initialPathName"
+              is-experiences-enabled="app.appSettings.referencesEnabled"
+              is-own-profile="profileCtrl.profile._id === app.user._id"
+              user-id="profileCtrl.profile._id"
+              username="profileCtrl.profile.username"
+            ></profile-tabs>
             <div ui-view></div>
           </div>
         </div>


### PR DESCRIPTION
Resolves https://github.com/Trustroots/trustroots/issues/1840 (or is that a bit different issue?)


#### Proposed Changes

* Convert "profile tabs" into React component
* Show number of experiences in the tab
* Show a notification dot if there are pending experiences and I'm looking at my own profile
* Adds new API endpoint just to receive the count. Alternatively we could fetch the whole list at this point, but it would be wasteful if user never opens the experiences tab.

#### Testing Instructions

* When user has public experiences, tab is shown with a count
* When user doesn't have public experiences, tab is not shown
* Tab shows up always also if you look at your own profile
* If you're looking at your own profile...
   * ...also private experiences are counted in
   * ...you see a dot if there are pending experiences
* If experiences are disabled, tab is hidden


When looking at other's profile (even when they have pending experiences):

<img width="716" alt="Screenshot 2020-12-26 at 13 08 46" src="https://user-images.githubusercontent.com/87168/103151309-9e7ac300-4785-11eb-9189-b8b9c8755cf7.png">

When looking at my own profile when there are pending experiences:

<img width="725" alt="Screenshot 2020-12-26 at 13 03 03" src="https://user-images.githubusercontent.com/87168/103151313-a63a6780-4785-11eb-8211-b4433f31fba7.png">
