### PR TITLE
Fix admin route check

### DIFF
--- a/modules/core/client/controllers/app.client.controller.js
+++ b/modules/core/client/controllers/app.client.controller.js
@@ -239,10 +239,7 @@ function AppController(
           toState.requiresAuth = true;
         }
         // Check if user has the required role
-        else if (
-          Authentication.user &&
-          !Authentication.user.roles.includes(toState.requiresRole)
-        ) {
+        else if (!Authentication?.user?.roles?.includes(toState.requiresRole)) {
           event.preventDefault();
           $window.alert(
             'This page would require you to be a Trustroots volunteer. Wanna help us build Trustroots?',

--- a/modules/users/server/controllers/users.profile.server.controller.js
+++ b/modules/users/server/controllers/users.profile.server.controller.js
@@ -886,7 +886,12 @@ exports.sanitizeProfile = function (profile, authenticatedUser) {
   delete profile.emailToken;
   delete profile.password;
   delete profile.salt;
-  delete profile.roles;
+
+  // Authenticated admins can receive roles object for all users
+  // This is mostly to allow `/admin` routes at client for them
+  if (!authenticatedUser.roles.includes('admin')) {
+    delete profile.roles;
+  }
 
   // This information is not sensitive, but isn't needed at frontend
   delete profile.publicReminderCount;


### PR DESCRIPTION
#### Proposed Changes

* Fix checking for `admin` role requirement for `/admin/*` routes.

This was implemented earlier but broke in some refactor. Having it visible for everyone isn't a big deal since it's just client, admin APIs are still limited for admins only. Might as well just hide it though.

#### Testing Instructions

* Have user with `admin` in `roles` array.
* Have user without `admin` in `roles` array.
* Test opening `/admin`
* Test also as non-authenticated user
