### PR TITLE
Admin: list reference threads

### DIFF
--- a/modules/admin/client/api/admin-reference-threads.api.js
+++ b/modules/admin/client/api/admin-reference-threads.api.js
@@ -1,0 +1,6 @@
+import axios from 'axios';
+
+export async function getReferenceThreads() {
+  const { data } = await axios.get('/api/admin/reference-threads');
+  return data;
+}

--- a/modules/admin/client/components/AdminHeader.component.js
+++ b/modules/admin/client/components/AdminHeader.component.js
@@ -6,7 +6,41 @@ import React from 'react';
 import adminIcon from '../images/bmo.png';
 
 export default function AdminHeader() {
-  const path = window.location.pathname;
+  const currentPath = window.location.pathname.replace('/admin/', '');
+
+  const pages = [
+    {
+      path: 'user',
+      label: 'Member report card',
+    },
+    {
+      path: 'search-users',
+      label: 'Search members',
+    },
+    {
+      path: 'messages',
+      label: 'Messages',
+    },
+    {
+      path: 'threads',
+      label: 'Threads',
+    },
+    {
+      path: 'reference-threads',
+      label: 'Reference threads',
+    },
+    {
+      path: 'acquisition-stories',
+      label: 'Acquisition stories',
+    },
+  ];
+
+  const renderTab = ({ path, label }) => (
+    <li key={path} className={classnames({ active: currentPath === path })}>
+      <a href={`/admin/${path}`}>{label}</a>
+    </li>
+  );
+
   return (
     <>
       <br />
@@ -29,32 +63,10 @@ export default function AdminHeader() {
             </a>
           </div>
           <ul className="nav navbar-nav">
-            <li className={classnames({ active: path === '/admin/user' })}>
-              <a href="/admin/user">Member report card</a>
-            </li>
-            <li
-              className={classnames({ active: path === '/admin/search-users' })}
-            >
-              <a href="/admin/search-users">Search members</a>
-            </li>
-            <li className={classnames({ active: path === '/admin/messages' })}>
-              <a href="/admin/messages">Messages</a>
-            </li>
-            <li className={classnames({ active: path === '/admin/threads' })}>
-              <a href="/admin/threads">Threads</a>
-            </li>
-            <li
-              className={classnames({
-                active: path === '/admin/acquisition-stories',
-              })}
-            >
-              <a href="/admin/acquisition-stories">Acquisition stories</a>
-            </li>
+            {pages.map(page => renderTab(page))}
           </ul>
           <ul className="nav navbar-nav pull-right">
-            <li className={classnames({ active: path === '/admin/audit-log' })}>
-              <a href="/admin/audit-log">Audit log</a>
-            </li>
+            {renderTab({ path: 'audit-log', label: 'Audit log' })}
           </ul>
         </div>
       </nav>

--- a/modules/admin/client/components/AdminReferenceThreads.component.js
+++ b/modules/admin/client/components/AdminReferenceThreads.component.js
@@ -1,0 +1,69 @@
+// External dependencies
+import React, { useEffect, useState } from 'react';
+
+import * as api from '../api/admin-reference-threads.api';
+import TimeAgo from '@/modules/core/client/components/TimeAgo';
+import UserLink from './UserLink.component';
+import AdminHeader from './AdminHeader.component';
+
+/**
+ * Lists threads that received negative references
+ */
+export default function AdminReferenceThreads() {
+  const [isFetching, setIsFetching] = useState(false);
+  const [referenceThreads, setReferenceThreads] = useState([]);
+
+  async function fetchReferenceThreads() {
+    setIsFetching(true);
+    try {
+      const results = await api.getReferenceThreads();
+      setReferenceThreads(results);
+    } catch {
+      // eslint-disable-next-line no-console
+      console.log(`Could not load reference threads`);
+    } finally {
+      setIsFetching(false);
+    }
+  }
+
+  useEffect(() => {
+    fetchReferenceThreads();
+  }, []);
+
+  return (
+    <>
+      <AdminHeader />
+      <div className="container">
+        <h2>Reference Threads</h2>
+        <p>500 latest negative reference threads.</p>
+        {isFetching && <p>Loading reference threads...</p>}
+        {!isFetching &&
+          referenceThreads.length > 0 &&
+          referenceThreads.map(({ _id, userFrom, userTo, created }) => {
+            return (
+              <div key={_id} className="panel">
+                <div className="panel-body">
+                  <p>
+                    <TimeAgo date={new Date(created)} />
+                    {' by '}
+                    <UserLink user={userFrom} />
+                    {' for '}
+                    <UserLink user={userTo} />
+                  </p>
+                  <p>
+                    <a
+                      href={`/admin/messages?userId1=${userTo._id}&userId2=${userFrom._id}`}
+                    >
+                      See message thread
+                    </a>
+                  </p>
+                </div>
+              </div>
+            );
+          })}
+      </div>
+    </>
+  );
+}
+
+AdminReferenceThreads.propTypes = {};

--- a/modules/admin/client/config/admin.client.routes.js
+++ b/modules/admin/client/config/admin.client.routes.js
@@ -90,5 +90,18 @@ function AdminRoutes($stateProvider) {
       data: {
         pageTitle: 'Admin - User',
       },
+    })
+    .state('admin-reference-threads', {
+      url: '/admin/reference-threads',
+      // `template` is Angular state so
+      // it should be lowercase, with dashes
+      // This is the bridge towards (and from) React
+      template: '<admin-reference-threads></admin-reference-threads>',
+      requiresRole: 'admin',
+      requiresAuth: true,
+      footerHidden: true,
+      data: {
+        pageTitle: 'Admin - Reference threads',
+      },
     });
 }

--- a/modules/admin/server/controllers/admin.reference-threads.server.controller.js
+++ b/modules/admin/server/controllers/admin.reference-threads.server.controller.js
@@ -1,0 +1,25 @@
+/**
+ * Module dependencies.
+ */
+const mongoose = require('mongoose');
+
+const ReferenceThread = mongoose.model('ReferenceThread');
+
+exports.list = async (req, res) => {
+  const items = await ReferenceThread.find({ reference: 'no' })
+    .sort('-created')
+    .limit(500)
+    .populate({
+      path: 'userTo',
+      select: 'username displayName _id',
+      model: 'User',
+    })
+    .populate({
+      path: 'userFrom',
+      select: 'username displayName _id',
+      model: 'User',
+    })
+    .exec();
+
+  res.send(items || []);
+};

--- a/modules/admin/server/policies/admin.server.policy.js
+++ b/modules/admin/server/policies/admin.server.policy.js
@@ -28,6 +28,7 @@ exports.invokeRolesPolicies = () => {
         { resources: '/api/admin/user/change-role', permissions: ['post'] },
         { resources: '/api/admin/users', permissions: ['post'] },
         { resources: '/api/admin/users/by-role', permissions: ['post'] },
+        { resources: '/api/admin/reference-threads', permissions: ['get'] },
       ],
     },
   ]);

--- a/modules/admin/server/routes/admin.server.routes.js
+++ b/modules/admin/server/routes/admin.server.routes.js
@@ -8,6 +8,7 @@ const adminPolicy = require('../policies/admin.server.policy');
 const adminThreads = require('../controllers/admin.threads.server.controller');
 const adminUsers = require('../controllers/admin.users.server.controller');
 const adminNotes = require('../controllers/admin.notes.server.controller');
+const adminReferenceThreads = require('../controllers/admin.reference-threads.server.controller');
 
 module.exports = app => {
   app
@@ -59,4 +60,9 @@ module.exports = app => {
     .route('/api/admin/user/change-role')
     .all(adminPolicy.isAllowed)
     .post(adminAuditLog.record, adminUsers.changeRole);
+
+  app
+    .route('/api/admin/reference-threads')
+    .all(adminPolicy.isAllowed)
+    .get(adminAuditLog.record, adminReferenceThreads.list);
 };

--- a/modules/admin/tests/server/admin.reference-threads.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.reference-threads.server.routes.tests.js
@@ -39,16 +39,22 @@ describe('Admin Reference thread CRUD tests', () => {
   afterEach(utils.clearDatabase);
 
   beforeEach(async () => {
-    const reference1 = new ReferenceThread({
-      reference: 'yes',
+    const referenceBase = {
       created: new Date(),
+      // eslint-disable-next-line new-cap
+      thread: mongoose.Types.ObjectId().toString(),
+    };
+
+    const reference1 = new ReferenceThread({
+      ...referenceBase,
+      reference: 'yes',
       userFrom: userRegular1Id,
       userTo: userRegular2Id,
     });
 
     const reference2 = new ReferenceThread({
+      ...referenceBase,
       reference: 'no',
-      created: new Date(),
       userFrom: userRegular2Id,
       userTo: userRegular1Id,
     });
@@ -59,7 +65,9 @@ describe('Admin Reference thread CRUD tests', () => {
 
   describe('Read reference threads', () => {
     it('non-authenticated users should not be allowed to read reference threads', async () => {
-      const { body } = agent.get('/api/admin/reference-threads').expect(403);
+      const { body } = await agent
+        .get('/api/admin/reference-threads')
+        .expect(403);
 
       body.message.should.equal('Forbidden.');
     });

--- a/modules/admin/tests/server/admin.reference-threads.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.reference-threads.server.routes.tests.js
@@ -1,0 +1,94 @@
+const request = require('supertest');
+const path = require('path');
+const mongoose = require('mongoose');
+require('should');
+
+const express = require(path.resolve('./config/lib/express'));
+const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+
+const ReferenceThread = mongoose.model('ReferenceThread');
+
+describe('Admin Reference thread CRUD tests', () => {
+  // Get application
+  const app = express.init(mongoose.connection);
+  const agent = request.agent(app);
+
+  let _users;
+  let userRegular1Id;
+  let userRegular2Id;
+
+  const _usersRaw = utils.generateUsers(3);
+  _usersRaw[0].roles = ['user', 'admin'];
+
+  const credentialsAdmin = {
+    username: _usersRaw[0].username,
+    password: _usersRaw[0].password,
+  };
+
+  const credentialsRegular = {
+    username: _usersRaw[1].username,
+    password: _usersRaw[1].password,
+  };
+
+  beforeEach(async () => {
+    _users = await utils.saveUsers(_usersRaw);
+    userRegular1Id = _users[1]._id;
+    userRegular2Id = _users[2]._id;
+  });
+
+  afterEach(utils.clearDatabase);
+
+  beforeEach(async () => {
+    const reference1 = new ReferenceThread({
+      reference: 'yes',
+      created: new Date(),
+      userFrom: userRegular1Id,
+      userTo: userRegular2Id,
+    });
+
+    const reference2 = new ReferenceThread({
+      reference: 'no',
+      created: new Date(),
+      userFrom: userRegular2Id,
+      userTo: userRegular1Id,
+    });
+
+    await reference1.save();
+    await reference2.save();
+  });
+
+  describe('Read reference threads', () => {
+    it('non-authenticated users should not be allowed to read reference threads', async () => {
+      const { body } = agent.get('/api/admin/reference-threads').expect(403);
+
+      body.message.should.equal('Forbidden.');
+    });
+
+    describe('As authenticated user...', () => {
+      afterEach(async () => {
+        await utils.signOut(agent);
+      });
+
+      it('non-admin users should not be allowed to read reference threads', async () => {
+        await utils.signIn(credentialsRegular, agent);
+
+        const { body } = await agent
+          .get('/api/admin/reference-threads')
+          .expect(403);
+
+        body.message.should.equal('Forbidden.');
+      });
+
+      it('admin users should be allowed to read reference threads', async () => {
+        await utils.signIn(credentialsAdmin, agent);
+
+        const { body } = await agent
+          .get('/api/admin/reference-threads')
+          .expect(200);
+
+        body.length.should.equal(1);
+        body[0].reference.should.equal('no');
+      });
+    });
+  });
+});

--- a/testutils/server/data.server.testutil.js
+++ b/testutils/server/data.server.testutil.js
@@ -82,7 +82,7 @@ async function clearDatabaseCollections(collections) {
  * The new collections should be added as needed
  * Eventually this list shall become complete
  */
-const collections = ['User', 'Reference'];
+const collections = ['User', 'Reference', 'ReferenceThread'];
 
 /**
  * Clear all collections in a database


### PR DESCRIPTION
#### Proposed Changes

* List latest 500 negative reference threads at admin tool

<img width="1208" alt="Screenshot 2020-12-27 at 17 36 51" src="https://user-images.githubusercontent.com/87168/103174410-8892fe00-486a-11eb-9b93-b2715411ae04.png">


#### Testing Instructions

* Give some positive and negative references to message threads (use https://github.com/Trustroots/trustroots/pull/1978)
* Open `/admin/reference-threads`
* See list of negative ones there
