### PR TITLE
Admin: improved message list

### DIFF
--- a/modules/admin/client/components/AdminMessages.component.js
+++ b/modules/admin/client/components/AdminMessages.component.js
@@ -6,6 +6,7 @@ import { getMessages } from '../api/messages.api';
 import AdminHeader from './AdminHeader.component';
 import Json from './Json.component';
 import UserLink from './UserLink.component';
+import TimeAgo from '@/modules/core/client/components/TimeAgo';
 
 // Mongo ObjectId is always 24 chars long
 const MONGO_OBJECT_ID_LENGTH = 24;
@@ -104,12 +105,19 @@ export default function AdminMessages() {
               return (
                 <div className="panel panel-default" key={_id}>
                   <div className="panel-body">
-                    {message.content}
-                    <br />
-                    <br />
                     <UserLink user={message.userFrom} />
+                    {' · '}
+                    <TimeAgo date={new Date(message.created)} />
+                    {' · '}
+                    {message.read ? 'Seen.' : 'Not seen.'}
+                    <br />
+                    <br />
+                    <div
+                      dangerouslySetInnerHTML={{ __html: message.content }}
+                    />
+                    <br />
                     <details>
-                      <summary>Message details</summary>
+                      <summary>Database entry</summary>
                       <Json content={message} />
                     </details>
                   </div>

--- a/modules/admin/server/controllers/admin.messages.server.controller.js
+++ b/modules/admin/server/controllers/admin.messages.server.controller.js
@@ -36,6 +36,7 @@ exports.getMessages = (req, res) => {
       { userFrom: user2, userTo: user1 },
     ],
   })
+    .sort({ created: 1 })
     .populate({
       path: 'userFrom',
       select: 'username displayName',


### PR DESCRIPTION
#### Proposed Changes

Improve message list for admins:

* Chronological order from oldest to newest
* Just making information more visual:

Before
![image](https://user-images.githubusercontent.com/87168/103224332-2dc3da00-4930-11eb-88d8-84454cfcd95a.png)


After
<img width="1170" alt="Screenshot 2020-12-28 at 17 10 09" src="https://user-images.githubusercontent.com/87168/103224215-0a009400-4930-11eb-9820-602d9dc0202e.png">


#### Testing Instructions

* Open message thread via `/admin/messages`

