### PR TITLE
Profiles: add volunteer badge

### DIFF
--- a/modules/users/client/components/ProfileViewBasics.js
+++ b/modules/users/client/components/ProfileViewBasics.js
@@ -183,6 +183,12 @@ export default function ProfileViewBasics({ profile }) {
 
   return (
     <div>
+      {profile.isVolunteer && (
+        <div className="profile-sidebar-section">
+          ✨ <a href="/team">{t('Trustroots volunteer')}</a>
+        </div>
+      )}
+
       {/* reply rate and reply time */}
       {(profile.replyRate || profile.replyTime) &&
         renderReplyData(profile.replyRate, profile.replyTime)}

--- a/modules/users/client/components/ProfileViewBasics.js
+++ b/modules/users/client/components/ProfileViewBasics.js
@@ -183,9 +183,13 @@ export default function ProfileViewBasics({ profile }) {
 
   return (
     <div>
-      {profile.isVolunteer && (
+      {(profile.isVolunteer || profile.isVolunteerAlumni) && (
         <div className="profile-sidebar-section">
-          ✨ <a href="/team">{t('Trustroots volunteer')}</a>
+          ✨{' '}
+          <a href="/team">
+            {profile.isVolunteer && t('Trustroots volunteer')}
+            {profile.isVolunteerAlumni && t('Trustroots volunteer alumni')}
+          </a>
         </div>
       )}
 

--- a/modules/users/server/controllers/users.profile.server.controller.js
+++ b/modules/users/server/controllers/users.profile.server.controller.js
@@ -868,6 +868,10 @@ exports.sanitizeProfile = function (profile, authenticatedUser) {
     delete profile.usernameUpdated;
   }
 
+  if (profile.roles.includes('volunteer')) {
+    profile.isVolunteer = true;
+  }
+
   // This info totally shouldn't be at the frontend
   //
   // - They're not included on `exports.userProfileFields`,

--- a/modules/users/server/controllers/users.profile.server.controller.js
+++ b/modules/users/server/controllers/users.profile.server.controller.js
@@ -868,7 +868,10 @@ exports.sanitizeProfile = function (profile, authenticatedUser) {
     delete profile.usernameUpdated;
   }
 
-  if (profile.roles.includes('volunteer')) {
+  // Volunteer status
+  if (profile.roles.includes('volunteer-alumni')) {
+    profile.isVolunteerAlumni = true;
+  } else if (profile.roles.includes('volunteer')) {
     profile.isVolunteer = true;
   }
 

--- a/modules/users/tests/server/user-profile.server.routes.tests.js
+++ b/modules/users/tests/server/user-profile.server.routes.tests.js
@@ -297,6 +297,47 @@ describe('User profile CRUD tests', function () {
     });
   });
 
+  it('should be able to see that someone is volunteer-alumni when they have "volunteer-alumni" role', function (done) {
+    user2.roles = ['user', 'volunteer-alumni'];
+
+    user2.save(function (err) {
+      should.not.exist(err);
+      agent
+        .post('/api/auth/signin')
+        .send(credentials)
+        .expect(200)
+        .end(function (signinErr) {
+          should.not.exist(signinErr);
+
+          // Get volunteer-alumni's profile
+          agent
+            .get('/api/users/' + user2.username)
+            .expect(200)
+            .end(function (err, res) {
+              if (err) {
+                return done(err);
+              }
+
+              res.body.isVolunteerAlumni.should.be.true();
+
+              // Get non volunteer-alumni's profile
+              agent
+                .get('/api/users/' + user.username)
+                .expect(200)
+                .end(function (err, res) {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  should.not.exist(res.body.isVolunteerAlumni);
+
+                  return done();
+                });
+            });
+        });
+    });
+  });
+
   it('should not be able to get any user details of confirmed user if not logged in', function (done) {
     // Get own user details
     agent

--- a/modules/users/tests/server/user-profile.server.routes.tests.js
+++ b/modules/users/tests/server/user-profile.server.routes.tests.js
@@ -256,6 +256,47 @@ describe('User profile CRUD tests', function () {
     });
   });
 
+  it('should be able to see that someone is volunteer when they have "volunteer" role', function (done) {
+    user2.roles = ['user', 'volunteer'];
+
+    user2.save(function (err) {
+      should.not.exist(err);
+      agent
+        .post('/api/auth/signin')
+        .send(credentials)
+        .expect(200)
+        .end(function (signinErr) {
+          should.not.exist(signinErr);
+
+          // Get volunteer's profile
+          agent
+            .get('/api/users/' + user2.username)
+            .expect(200)
+            .end(function (err, res) {
+              if (err) {
+                return done(err);
+              }
+
+              res.body.isVolunteer.should.be.true();
+
+              // Get non volunteer's profile
+              agent
+                .get('/api/users/' + user.username)
+                .expect(200)
+                .end(function (err, res) {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  should.not.exist(res.body.isVolunteer);
+
+                  return done();
+                });
+            });
+        });
+    });
+  });
+
   it('should not be able to get any user details of confirmed user if not logged in', function (done) {
     // Get own user details
     agent


### PR DESCRIPTION
Adds simple volunteer or volunteer-alumni badge to profiles:
- Small public "thank you" to our volunteers
- Assures members publicly that person whom they are communicating with really is Trustroots volunteer (important e.g. in support team)

#### Proposed Changes

* Adds simple volunteer badge to profiles for members who have `volunteer` role
* Volunteer alumni get the same
* Links badge to https://www.trustroots.org/team

<img width="326" alt="Screenshot 2020-12-30 at 17 32 28" src="https://user-images.githubusercontent.com/87168/103366126-6e575b00-4aca-11eb-80e3-b2bf38f35899.png">

<img width="326" alt="Screenshot 2020-12-30 at 18 15 59" src="https://user-images.githubusercontent.com/87168/103366446-559b7500-4acb-11eb-8a30-98858b0129a5.png">


#### Testing Instructions

* Add `volunteer` to `roles` array for member
* Open their profile, notice the badge
* Try same with `volunteer-alumni` role