### PR TITLE
Admin reference threads: fix listing when there are deleted users

### DIFF
--- a/modules/admin/client/components/AdminReferenceThreads.component.js
+++ b/modules/admin/client/components/AdminReferenceThreads.component.js
@@ -40,6 +40,9 @@ export default function AdminReferenceThreads() {
         {!isFetching &&
           referenceThreads.length > 0 &&
           referenceThreads.map(({ _id, userFrom, userTo, created }) => {
+            const userToId = userTo?._id ?? userTo;
+            const userFromId = userFrom?._id ?? userFrom;
+
             return (
               <div key={_id} className="panel">
                 <div className="panel-body">
@@ -52,7 +55,7 @@ export default function AdminReferenceThreads() {
                   </p>
                   <p>
                     <a
-                      href={`/admin/messages?userId1=${userTo._id}&userId2=${userFrom._id}`}
+                      href={`/admin/messages?userId1=${userToId}&userId2=${userFromId}`}
                     >
                       See message thread
                     </a>


### PR DESCRIPTION
#### Proposed Changes

* Fix in admin tool for reference threads in cases when user is deleted

<img width="753" alt="Screenshot 2021-01-03 at 19 08 36" src="https://user-images.githubusercontent.com/87168/103484902-fd31e380-4dfa-11eb-96ea-02700d8c6150.png">


#### Testing Instructions

* Have a reference thread
* Delete user or change IDs
* Load `/admin/reference-threads`

**Before**
![image](https://user-images.githubusercontent.com/87168/103484922-1d61a280-4dfb-11eb-99f8-3cecff71c3ce.png)



**After**

<img width="753" alt="Screenshot 2021-01-03 at 19 08 36" src="https://user-images.githubusercontent.com/87168/103484924-218dc000-4dfb-11eb-8356-6093ef2baf46.png">
