### PR TITLE
Experiences: update copy for "no references"

### DIFF
--- a/modules/core/client/components/NoContent.js
+++ b/modules/core/client/components/NoContent.js
@@ -1,16 +1,18 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-export default function NoContent({ icon, message }) {
+export default function NoContent({ children = null, icon, message }) {
   return (
     <div className="row content-empty">
       {icon && <i className={`icon-3x icon-${icon}`}></i>}
       <h4>{message}</h4>
+      {children}
     </div>
   );
 }
 
 NoContent.propTypes = {
+  children: PropTypes.node,
   icon: PropTypes.string,
   message: PropTypes.string.isRequired,
 };

--- a/modules/references/client/components/ListExperiences.component.js
+++ b/modules/references/client/components/ListExperiences.component.js
@@ -8,6 +8,7 @@ import { read as readExperiences } from '../api/references.api';
 import LoadingIndicator from '@/modules/core/client/components/LoadingIndicator';
 import ExperienceCounts from './read-experiences/ExperienceCounts';
 import ExperiencesSection from './read-experiences/ExperiencesSection';
+import NoContent from '@/modules/core/client/components/NoContent';
 
 /**
  * List of user's experiences
@@ -56,15 +57,19 @@ export default function ListExperiences({ profile, authenticatedUser }) {
   // No experiences
   if (!hasPendingExperiences && !hasPublicExperiences) {
     return (
-      <div className="row content-empty">
-        <i className="icon-3x icon-users"></i>
-        <h4>{t('No references yet.')}</h4>
+      <NoContent icon="users" message={t('No experiences yet.')}>
         {authenticatedUser._id !== profile._id && (
-          <a href={`/profile/${profile.username}/experiences/new`}>
-            {t('Write one!')}
-          </a>
+          <p>
+            <br />
+            <a
+              className="btn btn-primary"
+              href={`/profile/${profile.username}/experiences/new`}
+            >
+              {t('Share your experience')}
+            </a>
+          </p>
         )}
-      </div>
+      </NoContent>
     );
   }
 


### PR DESCRIPTION

#### Proposed Changes

* Change copy from "references" to "experiences" for "no experiences found" message
* Re-use EmptyContent component for it
* Change the link's appearance to be "primary" call to action

#### Testing Instructions

* Open profile without experiences 

**Before**

![image](https://user-images.githubusercontent.com/87168/103485095-97465b80-4dfc-11eb-912e-7fc95a21717a.png)


**After**

<img width="737" alt="Screenshot 2021-01-03 at 19 42 54" src="https://user-images.githubusercontent.com/87168/103485070-66662680-4dfc-11eb-8745-310317046979.png">
