### PR TITLE
Build: add bundle analyzer

### DIFF
--- a/config/env/default.js
+++ b/config/env/default.js
@@ -238,4 +238,12 @@ module.exports = {
       dsn: '',
     },
   },
+  // Webpack bundle analyzer
+  // Visualize size of webpack output files with an interactive zoomable treemap.
+  // https://www.npmjs.com/package/webpack-bundle-analyzer
+  bundleAnalyzer: {
+    enabled: false,
+    // See https://github.com/webpack-contrib/webpack-bundle-analyzer#options-for-plugin
+    options: {},
+  },
 };

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -1,3 +1,5 @@
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
+  .BundleAnalyzerPlugin;
 const webpack = require('webpack');
 const webpackMerge = require('webpack-merge');
 const compact = require('lodash/compact');
@@ -148,6 +150,8 @@ module.exports = webpackMerge.merge(shims, {
     ],
   },
   plugins: compact([
+    config.bundleAnalyzer.enabled &&
+      new BundleAnalyzerPlugin(config.bundleAnalyzer.options),
     isProduction &&
       new MiniCssExtractPlugin({
         filename: 'main.css',

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -116,6 +116,20 @@ More information can be found in the NodeJS [debug documentation](https://nodejs
 - `npm run test:server`
 - `npm run test:server:watch` (run + watch for changes)
 
+## Analyzing bundles
+
+You can what goes into the "bundle" that [Webpack](https://webpack.js.org/) compiles from all the JS, style and image assets by adding this to your `config/env/local/js`:
+
+```js
+bundleAnalyzer: {
+  enabled: true,
+  // See https://github.com/webpack-contrib/webpack-bundle-analyzer#options-for-plugin
+  options: {},
+},
+```
+
+Now when you start the application, [bundle analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer#readme) will automatically open new browser tab at `http://127.0.0.1:8888/` that shows you information about the bundle.
+
 ## Coding styles
 
 We apply [Eslint](https://eslint.org/) rules to our JavaScript files and automatically format them using [Prettier](https://prettier.io/). You should install [Eslint editor integration](https://eslint.org/docs/user-guide/integrations#editors) as well [Prettier editor integration](https://prettier.io/docs/en/editors.html) to notice code formatting errors and let the editor autoformat files for you automatically.

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -118,7 +118,7 @@ More information can be found in the NodeJS [debug documentation](https://nodejs
 
 ## Analyzing bundles
 
-You can what goes into the "bundle" that [Webpack](https://webpack.js.org/) compiles from all the JS, style and image assets by adding this to your `config/env/local/js`:
+You can see what goes into the "bundle" that [Webpack](https://webpack.js.org/) compiles from all the JS, style and image assets by adding this to your `config/env/local/js`:
 
 ```js
 bundleAnalyzer: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4663,6 +4663,12 @@
         }
       }
     },
+    "@polka/url": {
+      "version": "1.0.0-next.11",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.11.tgz",
+      "integrity": "sha512-3NsZsJIA/22P3QUyrEDNA2D133H4j224twJrdipXN38dpnIOzAbUDtOwkcJ5pXmn75w7LSQDjA4tO9dm1XlqlA==",
+      "dev": true
+    },
     "@sentry/browser": {
       "version": "5.29.2",
       "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.29.2.tgz",
@@ -10595,6 +10601,12 @@
       "version": "2.1.0-0",
       "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
       "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
+    },
+    "duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -16894,6 +16906,15 @@
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
       "requires": {
         "glogg": "^1.0.0"
+      }
+    },
+    "gzip-size": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+      "dev": true,
+      "requires": {
+        "duplexer": "^0.1.2"
       }
     },
     "hammerjs": {
@@ -26721,6 +26742,12 @@
       "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
       "dev": true
     },
+    "opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true
+    },
     "opn": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/opn/-/opn-6.0.0.tgz",
@@ -29844,6 +29871,25 @@
         }
       }
     },
+    "sirv": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.10.tgz",
+      "integrity": "sha512-H5EZCoZaggEUQy8ocKsF7WAToGuZhjJlLvM3XOef46CbdIgbNeQ1p32N1PCuCjkVYwrAVOSMacN6CXXgIzuspg==",
+      "dev": true,
+      "requires": {
+        "@polka/url": "^1.0.0-next.9",
+        "mime": "^2.3.1",
+        "totalist": "^1.0.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.4.7",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.7.tgz",
+          "integrity": "sha512-dhNd1uA2u397uQk3Nv5LM4lm93WYDUXFn3Fu291FJerns4jyTudqhIWe4W04YLy7Uk1tm1Ore04NpjRvQp/NPA==",
+          "dev": true
+        }
+      }
+    },
     "sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -31697,6 +31743,12 @@
         }
       }
     },
+    "totalist": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-1.1.0.tgz",
+      "integrity": "sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==",
+      "dev": true
+    },
     "touch": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
@@ -33064,6 +33116,49 @@
           "requires": {
             "minimist": "^1.2.5"
           }
+        }
+      }
+    },
+    "webpack-bundle-analyzer": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.3.0.tgz",
+      "integrity": "sha512-J3TPm54bPARx6QG8z4cKBszahnUglcv70+N+8gUqv2I5KOFHJbzBiLx+pAp606so0X004fxM7hqRu10MLjJifA==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "chalk": "^4.1.0",
+        "commander": "^6.2.0",
+        "gzip-size": "^6.0.0",
+        "lodash": "^4.17.20",
+        "opener": "^1.5.2",
+        "sirv": "^1.0.7",
+        "ws": "^7.3.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.0.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.4.tgz",
+          "integrity": "sha512-XNP0PqF1XD19ZlLKvB7cMmnZswW4C/03pRHgirB30uSJTaS3A3V1/P4sS3HPvFmjoriPCJQs+JDSbm4bL1TxGQ==",
+          "dev": true
+        },
+        "acorn-walk": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.0.0.tgz",
+          "integrity": "sha512-oZRad/3SMOI/pxbbmqyurIx7jHw1wZDcR9G44L8pUVFEomX/0dH89SrM1KaDXuv1NpzAXz6Op/Xu/Qd5XXzdEA==",
+          "dev": true
+        },
+        "commander": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+          "dev": true
+        },
+        "ws": {
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
+          "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -254,6 +254,7 @@
     "supertest": "4.0.2",
     "url-loader": "4.1.1",
     "webpack": "4.44.2",
+    "webpack-bundle-analyzer": "4.3.0",
     "webpack-cli": "4.3.1",
     "webpack-dev-server": "3.11.1",
     "webpack-merge": "5.7.3",


### PR DESCRIPTION
I've found a need for this a couple times already, so figured we might as well have it pre-configured for ease of use.

#### Proposed Changes

* Adds Webpack bundle analyzer (disabled by default)

#### Testing Instructions

* Add config to your `config/env/local.js` and run `npm start`
* You should get browser tab at http://127.0.0.1:8888/ with:

![image](https://user-images.githubusercontent.com/87168/103486707-6b30d780-4e08-11eb-8f1b-96dcac45d1d1.png)
