### PR TITLE
Writing "response" experience with limited choice after the "initial" experience went public

### DIFF
--- a/modules/references/client/api/references.api.js
+++ b/modules/references/client/api/references.api.js
@@ -28,13 +28,19 @@ export async function read({ userTo }) {
 }
 
 /**
- * API request: read the experience shared by the logged-in user with `userTo`
+ * API request: read the experience shared
+ * - by the logged-in user with `userTo`
+ * and
+ * - by the `userTo` with the logged-in user
  *
- * @param {string} userTo - id of the user with whom the experience was shared
- * @returns {object} - experience object, which includes the "response" to it if exists
+ * @param {string} userWith - id of the user with whom the experience was shared
+ * @returns {object} - experience object, where both experiences are returned
+ * in an experience object with response. The `response` field is `null` if only
+ * one party shared the experience, otherwise the "primary" experience is the one
+ * shared by the logged-in user.
  */
-export async function readMine({ userTo }) {
-  const params = { userTo };
+export async function readMine({ userWith }) {
+  const params = { userWith };
   try {
     const { data: experience } = await axios.get('/api/my-experience', {
       params,

--- a/modules/references/client/components/CreateExperience.component.js
+++ b/modules/references/client/components/CreateExperience.component.js
@@ -125,9 +125,17 @@ export default function CreateExperience({ userFrom, userTo }) {
   );
 
   let tabs = [
-    { title: t('How do you know them'), component: interactionsTab },
-    { title: t('Recommendation'), component: recommendationTab },
-    { title: t('Feedback'), component: feedbackTab },
+    {
+      id: 'interactions',
+      title: t('How do you know them'),
+      component: interactionsTab,
+    },
+    {
+      id: 'recommendation',
+      title: t('Recommendation'),
+      component: recommendationTab,
+    },
+    { id: 'feedback', title: t('Feedback'), component: feedbackTab },
   ];
 
   if (!sharedOnTime) {
@@ -191,9 +199,9 @@ export default function CreateExperience({ userFrom, userTo }) {
         onSelect={() => {}}
         id="create-reference-tabs"
       >
-        {tabs.map(({ component, title }, i) => {
+        {tabs.map(({ id, component, title }, i) => {
           return (
-            <Tab eventKey={i} key={`${i}`} title={title} disabled>
+            <Tab eventKey={i} key={id} title={title} disabled>
               {component}
             </Tab>
           );

--- a/modules/references/client/components/CreateExperience.component.js
+++ b/modules/references/client/components/CreateExperience.component.js
@@ -32,15 +32,21 @@ export default function CreateExperience({ userFrom, userTo }) {
   const [isDuplicate, setIsDuplicate] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [isPublic, setIsPublic] = useState(false);
+  const [sharedOnTime, setSharedOnTime] = useState(true);
 
   useEffect(() => {
     (async () => {
       const experience = await api.references.readMine({
-        userTo: userTo._id,
+        userWith: userTo._id,
       });
-
-      if (experience !== null) {
-        setIsDuplicate(true);
+      if (experience) {
+        if (experience.userFrom === userFrom._id || !!experience.response) {
+          setIsDuplicate(true);
+        } else {
+          setIsDuplicate(false);
+          setSharedOnTime(!experience.public);
+          setRecommend('yes');
+        }
       }
 
       setIsLoading(false);
@@ -87,12 +93,15 @@ export default function CreateExperience({ userFrom, userTo }) {
   const primaryInteraction =
     (hostedMe && 'hostedMe') || (hostedThem && 'hostedThem') || 'met';
 
-  const tabs = [
+  const interactionsTab = (
     <Interaction
       key="interaction"
       interactions={{ hostedMe, hostedThem, met }}
       onChange={handleChangeInteraction}
-    />,
+    />
+  );
+
+  const recommendationTab = (
     <Recommend
       key="recommend"
       primaryInteraction={primaryInteraction}
@@ -102,15 +111,28 @@ export default function CreateExperience({ userFrom, userTo }) {
       onChangeRecommend={recommend => setRecommend(recommend)}
       onChangeReport={() => setReport(report => !report)}
       onChangeReportMessage={message => setReportMessage(message)}
-    />,
+    />
+  );
+
+  const feedbackTab = (
     <Feedback
       key="feedback"
       feedback={feedbackPublic}
       recommend={recommend}
       report={report}
       onChangeFeedback={setFeedbackPublic}
-    />,
+    />
+  );
+
+  let tabs = [
+    { title: t('How do you know them'), component: interactionsTab },
+    { title: t('Recommendation'), component: recommendationTab },
+    { title: t('Feedback'), component: feedbackTab },
   ];
+
+  if (!sharedOnTime) {
+    tabs = tabs.filter(elm => elm.component !== recommendationTab);
+  }
 
   // find out whether the current tab is valid, and whether we can continue
   // we'd prefer to create validator outside the render function,
@@ -169,15 +191,13 @@ export default function CreateExperience({ userFrom, userTo }) {
         onSelect={() => {}}
         id="create-reference-tabs"
       >
-        <Tab eventKey={0} title={t('How do you know them')} disabled>
-          {tabs[0]}
-        </Tab>
-        <Tab eventKey={1} title={t('Recommendation')} disabled>
-          {tabs[1]}
-        </Tab>
-        <Tab eventKey={2} title={t('Feedback')} disabled>
-          {tabs[2]}
-        </Tab>
+        {tabs.map(({ component, title }, i) => {
+          return (
+            <Tab eventKey={i} key={`${i}`} title={title} disabled>
+              {component}
+            </Tab>
+          );
+        })}
       </Tabs>
       <StepNavigation
         currentStep={step}

--- a/modules/references/client/components/CreateExperience.component.js
+++ b/modules/references/client/components/CreateExperience.component.js
@@ -164,8 +164,9 @@ export default function CreateExperience({ userFrom, userTo }) {
   // can we continue?
   const isNextStepDisabled = isSubmitting || currentStepErrors.length > 0;
   // if not, why?
-  const nextStepError =
-    !isSubmitting && currentStepErrors.find(error => error.trim().length > 0);
+  const nextStepError = isSubmitting
+    ? ''
+    : currentStepErrors.find(error => error.trim().length > 0);
 
   if (userFrom._id === userTo._id) {
     return <ExperienceWithSelfInfo />;

--- a/modules/references/tests/client/components/CreateExperience.client.component.tests.js
+++ b/modules/references/tests/client/components/CreateExperience.client.component.tests.js
@@ -48,12 +48,16 @@ describe('<CreateExperience />', () => {
     api.references.readMine.mockResolvedValueOnce([]);
     render(<CreateExperience userFrom={userFrom} userTo={userTo} />);
     expect(api.references.readMine).toBeCalledWith({
-      userTo: userTo._id,
+      userWith: userTo._id,
     });
   });
 
-  it('can not leave a second reference', async () => {
-    api.references.readMine.mockResolvedValueOnce([{ userTo, public: false }]);
+  it('can not leave a second reference - without response', async () => {
+    api.references.readMine.mockResolvedValueOnce({
+      userFrom: userFrom._id,
+      public: false,
+      response: null,
+    });
     const { queryByRole } = render(
       <CreateExperience userFrom={userFrom} userTo={userTo} />,
     );
@@ -62,7 +66,25 @@ describe('<CreateExperience />', () => {
       `You already shared your experience with them`,
     );
     expect(api.references.readMine).toBeCalledWith({
-      userTo: userTo._id,
+      userWith: userTo._id,
+    });
+  });
+
+  it('can not leave a second reference - with response', async () => {
+    api.references.readMine.mockResolvedValueOnce({
+      userFrom: userTo._id,
+      public: true,
+      response: 'mocked response',
+    });
+    const { queryByRole } = render(
+      <CreateExperience userFrom={userFrom} userTo={userTo} />,
+    );
+    await waitForLoader();
+    expect(queryByRole('heading')).toHaveTextContent(
+      `You already shared your experience with them`,
+    );
+    expect(api.references.readMine).toBeCalledWith({
+      userWith: userTo._id,
     });
   });
 


### PR DESCRIPTION
#### Proposed Changes

Writing "response" experience with limited choice after the "initial" experience went public. 

Initial draft implementation: the tab where the recommendation can be chosen is not shown at all. Probably we don't want to do it like that, we should still give a possibility to report a person? Also, we should let the user know that the recommendation is "yes". (If we decide to keep recommendations)

- [x] disable tab on UI if the initial experience is public
- [x] change the `/api/my-experiences` endpoint to always return both A->B and B->A experiences if available
- [x] server-side validation had already been implemented.

#### Testing Instructions

* Log in as A; share experience with B; find the experience in the DB and change the `public` field to 'true'; log in as B and share experience with A; notice that you are not allowed to choose recommendation; look at the profile of A and notice that the left experience has `recommended` label
* Make sure experience cannot be shared twice with the same person

WIP #1493 


https://user-images.githubusercontent.com/2955794/104788013-6d445000-5791-11eb-9d2e-5cb9bca82177.mov


