### PR TITLE
Add prompt to share response under public experiences on the logged-in user's page

### DIFF
--- a/modules/references/client/components/ListExperiences.component.js
+++ b/modules/references/client/components/ListExperiences.component.js
@@ -54,11 +54,13 @@ export default function ListExperiences({ profile, authenticatedUser }) {
   const hasPublicExperiences = publicExperiences.length > 0;
   const hasPendingExperiences = pendingExperiences.length > 0;
 
+  const onReceiverProfile = authenticatedUser._id === profile._id;
+
   // No experiences
   if (!hasPendingExperiences && !hasPublicExperiences) {
     return (
       <NoContent icon="users" message={t('No experiences yet.')}>
-        {authenticatedUser._id !== profile._id && (
+        {!onReceiverProfile && (
           <p>
             <br />
             <a
@@ -82,6 +84,7 @@ export default function ListExperiences({ profile, authenticatedUser }) {
         <ExperiencesSection
           title={t('Experiences pending publishing')}
           experiences={pendingExperiences}
+          onReceiverProfile={onReceiverProfile}
         />
       )}
       {hasPublicExperiences && (
@@ -89,6 +92,7 @@ export default function ListExperiences({ profile, authenticatedUser }) {
           // Show "Public" title only if there are also pending experiences listed
           title={hasPendingExperiences && t('Public experiences')}
           experiences={publicExperiences}
+          onReceiverProfile={onReceiverProfile}
         />
       )}
     </>

--- a/modules/references/client/components/read-experiences/Experience.js
+++ b/modules/references/client/components/read-experiences/Experience.js
@@ -164,13 +164,6 @@ export default function Experience({ experience, onReceiverProfile }) {
             )}
           </Response>
         )}
-        {!response && isPublicExperience && onReceiverProfile && (
-          <Response>
-            <a href={`/profile/${userFrom.username}/experiences/new`}>
-              {t('Share experience also with them.')}
-            </a>
-          </Response>
-        )}
         {!isPublicExperience && feedbackPublic !== undefined && (
           <>
             <PendingNotice>
@@ -182,6 +175,16 @@ export default function Experience({ experience, onReceiverProfile }) {
           </>
         )}
       </div>
+      {!response && isPublicExperience && onReceiverProfile && (
+        <div className="panel-footer text-right">
+          <a
+            href={`/profile/${userFrom.username}/experiences/new`}
+            className="btn btn-default"
+          >
+            {t('Write about your experience')}
+          </a>
+        </div>
+      )}
     </div>
   );
 }

--- a/modules/references/client/components/read-experiences/Experience.js
+++ b/modules/references/client/components/read-experiences/Experience.js
@@ -164,7 +164,7 @@ export default function Experience({ experience, onReceiverProfile }) {
             )}
           </Response>
         )}
-        {!response && onReceiverProfile && (
+        {!response && isPublicExperience && onReceiverProfile && (
           <Response>
             <a href={`/profile/${userFrom.username}/experiences/new`}>
               {t('Share experience also with them.')}

--- a/modules/references/client/components/read-experiences/Experience.js
+++ b/modules/references/client/components/read-experiences/Experience.js
@@ -2,6 +2,7 @@
 import { useTranslation } from 'react-i18next';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 // Internal dependencies
@@ -72,7 +73,7 @@ const UserLinkStyled = styled(UserLink)`
   margin-right: 5px;
 `;
 
-export default function Experience({ experience }) {
+export default function Experience({ experience, onReceiverProfile }) {
   const { t } = useTranslation('references');
 
   const {
@@ -97,6 +98,7 @@ export default function Experience({ experience }) {
         Math.round((Date.now() - date.getTime()) / 3600 / 24 / 1000),
     );
 
+  // TODO use `onReceiverProfile` in conditions below instead of `feedbackPublic === undefined`
   return (
     <div className="panel panel-default" id={_id}>
       <div className="panel-body">
@@ -162,6 +164,13 @@ export default function Experience({ experience }) {
             )}
           </Response>
         )}
+        {!response && onReceiverProfile && (
+          <Response>
+            <a href={`/profile/${userFrom.username}/experiences/new`}>
+              {t('Share experience also with them.')}
+            </a>
+          </Response>
+        )}
         {!isPublicExperience && feedbackPublic !== undefined && (
           <>
             <PendingNotice>
@@ -179,4 +188,5 @@ export default function Experience({ experience }) {
 
 Experience.propTypes = {
   experience: experienceType.isRequired,
+  onReceiverProfile: PropTypes.bool.isRequired,
 };

--- a/modules/references/client/components/read-experiences/ExperiencesSection.js
+++ b/modules/references/client/components/read-experiences/ExperiencesSection.js
@@ -9,7 +9,11 @@ import { experienceType } from '@/modules/references/client/experiences.prop-typ
 /**
  * List of user's experiences
  */
-export default function ExperiencesSection({ title, experiences }) {
+export default function ExperiencesSection({
+  title,
+  experiences,
+  onReceiverProfile,
+}) {
   return (
     <section>
       {title && (
@@ -22,7 +26,10 @@ export default function ExperiencesSection({ title, experiences }) {
       {experiences.map(experience => (
         <div className="row" key={experience._id}>
           <div className="col-xs-12">
-            <Experience experience={experience} />
+            <Experience
+              experience={experience}
+              onReceiverProfile={onReceiverProfile}
+            />
           </div>
         </div>
       ))}
@@ -33,4 +40,5 @@ export default function ExperiencesSection({ title, experiences }) {
 ExperiencesSection.propTypes = {
   experiences: PropTypes.arrayOf(experienceType).isRequired,
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+  onReceiverProfile: PropTypes.bool.isRequired,
 };


### PR DESCRIPTION

#### Proposed Changes

Add prompt to share responses under public experiences on the logged-in user's page.

<image src="https://user-images.githubusercontent.com/2955794/104791025-7b966a00-5799-11eb-9a66-3617eccbd53d.png" width=500/>

Didn't put much thought into the design, so implemented the easiest option. 

#### Testing Instructions

- Go to my profile -> experiences. Check that there is a link "Share experience also with them." below public experiences to which the logged-in user hasn't yet shared a response. Click the link and check that it goes to the experience sharing page with the user who shared the initial experience.

- Go to someone else's profile make sure that the link is not present below the public experiences with no response



WIP #1493 
