### PR TITLE
Update links to instagram page: https://instagram.com/trustroots_org -> https://instagram.com/trustroots

### DIFF
--- a/modules/core/server/views/email-templates-text/partials/socialmedia.server.view.html
+++ b/modules/core/server/views/email-templates-text/partials/socialmedia.server.view.html
@@ -7,4 +7,4 @@ Follow us on social media — it would really help us out!
 - Facebook page: https://www.facebook.com/trustroots.org
 - Facebook group: https://www.facebook.com/groups/trustroots/
 - https://twitter.com/trustroots
-- https://www.instagram.com/trustroots_org/
+- https://www.instagram.com/trustroots/

--- a/modules/core/server/views/email-templates/partials/socialmedia.server.view.html
+++ b/modules/core/server/views/email-templates/partials/socialmedia.server.view.html
@@ -7,6 +7,6 @@
   Like our <a href="https://www.facebook.com/trustroots.org/?ref=welcome-email">Facebook page</a>,
   join our <a href="https://www.facebook.com/groups/trustroots/?ref=welcome-email">Facebook group</a>
   and follow us on <a href="https://twitter.com/trustroots">Twitter</a>
-  or <a href="https://www.instagram.com/trustroots_org/">Instagram</a>
+  or <a href="https://www.instagram.com/trustroots/">Instagram</a>
   — it would really help us out!
 </p>

--- a/modules/core/server/views/partials/footer.server.view.html
+++ b/modules/core/server/views/partials/footer.server.view.html
@@ -48,7 +48,7 @@
         </li>
         <li>
           <a
-            href="https://www.instagram.com/trustroots_org/"
+            href="https://www.instagram.com/trustroots/"
             uib-tooltip="Instagram"
             aria-label="Trustroots at Instagram"
           >

--- a/modules/core/server/views/partials/header.server.view.html
+++ b/modules/core/server/views/partials/header.server.view.html
@@ -247,7 +247,7 @@
               </li>
               <li>
                 <a
-                  href="https://www.instagram.com/trustroots_org/"
+                  href="https://www.instagram.com/trustroots/"
                   class="text-muted"
                   aria-label="Trustroots at Instagram"
                 >

--- a/modules/pages/client/components/Home.component.js
+++ b/modules/pages/client/components/Home.component.js
@@ -440,7 +440,7 @@ export default function Home({ user, isNativeMobileApp, photoCredits }) {
               <li>
                 <Tooltip id="instagram-tooltip" tooltip="Instagram">
                   <a
-                    href="https://www.instagram.com/trustroots_org/"
+                    href="https://www.instagram.com/trustroots/"
                     aria-label={t('Trustroots at Instagram')}
                   >
                     <i className="icon-instagram icon-lg"></i>

--- a/modules/pages/client/components/Navigation.component.js
+++ b/modules/pages/client/components/Navigation.component.js
@@ -177,7 +177,7 @@ export default function Navigation({ user, onSignout, isNativeMobileApp }) {
           <li>
             <p>
               <a
-                href="https://www.instagram.com/trustroots_org/"
+                href="https://www.instagram.com/trustroots/"
                 className="btn btn-default center-block"
                 aria-label="{t('Trustroots at Instagram')}"
               >

--- a/modules/pages/client/components/Team.component.js
+++ b/modules/pages/client/components/Team.component.js
@@ -184,7 +184,7 @@ export default function Team({ user }) {
                 {t('Facebook group')}
               </a>
               <a
-                href="https://www.instagram.com/trustroots_org/"
+                href="https://www.instagram.com/trustroots/"
                 className="btn btn-link btn-lg"
               >
                 Twitter


### PR DESCRIPTION
#### Testing Instructions

Browse around the website; all links to Instagram should point to https://instagram.com/trustroots now
