### PR TITLE
Mobile navigation: add "find people"

### DIFF
--- a/modules/pages/client/components/Navigation.component.js
+++ b/modules/pages/client/components/Navigation.component.js
@@ -40,6 +40,10 @@ export default function Navigation({ user, onSignout, isNativeMobileApp }) {
           {t('Contacts')}
         </a>
 
+        <a href="/search/members" className="list-group-item">
+          {t('Find people')}
+        </a>
+
         <a href="/circles" className="list-group-item">
           {t('Circles')}
         </a>


### PR DESCRIPTION
#### Proposed Changes

* Add "Find people" to mobile navigation. It was already on desktop menu but missing from mobile version.

<img width="440" alt="Screenshot 2021-01-24 at 19 17 32" src="https://user-images.githubusercontent.com/87168/105638112-a0659e00-5e79-11eb-92ce-2599ec1fce52.png">


#### Testing Instructions

* Open navigation on mobile screen

Resolves 
https://github.com/Trustroots/trustroots/issues/1819


There's not much to review/test here so I'll merge on CI passing green.