### PR TITLE
Circle page: fix bug of linking to signup form without circle slug

### DIFF
--- a/modules/tribes/client/views/tribe.client.view.html
+++ b/modules/tribes/client/views/tribe.client.view.html
@@ -139,7 +139,7 @@
               <br /><br />
               <a
                 class="btn btn-lg btn-primary btn-action tribe-join"
-                ui-sref="signup({'circle': tribeCtrl.tribe.slug})"
+                ui-sref="signup({'tribe': tribeCtrl.tribe.slug})"
               >
                 Join {{::tribeCtrl.tribe.label}} on Trustroots
               </a>


### PR DESCRIPTION
#### Proposed Changes

* Fix circle page's signup button not passing circle slug to signup form. It was renamed to "circle" but signup route doesn't support that param yet, so let's keep it at `tribe` for now and fix separately. Found while working on https://github.com/Trustroots/trustroots/pull/2086

#### Testing Instructions

* Open circle as unlogged
* Click signup, confirm that circle slug gets carried over


This one is so simple that I'll just go ahead and get it live.