### PR TITLE
Upgrade MongoDB engine to 4.4, aligning it to the docker image

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "engines": {
     "node": ">=10.0.0",
     "npm": ">=6.0.0",
-    "mongodb": ">=3.6 <=4.2"
+    "mongodb": ">=3.6 <=4.4"
   },
   "browserslist": [
     "extends @wordpress/browserslist-config"


### PR DESCRIPTION
#### Proposed Changes

I had some problems in making working locally the dockerized version, realised that it was due to a misalignment between `package.json` and `docker-compose.yml`, and then found this conversation: https://trustroots.slack.com/archives/C0A3Q15SS/p1610276209013800?thread_ts=1610274347.012200&cid=C0A3Q15SS

![Screenshot 2021-02-14 at 00 17 15](https://user-images.githubusercontent.com/4105325/107864624-6840f200-6e5e-11eb-83cf-c9ee6964a75e.png)