### PR TITLE
Experiences: add question mark to question

### DIFF
--- a/modules/experiences/client/components/CreateExperience.component.js
+++ b/modules/experiences/client/components/CreateExperience.component.js
@@ -124,7 +124,7 @@ export default function CreateExperience({ userFrom, userTo }) {
   let tabs = [
     {
       id: 'interactions',
-      title: t('How do you know them'),
+      title: t('How do you know them?'),
       component: interactionsTab,
     },
     {

--- a/modules/experiences/tests/client/components/CreateExperience.client.component.tests.js
+++ b/modules/experiences/tests/client/components/CreateExperience.client.component.tests.js
@@ -111,7 +111,7 @@ describe('<CreateExperience />', () => {
 
     await waitForLoader();
 
-    expect(queryByLabelText('How do you know them?')).toBeInTheDocument();
+    expect(getAllByText('How do you know them?')[1]).toBeInTheDocument();
     fireEvent.click(getByLabelText('They hosted me'));
 
     fireEvent.click(getAllByText('Next')[0]);
@@ -169,7 +169,7 @@ describe('<CreateExperience />', () => {
 
     await waitForLoader();
 
-    expect(queryByLabelText('How do you know them?')).toBeInTheDocument();
+    expect(getAllByText('How do you know them?')[1]).toBeInTheDocument();
     fireEvent.click(getByLabelText('They hosted me'));
 
     fireEvent.click(getAllByText('Next')[0]);


### PR DESCRIPTION
The same sentence is already being translated with a question mark here: 

https://github.com/Trustroots/trustroots/blob/d146c16f6547a5e3397ca4cc7fb164d28f8482fe/modules/experiences/client/components/create-experience/Interaction.js#L15

<img width="936" alt="Screenshot 2021-03-07 at 02 21 15" src="https://user-images.githubusercontent.com/87168/110225211-d459c780-7eeb-11eb-87a8-b3d1288f4763.png">

#### Proposed Changes

* Add a question mark to the tab when adding new experience

#### Testing Instructions

* Add experience to someone and see the tabs