### PR TITLE
Rename hostedMe/hostedThem to guest/host

### DIFF
--- a/bin/fillTestData/Experiences.js
+++ b/bin/fillTestData/Experiences.js
@@ -101,8 +101,8 @@ const profileType = {
 const experienceGenerator = {
   interactions: (to, from) => ({
     met: true,
-    hostedMe: to < from,
-    hostedThem: from < to,
+    guest: to < from,
+    host: from < to,
   }),
 
   recommendation: () => {

--- a/modules/experiences/client/components/CreateExperience.component.js
+++ b/modules/experiences/client/components/CreateExperience.component.js
@@ -18,8 +18,8 @@ export default function CreateExperience({ userFrom, userTo }) {
   const { t } = useTranslation('experiences');
 
   const [met, setMet] = useState(false);
-  const [hostedThem, setHostedThem] = useState(false);
-  const [hostedMe, setHostedMe] = useState(false);
+  const [host, setHostedThem] = useState(false);
+  const [guest, setHostedMe] = useState(false);
   const [recommend, setRecommend] = useState(null);
   const [report, setReport] = useState(false);
   const [reportMessage, setReportMessage] = useState('');
@@ -56,11 +56,11 @@ export default function CreateExperience({ userFrom, userTo }) {
       case 'met':
         setMet(met => !met);
         break;
-      case 'hostedThem':
-        setHostedThem(hostedThem => !hostedThem);
+      case 'host':
+        setHostedThem(host => !host);
         break;
-      case 'hostedMe':
-        setHostedMe(hostedMe => !hostedMe);
+      case 'guest':
+        setHostedMe(guest => !guest);
         break;
       default:
     }
@@ -70,7 +70,7 @@ export default function CreateExperience({ userFrom, userTo }) {
     setIsSubmitting(true);
 
     const experience = {
-      interactions: { met, hostedThem, hostedMe },
+      interactions: { met, host, guest },
       recommend,
       feedbackPublic,
     };
@@ -88,13 +88,12 @@ export default function CreateExperience({ userFrom, userTo }) {
     setIsPublic(savedExperience.public);
   };
 
-  const primaryInteraction =
-    (hostedMe && 'hostedMe') || (hostedThem && 'hostedThem') || 'met';
+  const primaryInteraction = (guest && 'guest') || (host && 'host') || 'met';
 
   const interactionsTab = (
     <Interaction
       key="interaction"
-      interactions={{ hostedMe, hostedThem, met }}
+      interactions={{ guest, host, met }}
       onChange={handleChangeInteraction}
     />
   );
@@ -146,14 +145,14 @@ export default function CreateExperience({ userFrom, userTo }) {
   const validate = createValidator({
     interaction: [
       [
-        ({ hostedMe, hostedThem, met }) => hostedMe || hostedThem || met,
+        ({ guest, host, met }) => guest || host || met,
         t('Choose your interaction'),
       ],
     ],
     recommend: [[value => !!value, t('Choose your recommendation')]],
   });
   const errorDict = validate({
-    interaction: { hostedMe, hostedThem, met },
+    interaction: { guest, host, met },
     recommend,
   });
   // map errors to tabs and find errors relevant for current tab

--- a/modules/experiences/client/components/create-experience/Interaction.js
+++ b/modules/experiences/client/components/create-experience/Interaction.js
@@ -30,8 +30,8 @@ export default function Interaction({ interactions, onChange }) {
             <label>
               <input
                 type="checkbox"
-                checked={interactions.hostedThem}
-                onChange={() => onChange('hostedThem')}
+                checked={interactions.host}
+                onChange={() => onChange('host')}
               />
               {t('I hosted them')}
             </label>
@@ -40,8 +40,8 @@ export default function Interaction({ interactions, onChange }) {
             <label>
               <input
                 type="checkbox"
-                checked={interactions.hostedMe}
-                onChange={() => onChange('hostedMe')}
+                checked={interactions.guest}
+                onChange={() => onChange('guest')}
               />
               {t('They hosted me')}
             </label>

--- a/modules/experiences/client/components/create-experience/Recommend.js
+++ b/modules/experiences/client/components/create-experience/Recommend.js
@@ -25,8 +25,8 @@ export default function Recommend({
   const { t } = useTranslation('experiences');
 
   const recommendQuestions = {
-    hostedMe: t('Would you recommend others to stay with them?'),
-    hostedThem: t('Would you recommend others to host them?'),
+    guest: t('Would you recommend others to stay with them?'),
+    host: t('Would you recommend others to host them?'),
     met: t('Would you recommend others to meet them?'),
   };
 

--- a/modules/experiences/client/components/read-experiences/ExperienceCounts.js
+++ b/modules/experiences/client/components/read-experiences/ExperienceCounts.js
@@ -108,25 +108,25 @@ export default function ExperienceCounts({ experiences }) {
     };
 
     const met = getInteractionPercentage('met');
-    const hostedMe = getInteractionPercentage('hostedMe');
-    const hostedThem = getInteractionPercentage('hostedThem');
+    const guest = getInteractionPercentage('guest');
+    const host = getInteractionPercentage('host');
 
-    if (hostedThem === 100) {
+    if (host === 100) {
       interactions.push(t('They hosted everyone.'));
-    } else if (hostedThem > 0) {
+    } else if (host > 0) {
       interactions.push(
         t('They hosted {{percentage}}% of members.', {
-          percentage: hostedThem,
+          percentage: host,
         }),
       );
     }
 
-    if (hostedMe === 100) {
+    if (guest === 100) {
       interactions.push(t('Was hosted by everyone.'));
-    } else if (hostedMe > 0) {
+    } else if (guest > 0) {
       interactions.push(
         t('Was hosted by {{percentage}}% of members.', {
-          percentage: hostedMe,
+          percentage: guest,
         }),
       );
     }

--- a/modules/experiences/client/components/read-experiences/Meta.js
+++ b/modules/experiences/client/components/read-experiences/Meta.js
@@ -23,8 +23,8 @@ export default function Meta({ interactions, recommend }) {
       {[
         recommend === 'yes' && t('Recommend'),
         recommend === 'no' && t('Not recommend'),
-        interactions?.hostedMe && t('Guest'),
-        interactions?.hostedThem && t('Host'),
+        interactions?.guest && t('Guest'),
+        interactions?.host && t('Host'),
         interactions?.met && t('Met in person'),
       ]
         .filter(label => !!label)

--- a/modules/experiences/client/experiences.prop-types.js
+++ b/modules/experiences/client/experiences.prop-types.js
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 
 export const interactionsType = PropTypes.shape({
   met: PropTypes.bool.isRequired,
-  hostedMe: PropTypes.bool.isRequired,
-  hostedThem: PropTypes.bool.isRequired,
+  guest: PropTypes.bool.isRequired,
+  host: PropTypes.bool.isRequired,
 });
 
 const recommendType = PropTypes.oneOf(['yes', 'no', 'unknown']);

--- a/modules/experiences/server/controllers/experiences.server.controller.js
+++ b/modules/experiences/server/controllers/experiences.server.controller.js
@@ -40,8 +40,8 @@ function validateCreate(req) {
   const isInteraction =
     req.body.interactions &&
     (req.body.interactions.met ||
-      req.body.interactions.hostedMe ||
-      req.body.interactions.hostedThem);
+      req.body.interactions.guest ||
+      req.body.interactions.host);
   if (!isInteraction) {
     valid = false;
     interactionErrors.any = 'missing';
@@ -57,7 +57,7 @@ function validateCreate(req) {
   }
 
   // Values of interactions must be boolean
-  ['met', 'hostedMe', 'hostedThem'].forEach(function (interaction) {
+  ['met', 'guest', 'host'].forEach(function (interaction) {
     if (
       _.has(req, ['body', 'interactions', interaction]) &&
       typeof req.body.interactions[interaction] !== 'boolean'
@@ -97,7 +97,7 @@ function validateCreate(req) {
   ];
   const fields = Object.keys(req.body);
   const unexpectedFields = _.difference(fields, allowedFields);
-  const allowedInteractions = ['met', 'hostedMe', 'hostedThem'];
+  const allowedInteractions = ['met', 'guest', 'host'];
   const interactions = Object.keys(req.body.interactions || {});
   const unexpectedInteractions = _.difference(
     interactions,
@@ -131,8 +131,8 @@ const nonpublicExperienceFields = [
 
 const experienceFields = nonpublicExperienceFields.concat([
   'feedbackPublic',
-  'interactions.hostedMe',
-  'interactions.hostedThem',
+  'interactions.guest',
+  'interactions.host',
   'interactions.met',
   'recommend',
 ]);
@@ -141,8 +141,8 @@ const responseFields = [
   '_id',
   'created',
   'feedbackPublic',
-  'interactions.hostedMe',
-  'interactions.hostedThem',
+  'interactions.guest',
+  'interactions.host',
   'interactions.met',
   'recommend',
 ];
@@ -502,8 +502,8 @@ exports.readMany = async function readMany(req, res, next) {
           userTo: userKeys,
           feedbackPublic: 1,
           interactions: {
-            hostedMe: 1,
-            hostedThem: 1,
+            guest: 1,
+            host: 1,
             met: 1,
           },
           recommend: 1,

--- a/modules/experiences/server/models/experiences.server.model.js
+++ b/modules/experiences/server/models/experiences.server.model.js
@@ -35,12 +35,12 @@ const ExperienceSchema = new Schema({
       default: false,
       required: true,
     },
-    hostedMe: {
+    guest: {
       type: Boolean,
       default: false,
       required: true,
     },
-    hostedThem: {
+    host: {
       type: Boolean,
       default: false,
       required: true,

--- a/modules/experiences/tests/client/components/CreateExperience.client.component.tests.js
+++ b/modules/experiences/tests/client/components/CreateExperience.client.component.tests.js
@@ -137,8 +137,8 @@ describe('<CreateExperience />', () => {
     expect(experiencesApi.create).toHaveBeenCalledWith({
       interactions: {
         met: false,
-        hostedMe: true,
-        hostedThem: false,
+        guest: true,
+        host: false,
       },
       recommend: 'yes',
       feedbackPublic: 'they made a tasty pie',
@@ -191,8 +191,8 @@ describe('<CreateExperience />', () => {
     expect(experiencesApi.create).toHaveBeenCalledWith({
       interactions: {
         met: false,
-        hostedMe: true,
-        hostedThem: false,
+        guest: true,
+        host: false,
       },
       recommend: 'no',
       feedbackPublic: '',

--- a/modules/experiences/tests/server/experience-create.server.routes.tests.js
+++ b/modules/experiences/tests/server/experience-create.server.routes.tests.js
@@ -71,8 +71,8 @@ describe('Create an experience', () => {
               userTo: user2._id,
               interactions: {
                 met: true,
-                hostedMe: true,
-                hostedThem: true,
+                guest: true,
+                host: true,
               },
               recommend: 'yes',
               feedbackPublic,
@@ -86,8 +86,8 @@ describe('Create an experience', () => {
             created: new Date().toISOString(),
             interactions: {
               met: true,
-              hostedMe: true,
-              hostedThem: true,
+              guest: true,
+              host: true,
             },
             feedbackPublic,
             recommend: 'yes',
@@ -111,8 +111,8 @@ describe('Create an experience', () => {
               userTo: user2._id,
               interactions: {
                 met: true,
-                hostedMe: true,
-                hostedThem: true,
+                guest: true,
+                host: true,
               },
               recommend: 'yes',
             })
@@ -129,8 +129,8 @@ describe('Create an experience', () => {
             userTo: user2._id,
             interactions: {
               met: true,
-              hostedMe: true,
-              hostedThem: true,
+              guest: true,
+              host: true,
             },
           });
         });
@@ -143,8 +143,8 @@ describe('Create an experience', () => {
               userTo: user2._id,
               interactions: {
                 met: true,
-                hostedMe: true,
-                hostedThem: true,
+                guest: true,
+                host: true,
               },
               recommend: 'yes',
             })
@@ -157,8 +157,8 @@ describe('Create an experience', () => {
               userTo: user2._id,
               interactions: {
                 met: false,
-                hostedMe: true,
-                hostedThem: false,
+                guest: true,
+                host: false,
               },
               recommend: 'no',
             })
@@ -172,8 +172,8 @@ describe('Create an experience', () => {
               userTo: user1._id, // the same user as logged in user
               interactions: {
                 met: false,
-                hostedMe: true,
-                hostedThem: false,
+                guest: true,
+                host: false,
               },
               recommend: 'no',
             })
@@ -194,8 +194,8 @@ describe('Create an experience', () => {
               userTo: '0'.repeat(24), // nonexistent user id
               interactions: {
                 met: false,
-                hostedMe: true,
-                hostedThem: false,
+                guest: true,
+                host: false,
               },
               recommend: 'no',
             })
@@ -216,8 +216,8 @@ describe('Create an experience', () => {
               userTo: user3Nonpublic._id, // non-public user id
               interactions: {
                 met: false,
-                hostedMe: true,
-                hostedThem: false,
+                guest: true,
+                host: false,
               },
               recommend: 'no',
             })
@@ -241,8 +241,8 @@ describe('Create an experience', () => {
               userTo: user2._id,
               interactions: {
                 met: true,
-                hostedMe: true,
-                hostedThem: true,
+                guest: true,
+                host: true,
               },
               recommend: 'yes',
             })
@@ -267,8 +267,8 @@ describe('Create an experience', () => {
               userTo: user2._id,
               interactions: {
                 met: true,
-                hostedMe: true,
-                hostedThem: true,
+                guest: true,
+                host: true,
               },
               recommend: 'yes',
             })
@@ -303,8 +303,8 @@ describe('Create an experience', () => {
               userTo: user2._id,
               interactions: {
                 met: true,
-                hostedMe: true,
-                hostedThem: true,
+                guest: true,
+                host: true,
               },
               recommend: 'yes',
             })
@@ -346,8 +346,8 @@ describe('Create an experience', () => {
               userTo: user2._id,
               interactions: {
                 met: true,
-                hostedMe: true,
-                hostedThem: true,
+                guest: true,
+                host: true,
               },
               recommend: 'yes',
             })
@@ -389,8 +389,8 @@ describe('Create an experience', () => {
               userTo: user2._id,
               interactions: {
                 met: true,
-                hostedMe: true,
-                hostedThem: true,
+                guest: true,
+                host: true,
               },
               recommend: 'no',
             })
@@ -411,8 +411,8 @@ describe('Create an experience', () => {
               userTo: user2._id,
               interactions: {
                 met: true,
-                hostedMe: true,
-                hostedThem: true,
+                guest: true,
+                host: true,
               },
               recommend: 'yes',
             })
@@ -438,8 +438,8 @@ describe('Create an experience', () => {
               userTo: user2._id,
               interactions: {
                 met: true,
-                hostedMe: true,
-                hostedThem: true,
+                guest: true,
+                host: true,
               },
               recommend: 'yes',
             })
@@ -483,8 +483,8 @@ describe('Create an experience', () => {
               userTo: user2._id,
               interactions: {
                 met: true,
-                hostedMe: true,
-                hostedThem: true,
+                guest: true,
+                host: true,
               },
               recommend: 'yes',
             })
@@ -515,7 +515,7 @@ describe('Create an experience', () => {
             userTo: user2._id,
             interactions: {
               met: 'met',
-              hostedMe: false,
+              guest: false,
             },
             recommend: 'unknown',
           })
@@ -538,7 +538,7 @@ describe('Create an experience', () => {
             userTo: user2._id,
             interactions: {
               met: true,
-              hostedMe: false,
+              guest: false,
             },
             recommend: 'invalid',
           })
@@ -558,7 +558,7 @@ describe('Create an experience', () => {
           .send({
             userTo: 'hello',
             interactions: {
-              hostedMe: true,
+              guest: true,
             },
             recommend: 'yes',
           })
@@ -577,7 +577,7 @@ describe('Create an experience', () => {
           .post('/api/experiences')
           .send({
             interactions: {
-              hostedMe: true,
+              guest: true,
             },
             recommend: 'yes',
           })
@@ -597,7 +597,7 @@ describe('Create an experience', () => {
           .send({
             userTo: user2._id,
             interactions: {
-              hostedMe: true,
+              guest: true,
             },
             recommend: 'yes',
             foo: 'bar',
@@ -619,7 +619,7 @@ describe('Create an experience', () => {
             userTo: user2._id,
             met: false,
             interactions: {
-              hostedMe: true,
+              guest: true,
             },
             recommend: 'yes',
             feedbackPublic: faker.lorem.words(2000), // probably longer than the limit
@@ -641,7 +641,7 @@ describe('Create an experience', () => {
             userTo: user2._id,
             met: false,
             interactions: {
-              hostedMe: false,
+              guest: false,
             },
             recommend: 'yes',
           })

--- a/modules/experiences/tests/server/experience-read-many.server.routes.tests.js
+++ b/modules/experiences/tests/server/experience-read-many.server.routes.tests.js
@@ -115,8 +115,8 @@ describe('Read experiences by userTo Id', () => {
           );
 
         should(ref).have.propertyByPath('interactions', 'met').Boolean();
-        should(ref).have.propertyByPath('interactions', 'hostedMe').Boolean();
-        should(ref).have.propertyByPath('interactions', 'hostedThem').Boolean();
+        should(ref).have.propertyByPath('interactions', 'guest').Boolean();
+        should(ref).have.propertyByPath('interactions', 'host').Boolean();
         should(ref).have.property('public', true);
         should(ref).have.property('created', new Date().toISOString());
         should(ref)
@@ -131,12 +131,8 @@ describe('Read experiences by userTo Id', () => {
       const response = body[0].response;
       should(response).have.property('created', new Date().toISOString());
       should(response).have.propertyByPath('interactions', 'met').Boolean();
-      should(response)
-        .have.propertyByPath('interactions', 'hostedMe')
-        .Boolean();
-      should(response)
-        .have.propertyByPath('interactions', 'hostedThem')
-        .Boolean();
+      should(response).have.propertyByPath('interactions', 'guest').Boolean();
+      should(response).have.propertyByPath('interactions', 'host').Boolean();
       should(response)
         .have.property('recommend')
         .which.is.equalOneOf(['no', 'yes', 'unknown']);
@@ -176,8 +172,8 @@ describe('Read experiences by userTo Id', () => {
         );
 
         should(ref).have.propertyByPath('interactions', 'met');
-        should(ref).have.propertyByPath('interactions', 'hostedMe');
-        should(ref).have.propertyByPath('interactions', 'hostedThem');
+        should(ref).have.propertyByPath('interactions', 'guest');
+        should(ref).have.propertyByPath('interactions', 'host');
       }
 
       should(body[2]).have.only.properties(

--- a/modules/experiences/tests/server/experience-read-mine.server.routes.tests.js
+++ b/modules/experiences/tests/server/experience-read-mine.server.routes.tests.js
@@ -80,8 +80,8 @@ describe('Read my experience to userTo Id', () => {
         .expect(200);
 
       should(body).have.propertyByPath('interactions', 'met').Boolean();
-      should(body).have.propertyByPath('interactions', 'hostedMe').Boolean();
-      should(body).have.propertyByPath('interactions', 'hostedThem').Boolean();
+      should(body).have.propertyByPath('interactions', 'guest').Boolean();
+      should(body).have.propertyByPath('interactions', 'host').Boolean();
       should(body).have.property('public', true);
       should(body).have.property('created', new Date().toISOString());
       should(body)
@@ -102,12 +102,8 @@ describe('Read my experience to userTo Id', () => {
 
       const response = body.response;
       should(response).have.propertyByPath('interactions', 'met').Boolean();
-      should(response)
-        .have.propertyByPath('interactions', 'hostedMe')
-        .Boolean();
-      should(response)
-        .have.propertyByPath('interactions', 'hostedThem')
-        .Boolean();
+      should(response).have.propertyByPath('interactions', 'guest').Boolean();
+      should(response).have.propertyByPath('interactions', 'host').Boolean();
       should(response).have.property('created', new Date().toISOString());
       should(response)
         .have.property('recommend')
@@ -124,8 +120,8 @@ describe('Read my experience to userTo Id', () => {
         .expect(200);
 
       should(body).have.propertyByPath('interactions', 'met').Boolean();
-      should(body).have.propertyByPath('interactions', 'hostedMe').Boolean();
-      should(body).have.propertyByPath('interactions', 'hostedThem').Boolean();
+      should(body).have.propertyByPath('interactions', 'guest').Boolean();
+      should(body).have.propertyByPath('interactions', 'host').Boolean();
       should(body).have.property('public', true);
       should(body).have.property('created', new Date().toISOString());
       should(body)
@@ -152,8 +148,8 @@ describe('Read my experience to userTo Id', () => {
         .expect(200);
 
       should(body).have.propertyByPath('interactions', 'met').Boolean();
-      should(body).have.propertyByPath('interactions', 'hostedMe').Boolean();
-      should(body).have.propertyByPath('interactions', 'hostedThem').Boolean();
+      should(body).have.propertyByPath('interactions', 'guest').Boolean();
+      should(body).have.propertyByPath('interactions', 'host').Boolean();
       should(body).have.property('public', false);
       should(body).have.property('created', new Date().toISOString());
       should(body)

--- a/modules/experiences/tests/server/experience-read-one.server.routes.tests.js
+++ b/modules/experiences/tests/server/experience-read-one.server.routes.tests.js
@@ -101,8 +101,8 @@ describe('Read a single experience by experience id', () => {
         recommend: experiences[3].recommend,
         interactions: {
           met: experiences[3].interactions.met,
-          hostedMe: experiences[3].interactions.hostedMe,
-          hostedThem: experiences[3].interactions.hostedThem,
+          guest: experiences[3].interactions.guest,
+          host: experiences[3].interactions.host,
         },
         response: {
           _id: experiences[4]._id.toString(),
@@ -110,8 +110,8 @@ describe('Read a single experience by experience id', () => {
           recommend: experiences[4].recommend,
           interactions: {
             met: experiences[4].interactions.met,
-            hostedMe: experiences[4].interactions.hostedMe,
-            hostedThem: experiences[4].interactions.hostedThem,
+            guest: experiences[4].interactions.guest,
+            host: experiences[4].interactions.host,
           },
         },
       });

--- a/modules/experiences/tests/server/experience.server.jobs.tests.js
+++ b/modules/experiences/tests/server/experience.server.jobs.tests.js
@@ -34,8 +34,8 @@ describe('Job: Set experience to public after a given period of time', () => {
       // here we don't care if all interactions are false
       interactions: {
         met: true,
-        hostedMe: false,
-        hostedThem: true,
+        guest: false,
+        host: true,
       },
       recommend: 'yes',
     };

--- a/modules/experiences/tests/server/experience.server.model.tests.js
+++ b/modules/experiences/tests/server/experience.server.model.tests.js
@@ -25,8 +25,8 @@ describe('Experience Model Unit Tests', () => {
         userTo: user2._id,
         interactions: {
           met: true,
-          hostedMe: true,
-          hostedThem: false,
+          guest: true,
+          host: false,
         },
         recommend: 'no',
       });
@@ -36,8 +36,8 @@ describe('Experience Model Unit Tests', () => {
         userTo: user1._id,
         interactions: {
           met: true,
-          hostedMe: false,
-          hostedThem: true,
+          guest: false,
+          host: true,
         },
         recommend: 'yes',
       });
@@ -52,8 +52,8 @@ describe('Experience Model Unit Tests', () => {
         userTo: user2._id,
         interactions: {
           met: true,
-          hostedMe: true,
-          hostedThem: false,
+          guest: true,
+          host: false,
         },
         recommend: 'no',
       });
@@ -63,8 +63,8 @@ describe('Experience Model Unit Tests', () => {
         userTo: user3._id,
         interactions: {
           met: true,
-          hostedMe: false,
-          hostedThem: true,
+          guest: false,
+          host: true,
         },
         recommend: 'yes',
       });
@@ -73,14 +73,14 @@ describe('Experience Model Unit Tests', () => {
       await should(experience2.save()).be.resolved();
     });
 
-    it("show error when saving invalid values of 'met', 'recommend', 'hostedMe', 'hostedThem'", async () => {
+    it("show error when saving invalid values of 'met', 'recommend', 'guest', 'host'", async () => {
       const experience = new Experience({
         userFrom: user1._id,
         userTo: user2._id,
         interactions: {
           met: 'foo',
-          hostedMe: 'foolme',
-          hostedThem: 'foolthem',
+          guest: 'foolme',
+          host: 'foolthem',
         },
         recommend: 'bar',
       });
@@ -89,8 +89,8 @@ describe('Experience Model Unit Tests', () => {
       should(err).match({
         errors: {
           'interactions.met': { value: 'foo', kind: 'Boolean' },
-          'interactions.hostedMe': { value: 'foolme', kind: 'Boolean' },
-          'interactions.hostedThem': { value: 'foolthem', kind: 'Boolean' },
+          'interactions.guest': { value: 'foolme', kind: 'Boolean' },
+          'interactions.host': { value: 'foolthem', kind: 'Boolean' },
           recommend: { value: 'bar', kind: 'enum' },
         },
       });

--- a/testutils/common/data.common.testutil.js
+++ b/testutils/common/data.common.testutil.js
@@ -101,8 +101,8 @@ function generateExperiences(users, experienceData) {
       public: true,
       interactions: {
         met: faker.random.boolean(),
-        hostedMe: faker.random.boolean(),
-        hostedThem: faker.random.boolean(),
+        guest: faker.random.boolean(),
+        host: faker.random.boolean(),
       },
       recommend: _.sample(['yes', 'no', 'unknown']),
     };


### PR DESCRIPTION
#### Proposed Changes

* This PR changes hostedMe/hostedThem vocabulary to guest/host terms.

#### Testing Instructions

* To quote a similar PR that renamed many variables, I recommend to "Smoke test everything".

Please let me know if you would like me to fix anything, and thank you for the opportunity to work on this project.

Fixes #1843