### PR TITLE
Update/sparkpost webhooks

### DIFF
--- a/modules/sparkpost/server/controllers/sparkpost-webhooks.server.controller.js
+++ b/modules/sparkpost/server/controllers/sparkpost-webhooks.server.controller.js
@@ -171,7 +171,7 @@ exports.processAndSendMetrics = (event, callback) => {
 /**
  * Basic authentication middleware
  */
-exports.basicAuthenticate = function (req, res, next) {
+exports.basicAuthenticate = (req, res, next) => {
   // Get the basic auth credentials from the request.
   // The Authorization header is parsed and if the header is invalid,
   // undefined is returned, otherwise an object with name and pass properties.

--- a/modules/sparkpost/server/controllers/sparkpost-webhooks.server.controller.js
+++ b/modules/sparkpost/server/controllers/sparkpost-webhooks.server.controller.js
@@ -33,9 +33,7 @@ const config = require(path.resolve('./config/config'));
  * - Each webhook batch contains the header X-MessageSystems-Batch-ID, which
  *   is useful for auditing and prevention of processing duplicate batches.
  *
- * @link https://www.sparkpost.com/blog/webhooks-beyond-the-basics/
- * @link https://developers.sparkpost.com/api/webhooks.html
- * @link https://support.sparkpostelite.com/customer/en/portal/articles/2232381-sparkpost-event-and-metrics-definitions
+ * @link https://developers.sparkpost.com/api/webhooks/
  *
  * @todo Prevent processing duplicate batches.
  */
@@ -84,26 +82,26 @@ exports.processAndSendMetrics = function (event, callback) {
   // Validate against these event types
   // E.g. `{ msys: message_event: { type: 'bounce' } }`
   const eventTypes = [
-    'injection',
-    'delivery',
-    'policy_Rejection',
-    'delay',
     'bounce',
-    'out_of_band',
-    'spam_complaint',
+    'click',
+    'delay',
+    'delivery',
     'generation_failure',
     'generation_rejection',
-    'policy_rejection',
-    'sms_status',
+    'injection',
     'link_unsubscribe',
     'list_unsubscribe',
+    'open',
+    'out_of_band',
+    'policy_rejection',
+    'policy_Rejection',
     'relay_delivery',
     'relay_injection',
+    'relay_permfail',
     'relay_rejection',
     'relay_tempfail',
-    'relay_permfail',
-    'open',
-    'click',
+    'sms_status',
+    'spam_complaint',
   ];
 
   // Get what's in first key of `msys` object

--- a/modules/sparkpost/server/controllers/sparkpost-webhooks.server.controller.js
+++ b/modules/sparkpost/server/controllers/sparkpost-webhooks.server.controller.js
@@ -119,7 +119,11 @@ exports.processAndSendMetrics = (event, callback) => {
     return callback();
   }
 
-  const mailboxProvider = eventData?.mailbox_provider ?? 'unknown';
+  // Mailbox Provider of the recipient, e.g. "Gsuite"
+  const mailboxProvider = String(eventData?.mailbox_provider ?? 'unknown');
+
+  // Canonicalized text of the response returned by the remote server due to a failed delivery attempt.
+  const reason = String(eventData?.reason ?? '');
 
   // Add campaign id to tags if present
   let campaignId = String(eventData?.campaign_id ?? '');
@@ -150,6 +154,7 @@ exports.processAndSendMetrics = (event, callback) => {
       eventCategory,
       eventType,
       mailboxProvider,
+      reason,
     },
     meta: {},
   };

--- a/modules/sparkpost/server/controllers/sparkpost-webhooks.server.controller.js
+++ b/modules/sparkpost/server/controllers/sparkpost-webhooks.server.controller.js
@@ -82,26 +82,32 @@ exports.processAndSendMetrics = function (event, callback) {
   // Validate against these event types
   // E.g. `{ msys: message_event: { type: 'bounce' } }`
   const eventTypes = [
+    'ab_test_cancelled',
+    'ab_test_completed',
+    'amp_click',
+    'amp_initial_open',
+    'amp_open',
     'bounce',
     'click',
     'delay',
     'delivery',
+    'error',
     'generation_failure',
     'generation_rejection',
+    'initial_open',
     'injection',
     'link_unsubscribe',
     'list_unsubscribe',
     'open',
     'out_of_band',
     'policy_rejection',
-    'policy_Rejection',
     'relay_delivery',
     'relay_injection',
     'relay_permfail',
     'relay_rejection',
     'relay_tempfail',
-    'sms_status',
     'spam_complaint',
+    'success',
   ];
 
   // Get what's in first key of `msys` object

--- a/modules/sparkpost/server/controllers/sparkpost-webhooks.server.controller.js
+++ b/modules/sparkpost/server/controllers/sparkpost-webhooks.server.controller.js
@@ -60,14 +60,12 @@ exports.processAndSendMetrics = function (event, callback) {
     return callback();
   }
 
-  // we changed fields to meta
-  // only numbers can be saved as count/value in stathat, so every string value must be either tag (saved) or meta (ignored)
-  const meta = {
+  const meta = {};
+
+  const tags = {
     country: '',
     campaignId: '',
   };
-
-  const tags = {};
 
   // Validate against these event categories
   // E.g. `{ msys: message_event: { } }`
@@ -137,12 +135,12 @@ exports.processAndSendMetrics = function (event, callback) {
     return callback();
   }
 
-  // Add campaign id to meta if present
+  // Add campaign id to tags if present
   const campaignId = _.get(event, 'msys.' + eventCategory + '.campaign_id');
   if (_.isString(campaignId) && campaignId.length > 0) {
     // "Slugify" `campaignId` to ensure we don't get any carbage
     // Allows only `A-Za-z0-9_-`
-    meta.campaignId = speakingurl(campaignId, {
+    tags.campaignId = speakingurl(campaignId, {
       separator: '-', // char that replaces the whitespaces
       maintainCase: false, // don't maintain case
       truncate: 255, // truncate to 255 chars
@@ -152,7 +150,7 @@ exports.processAndSendMetrics = function (event, callback) {
   // Add country if present
   const country = _.get(event, 'msys.' + eventCategory + '.geo_ip.country');
   if (_.isString(country) && country.length > 0 && country.length <= 3) {
-    meta.country = country.replace(/\W/g, '').toUpperCase();
+    tags.country = country.replace(/\W/g, '').toUpperCase();
   }
 
   const statObj = {

--- a/modules/sparkpost/tests/server/sparkpost-webhooks.server.controller.tests.js
+++ b/modules/sparkpost/tests/server/sparkpost-webhooks.server.controller.tests.js
@@ -52,6 +52,8 @@ describe('Sparkpost Webhooks - Integration Test', function () {
         },
         timestamp: 1234567890,
         campaign_id: 'this is a campaign id',
+        mailbox_provider: 'Gsuite',
+        reason: 'MAIL REFUSED - IP (a.b.c.d) is in black list',
       },
     },
   };
@@ -83,9 +85,15 @@ describe('Sparkpost Webhooks - Integration Test', function () {
 
           should(measurement).eql('transactionalEmailEvent');
           should(point).have.propertyByPath('fields', 'count').eql(1);
-          should(point).have.propertyByPath('fields', 'country').eql('ABC');
+          should(point).have.propertyByPath('tags', 'country').eql('ABC');
           should(point)
-            .have.propertyByPath('fields', 'campaignId')
+            .have.propertyByPath('tags', 'mailboxProvider')
+            .eql('Gsuite');
+          should(point)
+            .have.propertyByPath('tags', 'reason')
+            .eql('MAIL REFUSED - IP (a.b.c.d) is in black list');
+          should(point)
+            .have.propertyByPath('tags', 'campaignId')
             .eql('this-is-a-campaign-id');
           should(point)
             .have.propertyByPath('tags', 'category')

--- a/modules/sparkpost/tests/server/sparkpost.server.routes.tests.js
+++ b/modules/sparkpost/tests/server/sparkpost.server.routes.tests.js
@@ -5,77 +5,57 @@ const express = require(path.resolve('./config/lib/express'));
 const config = require(path.resolve('./config/config'));
 
 /**
- * Globals
- */
-let app;
-let agent;
-let events;
-
-/**
  * Sparkpost routes tests
  */
-describe('Sparkpost CRUD tests', function () {
-  describe('Webhook endpoint', function () {
-    before(function (done) {
-      // Get application
-      app = express.init(mongoose.connection);
-      agent = request.agent(app);
+describe('Sparkpost CRUD tests', () => {
+  const app = express.init(mongoose.connection);
+  const agent = request.agent(app);
 
-      // Sparkpost webhook event example
-      events = [
-        {
-          msys: {
-            message_event: {
-              type: 'delivery',
-              campaign_id: 'example',
-              timestamp: '1454442600',
-              mailbox_provider: 'Gsuite',
-              reason: 'MAIL REFUSED - IP (a.b.c.d) is in black list',
-            },
-          },
+  // Sparkpost webhook event example
+  const events = [
+    {
+      msys: {
+        message_event: {
+          type: 'delivery',
+          campaign_id: 'example',
+          timestamp: '1454442600',
+          mailbox_provider: 'Gsuite',
+          reason: 'MAIL REFUSED - IP (a.b.c.d) is in black list',
         },
-      ];
+      },
+    },
+  ];
 
-      done();
+  describe('Webhook endpoint', () => {
+    it('Should not be able to request using GET method', async () => {
+      await agent.get('/api/sparkpost/webhook').expect(404);
     });
 
-    it('Should not be able to request using GET method', function (done) {
-      agent.get('/api/sparkpost/webhook').expect(404).end(done);
-    });
-
-    it('Should not be allowed to access endpoint without credentials', function (done) {
-      agent
+    it('Should not be allowed to access endpoint without credentials', async () => {
+      const { body, headers } = await agent
         .post('/api/sparkpost/webhook')
-        .expect(401)
-        .end(function (err, res) {
-          res.headers['www-authenticate'].should.equal(
-            'Basic realm="Knock Knock"',
-          );
-          res.body.message.should.equal('Access denied');
+        .expect(401);
 
-          // Call the assertion callback
-          return done(err);
-        });
+      headers['www-authenticate'].should.equal('Basic realm="Knock Knock"');
+      body.message.should.equal('Access denied');
     });
 
-    it('Should not be allowed to access endpoint with wrong credentials', function (done) {
-      agent
+    it('Should not be allowed to access endpoint with wrong credentials', async () => {
+      await agent
         .post('/api/sparkpost/webhook')
         .auth('wrong', 'wrong')
-        .expect(401)
-        .end(done);
+        .expect(401);
     });
 
-    it('Should be allowed to access endpoint with credentials', function (done) {
-      agent
+    it('Should be allowed to access endpoint with credentials', async () => {
+      await agent
         .post('/api/sparkpost/webhook')
         .auth(
           config.sparkpostWebhook.username,
           config.sparkpostWebhook.password,
         )
         .send(events)
-        .expect(200)
-        .end(done);
+        .expect(200);
     });
   });
 });

--- a/modules/sparkpost/tests/server/sparkpost.server.routes.tests.js
+++ b/modules/sparkpost/tests/server/sparkpost.server.routes.tests.js
@@ -29,6 +29,8 @@ describe('Sparkpost CRUD tests', function () {
               type: 'delivery',
               campaign_id: 'example',
               timestamp: '1454442600',
+              mailbox_provider: 'Gsuite',
+              reason: 'MAIL REFUSED - IP (a.b.c.d) is in black list',
             },
           },
         },


### PR DESCRIPTION
#### Proposed Changes

* Update `eventTypes` list from [docs](https://www.sparkpost.com/docs/tech-resources/webhook-event-reference/), in two commits: https://github.com/Trustroots/trustroots/pull/2128/commits/7dabf6ce6607f222a37d61a73d0ec10748549e44 (alphabetize), https://github.com/Trustroots/trustroots/pull/2128/commits/531e7d106cc29e4d18927f6b5f4094317e79e905 (Fresh list of event names)
* Move `campaignId` and `country` to tags from meta object, so that we can query against them in Grafana. https://github.com/Trustroots/trustroots/pull/2128/commits/9a17281853f9c78ff947646f6f15966710ec1b79
* Add `reason` data (for `bounce` and other rejection events), see [docs](https://www.sparkpost.com/docs/tech-resources/webhook-event-reference/)
* Add `mailboxProvider` data (e.g. "Gsuite" etc) to help detecting if we're blocked by any specific providers e.g. due to email blacklists.
* Modernize code, don't use so much `lodash` etc

#### Testing Instructions

A bit tricky to test from end-to-end... 😅 

You could push to the webhook API endpoint an example data object and observe it from console get recorded to InfluxDB.

I'd be fine just for code-review and confirm that the test that I updated touches all the code paths.

I'll observe this in production after deploying and I'll be ready to revert if it behaves unexpectedly.

Note that we don't really run Stathat anymore so that code and test is obsolete — we should in fact just strip the code out.