### PR TITLE
Add translation status from Weblate to stats page

### DIFF
--- a/modules/statistics/client/components/Statistics.component.js
+++ b/modules/statistics/client/components/Statistics.component.js
@@ -221,9 +221,12 @@ export default function Statistics({ isAuthenticated }) {
                   </>
                 )}
               </Stat>
-              <Stat title={t('Translations status')}>
+              <Stat title={t('Translations status')} className="is-graph">
                 <a href="https://hosted.weblate.org/engage/trustroots/">
-                  <img src="https://hosted.weblate.org/widgets/trustroots/-/multi-auto.svg" alt={t('Translations status')} />
+                  <img
+                    alt={t('Translations status')}
+                    src="https://hosted.weblate.org/widgets/trustroots/-/multi-auto.svg"
+                  />
                 </a>
               </Stat>
             </Grid>

--- a/modules/statistics/client/components/Statistics.component.js
+++ b/modules/statistics/client/components/Statistics.component.js
@@ -156,17 +156,6 @@ export default function Statistics({ isAuthenticated }) {
                 </a>
               </Stat>
 
-              <Stat title={t('Most messages get replies')} className="is-graph">
-                <a href="https://grafana.trustroots.org/d/000000004/messages-detailed">
-                  <img
-                    className="img-responsive"
-                    src="https://grafana.trustroots.org/render/d-solo/000000004/messages-detailed?orgId=1&theme=light&panelId=4&width=800&height=400&tz=UTC"
-                    width="100%"
-                    alt={t('Weekly messages')}
-                  />
-                </a>
-              </Stat>
-
               <Stat title={t('Connected to networks')}>
                 <ul className="list-unstyled text-right">
                   {!statistics
@@ -221,11 +210,23 @@ export default function Statistics({ isAuthenticated }) {
                   </>
                 )}
               </Stat>
+
+              <Stat title={t('Most messages get replies')} className="is-graph">
+                <a href="https://grafana.trustroots.org/d/000000004/messages-detailed">
+                  <img
+                    className="img-responsive"
+                    src="https://grafana.trustroots.org/render/d-solo/000000004/messages-detailed?orgId=1&theme=light&panelId=4&width=800&height=400&tz=UTC"
+                    width="100%"
+                    alt={t('Weekly messages')}
+                  />
+                </a>
+              </Stat>
+
               <Stat title={t('Translations status')} className="is-graph">
                 <a href="https://hosted.weblate.org/engage/trustroots/">
                   <img
                     alt={t('Translations status')}
-                    src="https://hosted.weblate.org/widgets/trustroots/-/multi-auto.svg"
+                    src="https://hosted.weblate.org/widgets/trustroots/-/horizontal-auto.svg"
                   />
                 </a>
               </Stat>

--- a/modules/statistics/client/components/Statistics.component.js
+++ b/modules/statistics/client/components/Statistics.component.js
@@ -221,6 +221,11 @@ export default function Statistics({ isAuthenticated }) {
                   </>
                 )}
               </Stat>
+              <Stat title={t('Translations status')}>
+                <a href="https://hosted.weblate.org/engage/trustroots/">
+                  <img src="https://hosted.weblate.org/widgets/trustroots/-/multi-auto.svg" alt={t('Translations status')} />
+                </a>
+              </Stat>
             </Grid>
 
             <hr />


### PR DESCRIPTION
#### Proposed Changes

* Add translation Weblate status widget to `/statistics` page (https://hosted.weblate.org/widgets/trustroots)

<img width="1230" alt="image" src="https://user-images.githubusercontent.com/87168/110311701-d5cee100-800c-11eb-8a86-380a896bb273.png">


#### Testing Instructions

* Open `/statistics` and observe the language list that gets pulled from Weblate
