### PR TITLE
Admin tool: add role changes as notes

### DIFF
--- a/modules/admin/server/controllers/admin.users.server.controller.js
+++ b/modules/admin/server/controllers/admin.users.server.controller.js
@@ -10,6 +10,7 @@ const escapeStringRegexp = require('escape-string-regexp');
 const mongoose = require('mongoose');
 const log = require(path.resolve('./config/lib/logger'));
 
+const AdminNote = mongoose.model('AdminNote');
 const Contact = mongoose.model('Contact');
 const Message = mongoose.model('Message');
 const Offer = mongoose.model('Offer');
@@ -291,9 +292,12 @@ exports.changeRole = async (req, res) => {
       });
     }
 
+    let roleChangeMessage = `Role "${role}" added.`;
+
     // If adding role 'volunteer-alumni', remove 'volunteer' role
     if (role === 'volunteer-alumni') {
       await User.updateOne({ _id: userId }, { $pull: { roles: 'volunteer' } });
+      roleChangeMessage = 'User made into volunteer-alumni.';
     }
 
     // If adding role 'volunteer', remove 'volunteer-alumni' role
@@ -302,17 +306,28 @@ exports.changeRole = async (req, res) => {
         { _id: userId },
         { $pull: { roles: 'volunteer-alumni' } },
       );
+      roleChangeMessage = 'User made into volunteer.';
     }
 
     // If adding role 'shadowban', remove 'suspended' role
     if (role === 'shadowban') {
       await User.updateOne({ _id: userId }, { $pull: { roles: 'suspended' } });
+      roleChangeMessage = 'User shadowbanned.';
     }
 
     // If adding role 'suspended', remove 'shadowban' role
     if (role === 'suspended') {
       await User.updateOne({ _id: userId }, { $pull: { roles: 'shadowban' } });
+      roleChangeMessage = 'User suspended.';
     }
+
+    // Add new admin-note about role change
+    const adminNoteItem = new AdminNote({
+      admin: req.user._id,
+      note: `<p><b>Performed action:</b></p><p><i>${roleChangeMessage}</i></p>`,
+      user: userId,
+    });
+    await adminNoteItem.save();
 
     res.send({ message: 'Role changed.' });
   } catch (err) {

--- a/modules/admin/tests/server/admin.users.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.users.server.routes.tests.js
@@ -71,9 +71,9 @@ describe('Admin User CRUD tests', () => {
       });
 
       const { _id: _userAdminId } = await userAdmin.save();
-      userAdminId = _userAdminId;
+      userAdminId = _userAdminId.toString();
       const { _id: _userRegularId } = await userRegular.save();
-      userRegularId = _userRegularId;
+      userRegularId = _userRegularId.toString();
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error(err);
@@ -355,12 +355,10 @@ describe('Admin User CRUD tests', () => {
           .get(`/api/admin/notes?userId=${userRegularId}`)
           .expect(200);
 
-        // Script tag gets stripped out
-        // URL is turned into a link
         body[0].note.should.equal(
           '<p><b>Performed action:</b></p><p><i>User suspended.</i></p>',
         );
-        body[0].admin._id.equal(userAdminId);
+        body[0].admin._id.should.equal(userAdminId);
       });
     });
   });

--- a/modules/admin/tests/server/admin.users.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.users.server.routes.tests.js
@@ -358,7 +358,7 @@ describe('Admin User CRUD tests', () => {
         // Script tag gets stripped out
         // URL is turned into a link
         body[0].note.should.equal(
-          '<p><strong>Performed action:</strong></p><p><em>User suspended.</em></p>',
+          '<p><b>Performed action:</b></p><p><i>User suspended.</i></p>',
         );
         body[0].admin._id.equal(userAdminId);
       });


### PR DESCRIPTION
#### Proposed Changes

* Record user role changes as notes as a way to add clarity for support volunteers.

<img width="445" alt="Screenshot 2021-03-08 at 14 32 47" src="https://user-images.githubusercontent.com/87168/110323240-04ed4e80-801d-11eb-93d2-09e4d966d230.png">


#### Testing Instructions

* Open admin tool for user, and click on role buttons. They should appear in notes below.

I'll merge as CI greens, because this touches admin tool and not the whole site.