### PR TITLE
Content security policy: add Weblate

### DIFF
--- a/config/lib/express.js
+++ b/config/lib/express.js
@@ -288,7 +288,8 @@ module.exports.initHelmetHeaders = function (app) {
         // Defines the origins from which images can be loaded.
         imgSrc: [
           "'self'",
-          'grafana.trustroots.org',
+          'https://hosted.weblate.org', // Translation tool, used on /statistics page
+          'grafana.trustroots.org', // Stats tool, used on /statistics page
           'https://*.tiles.mapbox.com', // Map tiles
           'https://api.mapbox.com', // Map tiles/Geocoding
           'https://events.mapbox.com',


### PR DESCRIPTION
#### Proposed Changes

* Add Weblate to CSP (content security policy) header as domain where we can load images from

#### Testing Instructions

Fails only in production — the image doesn't load:

![image](https://user-images.githubusercontent.com/87168/111044856-ba703580-8453-11eb-8c79-a1637cde27f4.png)

