### PR TITLE
Allow only people from my circles find me

### DIFF
--- a/modules/offers/client/controllers/offer-host-edit.client.controller.js
+++ b/modules/offers/client/controllers/offer-host-edit.client.controller.js
@@ -46,6 +46,7 @@ function OfferHostEditController(
       noOfferDescription: '',
       location: defaultLocation,
       maxGuests: 1,
+      showOnlyInMyCircles: false,
     };
 
     // Make sure offer is there

--- a/modules/offers/client/views/offer-host-edit.client.view.html
+++ b/modules/offers/client/views/offer-host-edit.client.view.html
@@ -124,6 +124,30 @@
                     </span>
                   </div>
                 </fieldset>
+
+                <br /><br />
+
+                <fieldset
+                  class="offer-showOnlyInMyCircles"
+                  ng-if="offerHostEdit.offer.status !== 'no'"
+                >
+                  <legend>
+                    <h4 id="showOnlyInMyCircles">
+                      Available only in my circles?
+                    </h4>
+                  </legend>
+                  <div class="checkbox">
+                    <label>
+                      <input
+                        type="checkbox"
+                        name="newsletter"
+                        ng-model="offerHostEdit.offer.showOnlyInMyCircles"
+                      />
+                      People that are not in any of my circles should not find
+                      me.
+                    </label>
+                  </div>
+                </fieldset>
               </div>
             </div>
           </div>

--- a/modules/offers/client/views/offer-host-edit.client.view.html
+++ b/modules/offers/client/views/offer-host-edit.client.view.html
@@ -127,20 +127,14 @@
 
                 <br /><br />
 
-                <fieldset
-                  class="offer-showOnlyInMyCircles"
-                  ng-if="offerHostEdit.offer.status !== 'no'"
-                >
+                <fieldset ng-if="offerHostEdit.offer.status !== 'no'">
                   <legend>
-                    <h4 id="showOnlyInMyCircles">
-                      Available only in my circles?
-                    </h4>
+                    <h4>Available only in my circles?</h4>
                   </legend>
                   <div class="checkbox">
                     <label>
                       <input
                         type="checkbox"
-                        name="newsletter"
                         ng-model="offerHostEdit.offer.showOnlyInMyCircles"
                       />
                       People that are not in any of my circles should not find

--- a/modules/offers/server/controllers/offers.server.controller.js
+++ b/modules/offers/server/controllers/offers.server.controller.js
@@ -610,11 +610,8 @@ exports.list = function (req, res) {
 
   // Filter out users that do not share any circles with the authenticated user
   // and chose to not appear in those searches.
-  const showOnlyInMyCirclesQueries = [
-    { showOnlyInMyCircles: false },
-    { showOnlyInMyCircles: { $exists: false } },
-  ];
-  req.user.member.forEach(function (membership) {
+  const showOnlyInMyCirclesQueries = [{ showOnlyInMyCircles: false }];
+  req.user.member?.forEach(function (membership) {
     // Add all the circles that the authenticated user is member of. One of them
     // must match for an offer to appear in the search result.
     showOnlyInMyCirclesQueries.push({

--- a/modules/offers/server/controllers/offers.server.controller.js
+++ b/modules/offers/server/controllers/offers.server.controller.js
@@ -36,6 +36,7 @@ const publicOfferFields = [
   'location',
   'updated',
   'validUntil',
+  'showOnlyInMyCircles',
 ];
 
 // Offer fields users can modify
@@ -46,6 +47,7 @@ const allowedOfferFields = [
   'maxGuests',
   'location',
   'validUntil',
+  'showOnlyInMyCircles',
 ];
 
 /**
@@ -516,25 +518,23 @@ exports.list = function (req, res) {
   }
 
   // Some of the filters are based on `user` schema
-  if (
-    filters.hasArrayFilter('languages') ||
-    filters.hasArrayFilter('tribes') ||
-    filters.hasObjectFilter('seen')
-  ) {
-    query.push({
-      $lookup: {
-        from: 'users',
-        localField: 'user',
-        foreignField: '_id',
-        as: 'user',
-      },
-    });
-    // Because above `$lookup` returns an array with one user
-    // `[{userObject}]`, we have to unwind it back to `{userObject}`
-    query.push({
-      $unwind: '$user',
-    });
-  }
+  query.push({
+    $lookup: {
+      from: 'users',
+      localField: 'user',
+      foreignField: '_id',
+      as: 'user',
+    },
+  });
+  // Because above `$lookup` returns an array with one user
+  // `[{userObject}]`, we have to unwind it back to `{userObject}`
+  // Preserve the entry in case the user mapping fails.
+  query.push({
+    $unwind: {
+      path: '$user',
+      preserveNullAndEmptyArrays: true,
+    },
+  });
 
   // Last seen filter
   if (filters.hasObjectFilter('seen')) {
@@ -607,6 +607,25 @@ exports.list = function (req, res) {
       });
     }
   }
+
+  // Filter out users that do not share any circles with the authenticated user
+  // and chose to not appear in those searches.
+  const showOnlyInMyCirclesQueries = [
+    { showOnlyInMyCircles: false },
+    { showOnlyInMyCircles: { $exists: false } },
+  ];
+  req.user.member.forEach(function (membership) {
+    // Add all the circles that the authenticated user is member of. One of them
+    // must match for an offer to appear in the search result.
+    showOnlyInMyCirclesQueries.push({
+      'user.member.tribe': membership.tribe._id,
+    });
+  });
+  query.push({
+    $match: {
+      $or: showOnlyInMyCirclesQueries,
+    },
+  });
 
   // Pick fields and convert to GeoJson Feature
   query.push({

--- a/modules/offers/server/models/offer.server.model.js
+++ b/modules/offers/server/models/offer.server.model.js
@@ -157,6 +157,10 @@ const OfferSchema = new Schema({
   reactivateReminderSent: {
     type: Date,
   },
+  showOnlyInMyCircles: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 // Geospatial index (lat,lon)

--- a/modules/offers/tests/server/offer-search.server.routes.tests.js
+++ b/modules/offers/tests/server/offer-search.server.routes.tests.js
@@ -1147,7 +1147,7 @@ describe('Offer search tests', function () {
     });
   });
 
-  it('should be able to get offers from users with circles in common and have "showOnlyMyCircles" set', function (done) {
+  it('should be able to get offers from users with circles in common and have "showOnlyInMyCircles" set', function (done) {
     // Verify that offers where showOnlyInMyCircles is true are only appearing
     // in searches where the authenticated user (user1) has at least one circle
     // in common with the user that owns the offer.
@@ -1205,10 +1205,12 @@ describe('Offer search tests', function () {
         // Update the hosting offers.
         function (user3, done) {
           // Save hosting offer 1 (user2, showOnlyInMyCircles=true).
-          const o1 = new Offer(offer1);
-          o1.user = user2Id;
-          o1.location = testLocations.Europe.location;
-          o1.showOnlyInMyCircles = true;
+          const o1 = new Offer({
+            ...offer1,
+            user: user2Id,
+            location: testLocations.Europe.location,
+            showOnlyInMyCircles: true,
+          });
           o1.save(function (err, offer1) {
             offer1Id = offer1._id;
             done(err);

--- a/modules/offers/tests/server/offer-search.server.routes.tests.js
+++ b/modules/offers/tests/server/offer-search.server.routes.tests.js
@@ -1147,6 +1147,135 @@ describe('Offer search tests', function () {
     });
   });
 
+  it('should be able to get offers from users with circles in common and have "showOnlyMyCircles" set', function (done) {
+    // Verify that offers where showOnlyInMyCircles is true are only appearing
+    // in searches where the authenticated user (user1) has at least one circle
+    // in common with the user that owns the offer.
+    //
+    // Makes the users members of the following tribes:
+    //   - user1: tribe1, tribe2  (the authenticated user)
+    //   - user2: tribe2, tribe3  (overlaps with user1)
+    //   - user3: tribe3          (does not overlap with user1)
+    // The following hosting offers are available:
+    //   - offer1 is owned by user2 and should appear as user1's circles overlap
+    //     with the ones of user2 while showOnlyInMyCircles is true.
+    //   - offer2 is owned by user3 and should *not* appear as user1's circles
+    //     do not overlap with the ones of user3 while showOnlyInMyCircles is true.
+    //   - offer3 is owned by user3 and should appear despite user1's circles not
+    //     overlapping with the ones of user3 since showOnlyInMyCircles is false.
+    let tribe3Id;
+    let offer1Id;
+    async.waterfall(
+      [
+        // Save tribe 3.
+        function (done) {
+          const tribe3 = new Tribe({
+            slug: 'tribe3',
+            label: 'tribe3',
+            color: '333333',
+            count: 1,
+            public: true,
+          });
+          tribe3.save(function (err, tribe3) {
+            tribe3Id = tribe3._id;
+            done(err);
+          });
+        },
+
+        // Set the users' memberships.
+        function (done) {
+          user1.member = [
+            { tribe: tribe1Id, since: new Date() },
+            { tribe: tribe2Id, since: new Date() },
+          ];
+          user1.save(done);
+        },
+        function (user1, done) {
+          user2.member = [
+            { tribe: tribe2Id, since: new Date() },
+            { tribe: tribe3Id, since: new Date() },
+          ];
+          user2.save(done);
+        },
+        function (user2, done) {
+          user3.member = { tribe: tribe3Id, since: new Date() };
+          user3.save(done);
+        },
+
+        // Update the hosting offers.
+        function (user3, done) {
+          // Save hosting offer 1 (user2, showOnlyInMyCircles=true).
+          const o1 = new Offer(offer1);
+          o1.user = user2Id;
+          o1.location = testLocations.Europe.location;
+          o1.showOnlyInMyCircles = true;
+          o1.save(function (err, offer1) {
+            offer1Id = offer1._id;
+            done(err);
+          });
+        },
+        function (done) {
+          // Save hosting offer 2 (user3, showOnlyInMyCircles=true).
+          offer2.user = user3Id;
+          offer2.location = testLocations.Europe.location;
+          offer2.showOnlyInMyCircles = true;
+          offer2.save(done);
+        },
+        function (offer2, done) {
+          // Save hosting offer 3 (user3, showOnlyInMyCircles=false).
+          offer3.user = user3Id;
+          offer3.location = testLocations.Europe.location;
+          offer3.showOnlyInMyCircles = false;
+          offer3.save(done);
+        },
+
+        // The actual test.
+        function (offer3, done) {
+          // Sign in.
+          agent
+            .post('/api/auth/signin')
+            .send(credentials)
+            .expect(200)
+            .end(done);
+        },
+        function (res, done) {
+          // Fetch the offers.
+          agent
+            .get('/api/offers' + testLocations.Europe.queryBoundingBox)
+            .expect(200)
+            .end(done);
+        },
+        function (offersGetRes, done) {
+          // Verify the offers.
+
+          // Offer 1 and 3 should match. See the test description above for why.
+          const features = offersGetRes.body.features;
+          features.should.have.lengthOf(2);
+
+          // The offers are returned in any order.
+          let offerRes1;
+          let offerRes3;
+          if (features[0].properties.id === offer1Id.toString()) {
+            offerRes1 = features[0];
+            offerRes3 = features[1];
+          } else {
+            offerRes1 = features[1];
+            offerRes3 = features[0];
+          }
+
+          offerRes1.properties.id.should.equal(offer1Id.toString());
+          offerRes3.properties.id.should.equal(offer3Id.toString());
+
+          return done();
+        },
+      ],
+      function (err) {
+        should.not.exist(err);
+        done(err);
+      },
+    );
+  });
+
   afterEach(function (done) {
     User.deleteMany().exec(function () {
       Tribe.deleteMany().exec(function () {

--- a/modules/offers/tests/server/offer.server.routes.tests.js
+++ b/modules/offers/tests/server/offer.server.routes.tests.js
@@ -140,6 +140,7 @@ describe('Offer CRUD tests', function () {
       noOfferDescription: '<p>1 I cannot host... :(</p>',
       maxGuests: 5,
       location: testLocations.Europe.location,
+      showOnlyInMyCircles: false,
     };
 
     offer2 = new Offer({
@@ -888,6 +889,7 @@ describe('Offer CRUD tests', function () {
                   // Modify offer
                   offer.description = 'MODIFIED';
                   offer.noOfferDescription = 'MODIFIED';
+                  offer.showOnlyInMyCircles = true;
 
                   // Store this for later comparison
                   const previousUpdated = offer.updated;
@@ -911,6 +913,7 @@ describe('Offer CRUD tests', function () {
                           offerNew.description.should.equal('MODIFIED');
                           offerNew.noOfferDescription.should.equal('MODIFIED');
                           offerNew.updated.should.not.equal(previousUpdated);
+                          offerNew.showOnlyInMyCircles.should.equal(true);
                           return done(err);
                         },
                       );

--- a/modules/users/server/models/user.server.model.js
+++ b/modules/users/server/models/user.server.model.js
@@ -337,6 +337,7 @@ const UserSchema = new Schema({
   /* Tribes user is member of */
   member: {
     type: [UserMemberSchema],
+    default: [],
   },
   pushRegistration: {
     type: [UserPushRegistrationSchema],


### PR DESCRIPTION
#### Proposed Changes

* When editing a hosting offer, users can opt-in to not appear on the map of users with which they do not have any circles in common.

#### Testing Instructions

1. Manual
  * User 1: Edit profile -> Locations -> Modify your hosting location -> check "People that are not in any of my circles should not find me."
  * User 2 (that does not have any circles in common with user1): The hosting offer of user1 no longer appears on `/search`.
2. Automatic
  * Run `npm test` to run the additional tests.

Fixes: #397
