### PR TITLE
Husky: remove running `npm test` on pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,2 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
-
-npm test

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/package.json
+++ b/package.json
@@ -267,11 +267,6 @@
     "url": "https://github.com/Trustroots/trustroots/issues"
   },
   "license": "MIT",
-  "husky": {
-    "hooks": {
-      "pre-commit": "npx lint-staged"
-    }
-  },
   "lint-staged": {
     "*.js": [
       "npm run reformat-files",


### PR DESCRIPTION
#### Proposed Changes

* Remove running `npm test` on pre-commit hook and switch it to the actual pre-commit checks that we run.

Apparently this broke when migrating to Husky v6: https://github.com/Trustroots/trustroots/pull/2220

#### Testing Instructions

* Do some eslint or prettier worth changes in files, and then commi. You should see those changes modified automatically.
* Pre-commit hook shouldn't take ages anymore as it doesn't run `npm test`