### PR TITLE
Janitorial: fix deprecated Faker util call in tests

### DIFF
--- a/testutils/common/data.common.testutil.js
+++ b/testutils/common/data.common.testutil.js
@@ -29,7 +29,7 @@ function generateServerUser(overrides = {}) {
   return {
     ...generateBaseUser(),
     locale: '',
-    public: faker.random.boolean(),
+    public: faker.datatype.boolean(),
     roles: ['user'],
     password: faker.internet.password(),
     ...overrides,
@@ -100,9 +100,9 @@ function generateExperiences(users, experienceData) {
       userTo: users[data[1]]._id,
       public: true,
       interactions: {
-        met: faker.random.boolean(),
-        guest: faker.random.boolean(),
-        host: faker.random.boolean(),
+        met: faker.datatype.boolean(),
+        guest: faker.datatype.boolean(),
+        host: faker.datatype.boolean(),
       },
       recommend: _.sample(['yes', 'no', 'unknown']),
     };


### PR DESCRIPTION
#### Proposed Changes

* Gets rid of deprecation warnings in tests:
<img width="690" alt="Screenshot 2021-05-02 at 20 57 46" src="https://user-images.githubusercontent.com/87168/116822711-0fddde80-ab89-11eb-812b-64e61ba322c0.png">


#### Testing Instructions

* CI
