### PR TITLE
Languages: add a few missing locales

### DIFF
--- a/config/shared/locales.json
+++ b/config/shared/locales.json
@@ -116,5 +116,47 @@
     "code": "zh_Hans",
     "english": "Chinese (simplified)",
     "production": false
+  },
+  {
+    "label": "日本語",
+    "code": "ja",
+    "english": "Japanese",
+    "production": false
+  },
+  {
+    "label": "اَلْعَرَبِيَّةُ",
+    "code": "ar",
+    "english": "Arabic",
+    "production": false
+  },
+  {
+    "label": "hrvatski",
+    "code": "hr",
+    "english": "Croatian",
+    "production": false
+  },
+  {
+    "label": "latviešu",
+    "code": "lv",
+    "english": "Latvian",
+    "production": false
+  },
+  {
+    "label": "српски / srpski",
+    "code": "sr",
+    "english": "Serbian",
+    "production": false
+  },
+  {
+    "label": "slovenščina",
+    "code": "sl",
+    "english": "Slovenian",
+    "production": false
+  },
+  {
+    "label": "català",
+    "code": "ca",
+    "english": "Catalan",
+    "production": false
   }
 ]


### PR DESCRIPTION

#### Proposed Changes

* Add new locales, they're present in Weblate but this will also make them visible in the interface both locally and for volunteers. Members at the live site won't see these yet.

<img width="723" alt="Screenshot 2021-05-23 at 23 58 33" src="https://user-images.githubusercontent.com/87168/119276309-c41bd380-bc22-11eb-8562-4fe37ea92847.png">

#### Testing Instructions

* CI