### PR TITLE
Remove JSX highlight from linguist config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,2 @@
 package-lock.json merge=npm-merge-driver
-*.js linguist-language=JSX
 * text=auto eol=lf


### PR DESCRIPTION
Github has removed special JSX highlighting in Linguist, the library Github uses for syntax highlighting. It's now merged into JS highlighter. Hence we can let JS files be syntax highlighted as JS.

Reference https://github.com/github/linguist/pull/5133
