### PR TITLE
Up to date number of members based on actual stats

### DIFF
--- a/modules/pages/client/components/Home.component.js
+++ b/modules/pages/client/components/Home.component.js
@@ -80,23 +80,25 @@ export function getSignupUrl(circleSlug) {
   return '/signup';
 }
 
+function rounded(number, round = 5000) {
+  return parseInt(number / round) * round;
+}
+
 export default function Home({ user, isNativeMobileApp, photoCredits }) {
   const { t } = useTranslation('pages');
   // `tribe` route supported for legacy reasons, deprecated Feb 2021
   const { circle: circleRouteParam, tribe: tribeRouteParam } = getRouteParams();
   const circleRoute = circleRouteParam || tribeRouteParam;
 
-  const [stats, setStats] = useState([]);
-  useEffect(() => {
-    async function fetchData() {
-      const stats = await statisticsAPI.get({ limit: 3 });
-      setStats(stats);
-    }
-    fetchData();
+  const [statistics, setStats] = useState(false);
+  useEffect(async () => {
+    const { data } = await statisticsAPI.get();
+    setStats(data);
   }, []);
   // @TODO change this to be based on UI language rather than browser locale
+  const lastKnownMemberCount = 60000;
   const memberCount = new Intl.NumberFormat().format(
-    !stats ? 60000 : stats?.total,
+    rounded(statistics ? statistics?.total : lastKnownMemberCount),
   );
 
   // TODO get header height instead of magic number 56

--- a/modules/pages/client/components/Home.component.js
+++ b/modules/pages/client/components/Home.component.js
@@ -9,6 +9,7 @@ import { getCircleBackgroundStyle } from '@/modules/tribes/client/utils';
 import { getRouteParams } from '@/modules/core/client/services/angular-compat';
 import { userType } from '@/modules/users/client/users.prop-types';
 import * as circlesAPI from '@/modules/tribes/client/api/tribes.api';
+import * as statisticsAPI from '@/modules/statistics/client/api/statistics.api';
 import Board from '@/modules/core/client/components/Board.js';
 import BoardCredits from '@/modules/core/client/components/BoardCredits.js';
 import ManifestoText from './ManifestoText.component.js';
@@ -85,8 +86,18 @@ export default function Home({ user, isNativeMobileApp, photoCredits }) {
   const { circle: circleRouteParam, tribe: tribeRouteParam } = getRouteParams();
   const circleRoute = circleRouteParam || tribeRouteParam;
 
+  const [stats, setStats] = useState([]);
+  useEffect(() => {
+    async function fetchData() {
+      const stats = await statisticsAPI.get({ limit: 3 });
+      setStats(stats);
+    }
+    fetchData();
+  }, []);
   // @TODO change this to be based on UI language rather than browser locale
-  const memberCount = new Intl.NumberFormat().format(60000);
+  const memberCount = new Intl.NumberFormat().format(
+    !stats ? 60000 : stats?.total,
+  );
 
   // TODO get header height instead of magic number 56
   // const headerHeight = angular.element('#tr-header').height() || 0; // code of the original angular controller

--- a/modules/pages/client/components/Home.component.js
+++ b/modules/pages/client/components/Home.component.js
@@ -86,7 +86,7 @@ export default function Home({ user, isNativeMobileApp, photoCredits }) {
   const circleRoute = circleRouteParam || tribeRouteParam;
 
   // @TODO change this to be based on UI language rather than browser locale
-  const memberCount = new Intl.NumberFormat().format(59000);
+  const memberCount = new Intl.NumberFormat().format(60000);
 
   // TODO get header height instead of magic number 56
   // const headerHeight = angular.element('#tr-header').height() || 0; // code of the original angular controller


### PR DESCRIPTION
Number of members on the front page was hardcoded to 59K and got outdated as we crossed 60K.

#### Proposed Changes

Number of members on the page is now read from the stats and rounded down to the nearest 5000.

#### Testing Instructions

I tried to kind of test it locally with different hardcoded values, haven't tested api errors. No automated tests either. And this is my first ever javascript code written in IJ without JS plugin so give it some special care.

Fixes https://trustroots.slack.com/archives/C017CNA5UQY/p1627680505000500