### PR TITLE
Use place_name for US locations in location service

### DIFF
--- a/modules/core/client/services/location.client.service.js
+++ b/modules/core/client/services/location.client.service.js
@@ -208,6 +208,13 @@ function LocationService($log, $http, SettingsFactory) {
             title += ', ' + geolocation.context[i].text;
           } else if (geolocation.context[i].id.substring(0, 8) === 'country.') {
             title += ', ' + geolocation.context[i].text;
+            if (
+              geolocation.context[i].short_code === 'us' &&
+              geolocation.place_name
+            ) {
+              // override for US where we need region to disambiguate (e.g. Portland, Oregon & Portland, Maine)
+              title = geolocation.place_name;
+            }
           }
         }
       }


### PR DESCRIPTION
#### Proposed Changes

* use the mapbox place_name for US auto-complete suggestions

#### Testing Instructions

* Go to edit profile locations and type in the name of non-unique US city.

Fixes #2350
