### PR TITLE
add report member button to alert banner

### DIFF
--- a/modules/users/client/components/BlockedMemberBanner.component.js
+++ b/modules/users/client/components/BlockedMemberBanner.component.js
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import BlockMember from './BlockMember.component';
+import ReportMember from '@/modules/support/client/components/ReportMember.component.js';
 
 export default function BlockedMemberBanner({ username }) {
   const { t } = useTranslation('users');
@@ -17,6 +18,7 @@ export default function BlockedMemberBanner({ username }) {
       <p>
         {t('You have blocked this member.')}{' '}
         {t('They cannot see or message you.')}
+        <ReportMember username={username} className="btn btn-link" />
         <BlockMember isBlocked username={username} className="btn btn-link" />
       </p>
     </div>


### PR DESCRIPTION
#### Proposed Changes

* adds report member button into the blocked-user alert banner, as discussed in #2431
* modifies the pre-commit shell script to run in docker if the trustroots container is running (I don't have `prettier` installed on my host machine)

![option-to-report-in-banner](https://user-images.githubusercontent.com/305272/139318405-7845c726-599e-4a94-904e-f7cac0dbcc89.PNG)

