### PR TITLE
Eslint: fail on use of console only in prod, warn on dev

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,8 @@ const reactVersion = semver.coerce(
   require('./package.json').dependencies.react,
 ).version;
 
+const isDevelopment = process.env.NODE_ENV === 'development';
+
 const rules = {
   'comma-dangle': [2, 'always-multiline'],
   'comma-spacing': [2, { before: false, after: true }],
@@ -14,7 +16,7 @@ const rules = {
   'keyword-spacing': [2, { before: true, after: true }],
   'new-cap': [2, { newIsCapExceptions: ['acl.memoryBackend', 'acl'] }],
   'no-caller': 2,
-  'no-console': 2,
+  'no-console': isDevelopment ? 1 : 2,
   'no-duplicate-imports': 2,
   'no-multi-spaces': 2,
   'no-process-exit': 2,


### PR DESCRIPTION
#### Proposed Changes

* Fails Eslint only in CI / production when using `console.log`/`.warn`/`.error` etc without accompanying lint-ignore comment. Discussed in https://github.com/Trustroots/trustroots/pull/2454#discussion_r743189050

#### Testing Instructions

* Add console.log somewhere and it shouldn't fail your build locally when `npm start`
* Should fail when running `npm run start:prod`
* Try commit console.log and it should fail in PR in Github

