### PR TITLE
Roll back use-debounce update and add map test

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,8 @@ module.exports = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
     '^modules/(.*)$': '<rootDir>/modules/$1',
-    '^.+\\.(css|jpg|png|gif|webp|svg)$': '<rootDir>/jest/jest.empty-module.js',
+    '^.+\\.(css|jpg|png|gif|webp|svg|less)$':
+      '<rootDir>/jest/jest.empty-module.js',
   },
   testMatch: ['<rootDir>/modules/*/tests/client/**/*.tests.js'],
   testEnvironment: 'jsdom',

--- a/modules/search/tests/client/components/SearchMap.component.tests.js
+++ b/modules/search/tests/client/components/SearchMap.component.tests.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import '@/config/client/i18n';
+
+import SearchMap from '@/modules/search/client/components/SearchMap.component';
+// import * as tribesApi from '@/modules/tribes/client/api/tribes.api';
+
+// jest.mock('@/modules/tribes/client/api/tribes.api');
+// jest.mock('@/modules/core/client/services/angular-compat');
+
+describe('Search', () => {
+  it('Map loads', async () => {
+    render(
+      <SearchMap
+        filters="{}"
+        isUserPublic={true}
+        onOfferClose={() => {}}
+        onOfferOpen={() => {}}
+      />,
+    );
+  });
+});

--- a/modules/search/tests/client/components/SearchMap.component.tests.js
+++ b/modules/search/tests/client/components/SearchMap.component.tests.js
@@ -1,13 +1,8 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import '@/config/client/i18n';
 
 import SearchMap from '@/modules/search/client/components/SearchMap.component';
-// import * as tribesApi from '@/modules/tribes/client/api/tribes.api';
-
-// jest.mock('@/modules/tribes/client/api/tribes.api');
-// jest.mock('@/modules/core/client/services/angular-compat');
 
 describe('Search', () => {
   it('Map loads', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24465,7 +24465,7 @@
           }
         },
         "y18n": {
-          "version": "3.2.2",
+          "version": "3.2.1",
           "bundled": true,
           "dev": true
         },
@@ -32201,9 +32201,9 @@
       }
     },
     "use-debounce": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-7.0.1.tgz",
-      "integrity": "sha512-fOrzIw2wstbAJuv8PC9Vg4XgwyTLEOdq4y/Z3IhVl8DAE4svRcgyEUvrEXu+BMNgMoc3YND6qLT61kkgEKXh7Q=="
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-3.4.3.tgz",
+      "integrity": "sha512-nxy+opOxDccWfhMl36J5BSCTpvcj89iaQk2OZWLAtBJQj7ISCtx1gh+rFbdjGfMl6vtCZf6gke/kYvrkVfHMoA=="
     },
     "use-persisted-state": {
       "version": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
     "stopword": "1.0.11",
     "styled-components": "5.3.3",
     "ui-leaflet": "2.0.0",
-    "use-debounce": "7.0.1",
+    "use-debounce": "3.4.3",
     "use-persisted-state": "0.3.3",
     "uuid": "8.3.2",
     "validator": "13.7.0",


### PR DESCRIPTION
#### Proposed Changes
`use-debounce` was updated in https://github.com/Trustroots/trustroots/pull/2455 but it broke something.

* Rolls back to older version of `use-debounce`, this needs a bit more work as it currently breaks map search.
* Adds a basic "does it work?" test for the map search
* Adds support for importing `*.less` files in Jest

#### Testing Instructions

* CI, smoke-tested search

