### PR TITLE
Fixed the zoom buttons are off on maps #2423

### DIFF
--- a/modules/core/client/components/Map/map-navigation-control.less
+++ b/modules/core/client/components/Map/map-navigation-control.less
@@ -3,7 +3,7 @@
 
 .map-navigation-control-container {
   position: absolute;
-  right: 10px;
+  right: 45px;
   top: 10px;
   z-index: 5;
 


### PR DESCRIPTION
#### Proposed Changes

* Fixed the zoom buttons are off on maps 
* change in the css property  right to 45

#### Testing Instructions

*

Fixes #2423
