### PR TITLE
Add money clause to rules

### DIFF
--- a/modules/pages/client/components/RulesText.component.js
+++ b/modules/pages/client/components/RulesText.component.js
@@ -53,6 +53,11 @@ export default function RulesText() {
             'Be respectful of others and restrain from any kind of abusive behaviour.',
           )}
         </li>
+        <li>
+          {t(
+            "Our currency is hospitality: don't ask or accept any form of monetary exchange to use Trustroots.",
+          )}
+        </li>
       </ul>
 
       <p>


### PR DESCRIPTION
#### Proposed Changes

* Add a bit about money to our rules:
  
    > _"Our currency is hospitality: don't ask or accept any form of monetary exchange to use Trustroots."_

Part of https://github.com/Trustroots/trustroots/pull/1468#issuecomment-667358647