### PR TITLE
i18n: migrate from i18next-xhr-backend to i18next-http-backend

### DIFF
--- a/config/client/i18n.js
+++ b/config/client/i18n.js
@@ -1,5 +1,5 @@
 import { initReactI18next } from 'react-i18next';
-import Backend from 'i18next-xhr-backend';
+import HttpApi from 'i18next-http-backend';
 import i18n from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import moment from 'moment';
@@ -74,9 +74,9 @@ function format(value, format, languageCode) {
 }
 
 if (!isTest) {
-  // load translation using xhr -> see /public/locales
-  // learn more: https://github.com/i18next/i18next-xhr-backend
-  i18n.use(Backend);
+  // load translation using Fetch -> see /public/locales
+  // learn more: https://github.com/i18next/i18next-http-backend
+  i18n.use(HttpApi);
 }
 
 i18n

--- a/package-lock.json
+++ b/package-lock.json
@@ -6408,6 +6408,21 @@
         "luxon": "^1.26.0"
       }
     },
+    "cross-fetch": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
+      "requires": {
+        "node-fetch": "2.6.1"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+        }
+      }
+    },
     "cross-spawn": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
@@ -12226,12 +12241,12 @@
         "@babel/runtime": "^7.14.6"
       }
     },
-    "i18next-xhr-backend": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/i18next-xhr-backend/-/i18next-xhr-backend-3.2.2.tgz",
-      "integrity": "sha512-OtRf2Vo3IqAxsttQbpjYnmMML12IMB5e0fc5B7qKJFLScitYaXa1OhMX0n0X/3vrfFlpHL9Ro/H+ps4Ej2j7QQ==",
+    "i18next-http-backend": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-1.3.1.tgz",
+      "integrity": "sha512-o79n4GBBRpl20hByC+ne/S1UaSZ4iGAn59Hu2TEZGjN0WLB72L7WrM39Cshziyrssp6MQfdI8wjToU2Q6kpSvA==",
       "requires": {
-        "@babel/runtime": "^7.5.5"
+        "cross-fetch": "3.1.4"
       }
     },
     "iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "html-to-text": "8.1.0",
     "i18next": "20.3.2",
     "i18next-browser-languagedetector": "6.1.2",
-    "i18next-xhr-backend": "3.2.2",
+    "i18next-http-backend": "1.3.1",
     "imagesloaded": "4.1.4",
     "influx": "5.9.2",
     "juice": "8.0.0",


### PR DESCRIPTION
#### Proposed Changes

* Migrate from deprecated `i18next-xhr-backend` to `i18next-http-backend` — should be drop-in replacement.

#### Testing Instructions

* Smoke tested locally by changing language, worked fine.
