### PR TITLE
CI: ignore forks for Eslint task

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,10 @@ on:
 
 jobs:
   lint:
+    # Don't run inline ESlint test if PR is from a forked repo (i.e. it doesn't have read permission)
+    # See https://github.com/ataylorme/eslint-annotate-action/issues/28
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
#### Proposed Changes

* Add if clause to avoid running CI eslint task on PRs from forks.

Not sure if this is the way to go, or should I rather run the linter, but skip the inline-commenter.

#### Testing Instructions

* Not quite sure — we can merge and test, and revert if it doesn't work.

Fixes #
