### PR TITLE
Move away from require with path.resolve().

### DIFF
--- a/bin/admin/trshell.js
+++ b/bin/admin/trshell.js
@@ -3,7 +3,6 @@ process.chdir(__dirname);
 process.chdir('../../');
 
 var mongoose = require('mongoose');
-var path = require('path');
 var mongooseService = require('../../config/lib/mongoose');
 
 mongooseService.connect();

--- a/bin/admin/trshell.js
+++ b/bin/admin/trshell.js
@@ -4,7 +4,7 @@ process.chdir('../../');
 
 var mongoose = require('mongoose');
 var path = require('path');
-var mongooseService = require(path.resolve('config/lib/mongoose'));
+var mongooseService = require('../../config/lib/mongoose');
 
 mongooseService.connect();
 mongooseService.loadModels();

--- a/bin/db-maintenance/archive-done-agenda-jobs.js
+++ b/bin/db-maintenance/archive-done-agenda-jobs.js
@@ -16,7 +16,6 @@
  */
 
 const { MongoClient } = require('mongodb');
-const path = require('path');
 const chalk = require('chalk');
 const async = require('async');
 const config = require('../../config/config');

--- a/bin/db-maintenance/archive-done-agenda-jobs.js
+++ b/bin/db-maintenance/archive-done-agenda-jobs.js
@@ -19,7 +19,7 @@ const { MongoClient } = require('mongodb');
 const path = require('path');
 const chalk = require('chalk');
 const async = require('async');
-const config = require(path.resolve('./config/config'));
+const config = require('../../config/config');
 
 let dbClient;
 let sourceCollection;

--- a/bin/export-circle-members.js
+++ b/bin/export-circle-members.js
@@ -9,7 +9,6 @@
 
 const fs = require('fs');
 const mongoose = require('mongoose');
-const path = require('path');
 
 const mongooseService = require('../config/lib/mongoose');
 require('../config/lib/express');

--- a/bin/export-circle-members.js
+++ b/bin/export-circle-members.js
@@ -11,10 +11,10 @@ const fs = require('fs');
 const mongoose = require('mongoose');
 const path = require('path');
 
-const mongooseService = require(path.resolve('./config/lib/mongoose'));
-require(path.resolve('./config/lib/express'));
-require(path.resolve('./modules/users/server/models/user.server.model'));
-require(path.resolve('./modules/tribes/server/models/tribe.server.model'));
+const mongooseService = require('../config/lib/mongoose');
+require('../config/lib/express');
+require('../modules/users/server/models/user.server.model');
+require('../modules/tribes/server/models/tribe.server.model');
 
 // This is where CSV lines are generated
 // First line is the header

--- a/bin/fillTestData/Experiences.js
+++ b/bin/fillTestData/Experiences.js
@@ -3,13 +3,13 @@
  */
 const _ = require('lodash');
 const path = require('path');
-const mongooseService = require(path.resolve('./config/lib/mongoose'));
+const mongooseService = require('../../config/lib/mongoose');
 const chalk = require('chalk');
 const yargs = require('yargs');
 const faker = require('faker');
 const mongoose = require('mongoose');
 const queue = require('async/queue');
-const config = require(path.resolve('./config/config'));
+const config = require('../../config/config');
 const moment = require('moment');
 
 /**

--- a/bin/fillTestData/Experiences.js
+++ b/bin/fillTestData/Experiences.js
@@ -2,7 +2,6 @@
  * Required dependencies
  */
 const _ = require('lodash');
-const path = require('path');
 const mongooseService = require('../../config/lib/mongoose');
 const chalk = require('chalk');
 const yargs = require('yargs');

--- a/bin/fillTestData/Messages.js
+++ b/bin/fillTestData/Messages.js
@@ -3,12 +3,12 @@
  */
 const _ = require('lodash');
 const path = require('path');
-const mongooseService = require(path.resolve('./config/lib/mongoose'));
+const mongooseService = require('../../config/lib/mongoose');
 const chalk = require('chalk');
 const yargs = require('yargs');
 const faker = require('faker');
 const mongoose = require('mongoose');
-const config = require(path.resolve('./config/config'));
+const config = require('../../config/config');
 
 /**
  * Configure the script usage using yargs to obtain parameters and enforce usage.

--- a/bin/fillTestData/Messages.js
+++ b/bin/fillTestData/Messages.js
@@ -2,7 +2,6 @@
  * Required dependencies
  */
 const _ = require('lodash');
-const path = require('path');
 const mongooseService = require('../../config/lib/mongoose');
 const chalk = require('chalk');
 const yargs = require('yargs');

--- a/bin/fillTestData/Tribes.js
+++ b/bin/fillTestData/Tribes.js
@@ -3,12 +3,12 @@
  */
 const _ = require('lodash');
 const path = require('path');
-const mongooseService = require(path.resolve('./config/lib/mongoose'));
+const mongooseService = require('../../config/lib/mongoose');
 const chalk = require('chalk');
 const yargs = require('yargs');
 const faker = require('faker');
 const mongoose = require('mongoose');
-const config = require(path.resolve('./config/config'));
+const config = require('../../config/config');
 
 /**
  * Configure the script usage using yargs to obtain parameters and enforce usage.

--- a/bin/fillTestData/Tribes.js
+++ b/bin/fillTestData/Tribes.js
@@ -2,7 +2,6 @@
  * Required dependencies
  */
 const _ = require('lodash');
-const path = require('path');
 const mongooseService = require('../../config/lib/mongoose');
 const chalk = require('chalk');
 const yargs = require('yargs');

--- a/bin/fillTestData/Users.js
+++ b/bin/fillTestData/Users.js
@@ -3,17 +3,17 @@
  */
 const _ = require('lodash');
 const path = require('path');
-const mongooseService = require(path.resolve('./config/lib/mongoose'));
+const mongooseService = require('../../config/lib/mongoose');
 const chalk = require('chalk');
 const yargs = require('yargs');
 const faker = require('faker');
 const moment = require('moment');
 const mongoose = require('mongoose');
-const config = require(path.resolve('./config/config'));
-const cities = require(path.resolve('./bin/fillTestData/data/Cities.json'));
-const languages = require(path.resolve('./config/languages/languages.json'));
+const config = require('../../config/config');
+const cities = require('./data/Cities.json');
+const languages = require('../../config/languages/languages.json');
 
-require(path.resolve('./modules/offers/server/models/offer.server.model'));
+require('../../modules/offers/server/models/offer.server.model');
 
 /**
  * Configure the script usage using yargs to obtain parameters and enforce usage.

--- a/bin/fillTestData/Users.js
+++ b/bin/fillTestData/Users.js
@@ -2,7 +2,6 @@
  * Required dependencies
  */
 const _ = require('lodash');
-const path = require('path');
 const mongooseService = require('../../config/lib/mongoose');
 const chalk = require('chalk');
 const yargs = require('yargs');

--- a/config/assets/development.js
+++ b/config/assets/development.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const defaultAssets = require('./default');
 
 module.exports = defaultAssets;

--- a/config/assets/development.js
+++ b/config/assets/development.js
@@ -1,4 +1,4 @@
 const path = require('path');
-const defaultAssets = require(path.resolve('./config/assets/default'));
+const defaultAssets = require('./default');
 
 module.exports = defaultAssets;

--- a/config/assets/production.js
+++ b/config/assets/production.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const defaultAssets = require('./default');
 
 module.exports = defaultAssets;

--- a/config/assets/production.js
+++ b/config/assets/production.js
@@ -1,4 +1,4 @@
 const path = require('path');
-const defaultAssets = require(path.resolve('./config/assets/default'));
+const defaultAssets = require('./default');
 
 module.exports = defaultAssets;

--- a/config/assets/test.js
+++ b/config/assets/test.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const defaultAssets = require('./default');
 
 module.exports = defaultAssets;

--- a/config/assets/test.js
+++ b/config/assets/test.js
@@ -1,4 +1,4 @@
 const path = require('path');
-const defaultAssets = require(path.resolve('./config/assets/default'));
+const defaultAssets = require('./default');
 
 module.exports = defaultAssets;

--- a/config/lib/express.js
+++ b/config/lib/express.js
@@ -214,9 +214,7 @@ module.exports.initSession = function (app, connection) {
  * Wire in user last seen middleware
  */
 module.exports.initLastSeen = function (app) {
-  const lastSeenController = require(path.resolve(
-    './modules/users/server/controllers/users.lastseen.server.controller',
-  ));
+  const lastSeenController = require('../../modules/users/server/controllers/users.lastseen.server.controller');
   app.use(lastSeenController);
 };
 

--- a/config/lib/facebook-api.js
+++ b/config/lib/facebook-api.js
@@ -4,7 +4,7 @@
 const _ = require('lodash');
 const fbgraph = require('fbgraph');
 const path = require('path');
-const config = require(path.resolve('./config/config'));
+const config = require('../config');
 
 // Config vars
 // You can modify these from your `config/local.js`

--- a/config/lib/facebook-api.js
+++ b/config/lib/facebook-api.js
@@ -3,7 +3,6 @@
  */
 const _ = require('lodash');
 const fbgraph = require('fbgraph');
-const path = require('path');
 const config = require('../config');
 
 // Config vars

--- a/config/lib/firebase-messaging.js
+++ b/config/lib/firebase-messaging.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const firebase = require('firebase-admin');
 const config = require('../config');
 const serviceAccount = config.fcm.serviceAccount;

--- a/config/lib/firebase-messaging.js
+++ b/config/lib/firebase-messaging.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const firebase = require('firebase-admin');
-const config = require(path.resolve('./config/config'));
+const config = require('../config');
 const serviceAccount = config.fcm.serviceAccount;
 
 if (serviceAccount) {

--- a/config/lib/logger.js
+++ b/config/lib/logger.js
@@ -7,7 +7,6 @@
 /**
  * Module dependencies.
  */
-const path = require('path');
 const _ = require('lodash');
 const winston = require('winston');
 const config = require('../config');

--- a/config/lib/logger.js
+++ b/config/lib/logger.js
@@ -10,7 +10,7 @@
 const path = require('path');
 const _ = require('lodash');
 const winston = require('winston');
-const config = require(path.resolve('./config/config'));
+const config = require('../config');
 
 // Requiring `winston-papertrail` will expose
 // `winston.transports.Papertrail`

--- a/config/lib/mongoose.js
+++ b/config/lib/mongoose.js
@@ -94,7 +94,7 @@ module.exports.connect = function (callback) {
           return done();
         }
 
-        const engines = require(path.resolve('./package.json')).engines;
+        const engines = require('../../package.json').engines;
         const admin = new mongoose.mongo.Admin(mongoose.connection.db);
         admin.buildInfo(function (err, info) {
           log('info', 'MongoDB', {

--- a/config/lib/worker.js
+++ b/config/lib/worker.js
@@ -1,16 +1,14 @@
 const path = require('path');
 const config = require('../config');
 const format = require('util').format;
-const statService = require(path.resolve(
-  './modules/stats/server/services/stats.server.service',
-));
+const statService = require('../../modules/stats/server/services/stats.server.service');
 const MongoClient = require('mongodb').MongoClient;
 
 let agenda;
 
 exports.start = function (options, callback) {
   // Don't initialise Agenda outisde `start()`, because we might miss `ready` event otherwise.
-  agenda = require(path.resolve('./config/lib/agenda'));
+  agenda = require('./agenda');
 
   agenda.on('ready', function () {
     // Define jobs
@@ -18,79 +16,61 @@ exports.start = function (options, callback) {
     agenda.define(
       'send email',
       { priority: 'high', concurrency: 10 },
-      require(path.resolve('./modules/core/server/jobs/send-email.server.job')),
+      require('../../modules/core/server/jobs/send-email.server.job'),
     );
 
     agenda.define(
       'send push message',
       { priority: 'high', concurrency: 10 },
-      require(path.resolve(
-        './modules/core/server/jobs/send-push-message.server.job',
-      )),
+      require('../../modules/core/server/jobs/send-push-message.server.job'),
     );
 
     agenda.define(
       'check unread messages',
       { lockLifetime: 10000 },
-      require(path.resolve(
-        './modules/messages/server/jobs/message-unread.server.job',
-      )),
+      require('../../modules/messages/server/jobs/message-unread.server.job'),
     );
 
     agenda.define(
       'daily statistics',
       { lockLifetime: 10000, concurrency: 1 },
-      require(path.resolve(
-        './modules/statistics/server/jobs/daily-statistics.server.job',
-      )),
+      require('../../modules/statistics/server/jobs/daily-statistics.server.job'),
     );
 
     agenda.define(
       'send signup reminders',
       { lockLifetime: 10000, concurrency: 1 },
-      require(path.resolve(
-        './modules/users/server/jobs/user-finish-signup.server.job',
-      )),
+      require('../../modules/users/server/jobs/user-finish-signup.server.job'),
     );
 
     agenda.define(
       'reactivate hosts',
       { lockLifetime: 10000, concurrency: 1 },
-      require(path.resolve(
-        './modules/offers/server/jobs/reactivate-hosts.server.job',
-      )),
+      require('../../modules/offers/server/jobs/reactivate-hosts.server.job'),
     );
 
     agenda.define(
       'welcome sequence first',
       { lockLifetime: 10000, concurrency: 1 },
-      require(path.resolve(
-        './modules/users/server/jobs/user-welcome-sequence-first.server.job',
-      )),
+      require('../../modules/users/server/jobs/user-welcome-sequence-first.server.job'),
     );
 
     agenda.define(
       'welcome sequence second',
       { lockLifetime: 10000, concurrency: 1 },
-      require(path.resolve(
-        './modules/users/server/jobs/user-welcome-sequence-second.server.job',
-      )),
+      require('../../modules/users/server/jobs/user-welcome-sequence-second.server.job'),
     );
 
     agenda.define(
       'welcome sequence third',
       { lockLifetime: 10000, concurrency: 1 },
-      require(path.resolve(
-        './modules/users/server/jobs/user-welcome-sequence-third.server.job',
-      )),
+      require('../../modules/users/server/jobs/user-welcome-sequence-third.server.job'),
     );
 
     agenda.define(
       'publish expired experiences',
       { lockLifetime: 10000, concurrency: 1 },
-      require(path.resolve(
-        './modules/experiences/server/jobs/experiences-publish.server.job',
-      )),
+      require('../../modules/experiences/server/jobs/experiences-publish.server.job'),
     );
 
     // Schedule job(s)

--- a/config/lib/worker.js
+++ b/config/lib/worker.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const config = require('../config');
 const format = require('util').format;
 const statService = require('../../modules/stats/server/services/stats.server.service');

--- a/migrations/archived/1420751949-add-user-avatarUploaded.js
+++ b/migrations/archived/1420751949-add-user-avatarUploaded.js
@@ -3,7 +3,6 @@
  * Determines if avatars exist at users upload folder
  */
 
-const path = require('path');
 const mongooseService = require('../../config/lib/mongoose');
 const chalk = require('chalk');
 const mongoose = require('mongoose');

--- a/migrations/archived/1420751949-add-user-avatarUploaded.js
+++ b/migrations/archived/1420751949-add-user-avatarUploaded.js
@@ -4,11 +4,11 @@
  */
 
 const path = require('path');
-const mongooseService = require(path.resolve('./config/lib/mongoose'));
+const mongooseService = require('../../config/lib/mongoose');
 const chalk = require('chalk');
 const mongoose = require('mongoose');
 // eslint-disable-next-line no-unused-vars
-const userModels = require(path.resolve('./modules/users/server/models/user.server.model'));
+const userModels = require('../../modules/users/server/models/user.server.model');
 const User = mongoose.model('User');
 
 exports.up = function (next) {

--- a/migrations/archived/1429124257492-add-user-displayUsername.js
+++ b/migrations/archived/1429124257492-add-user-displayUsername.js
@@ -2,7 +2,6 @@
  * Updates model with displayUsername field
  */
 
-const path = require('path');
 const mongooseService = require('../../config/lib/mongoose');
 const chalk = require('chalk');
 const mongoose = require('mongoose');

--- a/migrations/archived/1429124257492-add-user-displayUsername.js
+++ b/migrations/archived/1429124257492-add-user-displayUsername.js
@@ -3,11 +3,11 @@
  */
 
 const path = require('path');
-const mongooseService = require(path.resolve('./config/lib/mongoose'));
+const mongooseService = require('../../config/lib/mongoose');
 const chalk = require('chalk');
 const mongoose = require('mongoose');
 // eslint-disable-next-line no-unused-vars
-const userModels = require(path.resolve('./modules/users/server/models/user.server.model'));
+const userModels = require('../../modules/users/server/models/user.server.model');
 const User = mongoose.model('User');
 
 exports.up = function (next) {

--- a/migrations/archived/1429617907153-update-user-avatarSource.js
+++ b/migrations/archived/1429617907153-update-user-avatarSource.js
@@ -3,11 +3,11 @@
  */
 
 const path = require('path');
-const mongooseService = require(path.resolve('./config/lib/mongoose'));
+const mongooseService = require('../../config/lib/mongoose');
 const chalk = require('chalk');
 const mongoose = require('mongoose');
 // eslint-disable-next-line no-unused-vars
-const userModels = require(path.resolve('./modules/users/server/models/user.server.model'));
+const userModels = require('../../modules/users/server/models/user.server.model');
 const User = mongoose.model('User');
 
 exports.up = function (next) {

--- a/migrations/archived/1429617907153-update-user-avatarSource.js
+++ b/migrations/archived/1429617907153-update-user-avatarSource.js
@@ -2,7 +2,6 @@
  * Replaces "locale" with "local" from User.avatarSource
  */
 
-const path = require('path');
 const mongooseService = require('../../config/lib/mongoose');
 const chalk = require('chalk');
 const mongoose = require('mongoose');

--- a/migrations/archived/1479386133911-refactor-contacts.js
+++ b/migrations/archived/1479386133911-refactor-contacts.js
@@ -4,13 +4,13 @@
 
 const path = require('path');
 const async = require('async');
-const mongooseService = require(path.resolve('./config/lib/mongoose'));
+const mongooseService = require('../../config/lib/mongoose');
 const mongoose = require('mongoose');
 const chalk = require('chalk');
 // userModels = require(path.resolve('./modules/users/server/models/user.server.model')),
 // User = mongoose.model('User'),
 // eslint-disable-next-line no-unused-vars
-const contactModels = require(path.resolve('./modules/contacts/server/models/contacts.server.model'));
+const contactModels = require('../../modules/contacts/server/models/contacts.server.model');
 const Contact = mongoose.model('Contact');
 
 exports.up = function (next) {

--- a/migrations/archived/1479386133911-refactor-contacts.js
+++ b/migrations/archived/1479386133911-refactor-contacts.js
@@ -2,7 +2,6 @@
  * Refactors `users` array to `userTo` and `userFrom` keys from Contact collection
  */
 
-const path = require('path');
 const async = require('async');
 const mongooseService = require('../../config/lib/mongoose');
 const mongoose = require('mongoose');

--- a/migrations/archived/1479386133912-refactor-messages.js
+++ b/migrations/archived/1479386133912-refactor-messages.js
@@ -11,12 +11,12 @@
 
 const path = require('path');
 const async = require('async');
-const mongooseService = require(path.resolve('./config/lib/mongoose'));
+const mongooseService = require('../../config/lib/mongoose');
 const mongoose = require('mongoose');
 const chalk = require('chalk');
-const config = require(path.resolve('./config/config'));
+const config = require('../../config/config');
 // eslint-disable-next-line no-unused-vars
-const messageModels = require(path.resolve('./modules/messages/server/models/message.server.model'));
+const messageModels = require('../../modules/messages/server/models/message.server.model');
 const Message = mongoose.model('Message');
 
 // define Promises for mongoose

--- a/migrations/archived/1479386133912-refactor-messages.js
+++ b/migrations/archived/1479386133912-refactor-messages.js
@@ -9,7 +9,6 @@
  * notifications configured in config/env/default.js.limits.unreadMessageReminders
  */
 
-const path = require('path');
 const async = require('async');
 const mongooseService = require('../../config/lib/mongoose');
 const mongoose = require('mongoose');

--- a/migrations/archived/1526109429319-tags-to-tribes.js
+++ b/migrations/archived/1526109429319-tags-to-tribes.js
@@ -7,13 +7,13 @@
 const path = require('path');
 const async = require('async');
 const chalk = require('chalk');
-const mongooseService = require(path.resolve('./config/lib/mongoose'));
+const mongooseService = require('../../config/lib/mongoose');
 const mongoose = require('mongoose');
 // eslint-disable-next-line no-unused-vars
-const tribeModels = require(path.resolve('./modules/tribes/server/models/tribe.server.model'));
+const tribeModels = require('../../modules/tribes/server/models/tribe.server.model');
 const Tribe = mongoose.model('Tribe');
 // eslint-disable-next-line no-unused-vars
-const userModels = require(path.resolve('./modules/users/server/models/user.server.model'));
+const userModels = require('../../modules/users/server/models/user.server.model');
 const User = mongoose.model('User');
 
 exports.up = function (next) {

--- a/migrations/archived/1526109429319-tags-to-tribes.js
+++ b/migrations/archived/1526109429319-tags-to-tribes.js
@@ -4,7 +4,6 @@
  * - Removes `tribe` keys
  */
 
-const path = require('path');
 const async = require('async');
 const chalk = require('chalk');
 const mongooseService = require('../../config/lib/mongoose');

--- a/modules/admin/server/controllers/admin.audit-log.server.controller.js
+++ b/modules/admin/server/controllers/admin.audit-log.server.controller.js
@@ -1,7 +1,6 @@
 /**
  * Module dependencies.
  */
-const path = require('path');
 const errorService = require('../../../core/server/services/error.server.service');
 const log = require('../../../../config/lib/logger');
 const mongoose = require('mongoose');

--- a/modules/admin/server/controllers/admin.audit-log.server.controller.js
+++ b/modules/admin/server/controllers/admin.audit-log.server.controller.js
@@ -2,10 +2,8 @@
  * Module dependencies.
  */
 const path = require('path');
-const errorService = require(path.resolve(
-  './modules/core/server/services/error.server.service',
-));
-const log = require(path.resolve('./config/lib/logger'));
+const errorService = require('../../../core/server/services/error.server.service');
+const log = require('../../../../config/lib/logger');
 const mongoose = require('mongoose');
 
 const AuditLog = mongoose.model('AuditLog');

--- a/modules/admin/server/controllers/admin.messages.server.controller.js
+++ b/modules/admin/server/controllers/admin.messages.server.controller.js
@@ -2,7 +2,6 @@
  * Module dependencies.
  */
 const _ = require('lodash');
-const path = require('path');
 const errorService = require('../../../core/server/services/error.server.service');
 const mongoose = require('mongoose');
 const Message = mongoose.model('Message');

--- a/modules/admin/server/controllers/admin.messages.server.controller.js
+++ b/modules/admin/server/controllers/admin.messages.server.controller.js
@@ -3,14 +3,10 @@
  */
 const _ = require('lodash');
 const path = require('path');
-const errorService = require(path.resolve(
-  './modules/core/server/services/error.server.service',
-));
+const errorService = require('../../../core/server/services/error.server.service');
 const mongoose = require('mongoose');
 const Message = mongoose.model('Message');
-const MessagesController = require(path.resolve(
-  'modules/messages/server/controllers/messages.server.controller.js',
-));
+const MessagesController = require('../../../messages/server/controllers/messages.server.controller.js');
 
 /*
  * This middleware sends response with an array of found users

--- a/modules/admin/server/controllers/admin.newsletter.server.controller.js
+++ b/modules/admin/server/controllers/admin.newsletter.server.controller.js
@@ -2,7 +2,6 @@
  * Module dependencies.
  */
 const mongoose = require('mongoose');
-const path = require('path');
 
 const errorService = require('../../../core/server/services/error.server.service');
 

--- a/modules/admin/server/controllers/admin.newsletter.server.controller.js
+++ b/modules/admin/server/controllers/admin.newsletter.server.controller.js
@@ -4,9 +4,7 @@
 const mongoose = require('mongoose');
 const path = require('path');
 
-const errorService = require(path.resolve(
-  './modules/core/server/services/error.server.service',
-));
+const errorService = require('../../../core/server/services/error.server.service');
 
 const User = mongoose.model('User');
 

--- a/modules/admin/server/controllers/admin.notes.server.controller.js
+++ b/modules/admin/server/controllers/admin.notes.server.controller.js
@@ -2,7 +2,6 @@
  * Module dependencies.
  */
 const _ = require('lodash');
-const path = require('path');
 const errorService = require('../../../core/server/services/error.server.service');
 const textService = require('../../../core/server/services/text.server.service');
 const sanitizeHtml = require('sanitize-html');

--- a/modules/admin/server/controllers/admin.notes.server.controller.js
+++ b/modules/admin/server/controllers/admin.notes.server.controller.js
@@ -3,12 +3,8 @@
  */
 const _ = require('lodash');
 const path = require('path');
-const errorService = require(path.resolve(
-  './modules/core/server/services/error.server.service',
-));
-const textService = require(path.resolve(
-  './modules/core/server/services/text.server.service',
-));
+const errorService = require('../../../core/server/services/error.server.service');
+const textService = require('../../../core/server/services/text.server.service');
 const sanitizeHtml = require('sanitize-html');
 const mongoose = require('mongoose');
 const AdminNote = mongoose.model('AdminNote');

--- a/modules/admin/server/controllers/admin.threads.server.controller.js
+++ b/modules/admin/server/controllers/admin.threads.server.controller.js
@@ -2,7 +2,6 @@
  * Module dependencies.
  */
 const _ = require('lodash');
-const path = require('path');
 const errorService = require('../../../core/server/services/error.server.service');
 const mongoose = require('mongoose');
 const Thread = mongoose.model('Thread');

--- a/modules/admin/server/controllers/admin.threads.server.controller.js
+++ b/modules/admin/server/controllers/admin.threads.server.controller.js
@@ -3,9 +3,7 @@
  */
 const _ = require('lodash');
 const path = require('path');
-const errorService = require(path.resolve(
-  './modules/core/server/services/error.server.service',
-));
+const errorService = require('../../../core/server/services/error.server.service');
 const mongoose = require('mongoose');
 const Thread = mongoose.model('Thread');
 

--- a/modules/admin/server/controllers/admin.users.server.controller.js
+++ b/modules/admin/server/controllers/admin.users.server.controller.js
@@ -5,10 +5,8 @@ const _ = require('lodash');
 const mongoose = require('mongoose');
 const path = require('path');
 
-const errorService = require(path.resolve(
-  './modules/core/server/services/error.server.service',
-));
-const log = require(path.resolve('./config/lib/logger'));
+const errorService = require('../../../core/server/services/error.server.service');
+const log = require('../../../../config/lib/logger');
 
 const AdminNote = mongoose.model('AdminNote');
 const Contact = mongoose.model('Contact');

--- a/modules/admin/server/controllers/admin.users.server.controller.js
+++ b/modules/admin/server/controllers/admin.users.server.controller.js
@@ -3,7 +3,6 @@
  */
 const _ = require('lodash');
 const mongoose = require('mongoose');
-const path = require('path');
 
 const errorService = require('../../../core/server/services/error.server.service');
 const log = require('../../../../config/lib/logger');

--- a/modules/admin/server/models/admin-note.server.model.js
+++ b/modules/admin/server/models/admin-note.server.model.js
@@ -3,9 +3,7 @@ const mongoose = require('mongoose');
 const path = require('path');
 
 // Internal dependencies
-const textService = require(path.resolve(
-  './modules/core/server/services/text.server.service',
-));
+const textService = require('../../../core/server/services/text.server.service');
 
 const { Schema } = mongoose;
 

--- a/modules/admin/server/models/admin-note.server.model.js
+++ b/modules/admin/server/models/admin-note.server.model.js
@@ -1,6 +1,5 @@
 // External dependencies
 const mongoose = require('mongoose');
-const path = require('path');
 
 // Internal dependencies
 const textService = require('../../../core/server/services/text.server.service');

--- a/modules/admin/server/policies/admin.server.policy.js
+++ b/modules/admin/server/policies/admin.server.policy.js
@@ -4,9 +4,7 @@
 const acl = require('acl');
 const _ = require('lodash');
 const path = require('path');
-const errorService = require(path.resolve(
-  './modules/core/server/services/error.server.service',
-));
+const errorService = require('../../../core/server/services/error.server.service');
 
 // Using the memory backend
 const aclInstance = new acl(new acl.memoryBackend());

--- a/modules/admin/server/policies/admin.server.policy.js
+++ b/modules/admin/server/policies/admin.server.policy.js
@@ -3,7 +3,6 @@
  */
 const acl = require('acl');
 const _ = require('lodash');
-const path = require('path');
 const errorService = require('../../../core/server/services/error.server.service');
 
 // Using the memory backend

--- a/modules/admin/tests/server/admin.acquisition-stories.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.acquisition-stories.server.routes.tests.js
@@ -1,5 +1,4 @@
 const mongoose = require('mongoose');
-const path = require('path');
 const request = require('supertest');
 const express = require('../../../../config/lib/express');
 const utils = require('../../../../testutils/server/data.server.testutil');

--- a/modules/admin/tests/server/admin.acquisition-stories.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.acquisition-stories.server.routes.tests.js
@@ -1,8 +1,8 @@
 const mongoose = require('mongoose');
 const path = require('path');
 const request = require('supertest');
-const express = require(path.resolve('./config/lib/express'));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const express = require('../../../../config/lib/express');
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 describe('Admin acquisition stories CRUD tests', () => {
   // Get application

--- a/modules/admin/tests/server/admin.audit-log.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.audit-log.server.routes.tests.js
@@ -1,8 +1,8 @@
 const request = require('supertest');
 const path = require('path');
 const mongoose = require('mongoose');
-const express = require(path.resolve('./config/lib/express'));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const express = require('../../../../config/lib/express');
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 describe('Admin Audit Log CRUD tests', () => {
   // Get application

--- a/modules/admin/tests/server/admin.audit-log.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.audit-log.server.routes.tests.js
@@ -1,5 +1,4 @@
 const request = require('supertest');
-const path = require('path');
 const mongoose = require('mongoose');
 const express = require('../../../../config/lib/express');
 const utils = require('../../../../testutils/server/data.server.testutil');

--- a/modules/admin/tests/server/admin.messages.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.messages.server.routes.tests.js
@@ -1,5 +1,4 @@
 const request = require('supertest');
-const path = require('path');
 const mongoose = require('mongoose');
 const Message = mongoose.model('Message');
 const User = mongoose.model('User');

--- a/modules/admin/tests/server/admin.messages.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.messages.server.routes.tests.js
@@ -3,8 +3,8 @@ const path = require('path');
 const mongoose = require('mongoose');
 const Message = mongoose.model('Message');
 const User = mongoose.model('User');
-const express = require(path.resolve('./config/lib/express'));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const express = require('../../../../config/lib/express');
+const utils = require('../../../../testutils/server/data.server.testutil');
 require('should');
 
 /**

--- a/modules/admin/tests/server/admin.newsletter.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.newsletter.server.routes.tests.js
@@ -2,8 +2,8 @@ const request = require('supertest');
 const path = require('path');
 const mongoose = require('mongoose');
 
-const express = require(path.resolve('./config/lib/express'));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const express = require('../../../../config/lib/express');
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 describe('Admin Newsletter subscribers CRUD tests', () => {
   // Get application

--- a/modules/admin/tests/server/admin.newsletter.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.newsletter.server.routes.tests.js
@@ -1,5 +1,4 @@
 const request = require('supertest');
-const path = require('path');
 const mongoose = require('mongoose');
 
 const express = require('../../../../config/lib/express');

--- a/modules/admin/tests/server/admin.notes.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.notes.server.routes.tests.js
@@ -1,8 +1,8 @@
 const request = require('supertest');
 const path = require('path');
 const mongoose = require('mongoose');
-const express = require(path.resolve('./config/lib/express'));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const express = require('../../../../config/lib/express');
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 const AdminNote = mongoose.model('AdminNote');
 

--- a/modules/admin/tests/server/admin.notes.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.notes.server.routes.tests.js
@@ -1,5 +1,4 @@
 const request = require('supertest');
-const path = require('path');
 const mongoose = require('mongoose');
 const express = require('../../../../config/lib/express');
 const utils = require('../../../../testutils/server/data.server.testutil');

--- a/modules/admin/tests/server/admin.reference-threads.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.reference-threads.server.routes.tests.js
@@ -3,8 +3,8 @@ const path = require('path');
 const mongoose = require('mongoose');
 require('should');
 
-const express = require(path.resolve('./config/lib/express'));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const express = require('../../../../config/lib/express');
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 const ReferenceThread = mongoose.model('ReferenceThread');
 

--- a/modules/admin/tests/server/admin.reference-threads.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.reference-threads.server.routes.tests.js
@@ -1,5 +1,4 @@
 const request = require('supertest');
-const path = require('path');
 const mongoose = require('mongoose');
 require('should');
 

--- a/modules/admin/tests/server/admin.threads.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.threads.server.routes.tests.js
@@ -1,5 +1,4 @@
 const request = require('supertest');
-const path = require('path');
 const mongoose = require('mongoose');
 const Thread = mongoose.model('Thread');
 const express = require('../../../../config/lib/express');

--- a/modules/admin/tests/server/admin.threads.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.threads.server.routes.tests.js
@@ -2,8 +2,8 @@ const request = require('supertest');
 const path = require('path');
 const mongoose = require('mongoose');
 const Thread = mongoose.model('Thread');
-const express = require(path.resolve('./config/lib/express'));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const express = require('../../../../config/lib/express');
+const utils = require('../../../../testutils/server/data.server.testutil');
 require('should');
 
 describe('Admin Thread CRUD tests', () => {

--- a/modules/admin/tests/server/admin.users.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.users.server.routes.tests.js
@@ -1,5 +1,4 @@
 const mongoose = require('mongoose');
-const path = require('path');
 const request = require('supertest');
 const should = require('should');
 

--- a/modules/admin/tests/server/admin.users.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.users.server.routes.tests.js
@@ -3,8 +3,8 @@ const path = require('path');
 const request = require('supertest');
 const should = require('should');
 
-const express = require(path.resolve('./config/lib/express'));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const express = require('../../../../config/lib/express');
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');
 

--- a/modules/contacts/server/controllers/contacts.server.controller.js
+++ b/modules/contacts/server/controllers/contacts.server.controller.js
@@ -4,18 +4,10 @@
 
 const _ = require('lodash');
 const path = require('path');
-const errorService = require(path.resolve(
-  './modules/core/server/services/error.server.service',
-));
-const textService = require(path.resolve(
-  './modules/core/server/services/text.server.service',
-));
-const emailService = require(path.resolve(
-  './modules/core/server/services/email.server.service',
-));
-const userProfile = require(path.resolve(
-  './modules/users/server/controllers/users.profile.server.controller',
-));
+const errorService = require('../../../core/server/services/error.server.service');
+const textService = require('../../../core/server/services/text.server.service');
+const emailService = require('../../../core/server/services/email.server.service');
+const userProfile = require('../../../users/server/controllers/users.profile.server.controller');
 const sanitizeHtml = require('sanitize-html');
 const htmlToText = require('html-to-text');
 const async = require('async');

--- a/modules/contacts/server/controllers/contacts.server.controller.js
+++ b/modules/contacts/server/controllers/contacts.server.controller.js
@@ -3,7 +3,6 @@
  */
 
 const _ = require('lodash');
-const path = require('path');
 const errorService = require('../../../core/server/services/error.server.service');
 const textService = require('../../../core/server/services/text.server.service');
 const emailService = require('../../../core/server/services/email.server.service');

--- a/modules/contacts/server/policies/contacts.server.policy.js
+++ b/modules/contacts/server/policies/contacts.server.policy.js
@@ -2,7 +2,6 @@
  * Module dependencies.
  */
 let acl = require('acl');
-const path = require('path');
 const errorService = require('../../../core/server/services/error.server.service');
 
 // Using the memory backend

--- a/modules/contacts/server/policies/contacts.server.policy.js
+++ b/modules/contacts/server/policies/contacts.server.policy.js
@@ -3,9 +3,7 @@
  */
 let acl = require('acl');
 const path = require('path');
-const errorService = require(path.resolve(
-  './modules/core/server/services/error.server.service',
-));
+const errorService = require('../../../core/server/services/error.server.service');
 
 // Using the memory backend
 acl = new acl(new acl.memoryBackend());

--- a/modules/contacts/tests/server/contact.server.model.tests.js
+++ b/modules/contacts/tests/server/contact.server.model.tests.js
@@ -4,7 +4,7 @@
 const should = require('should');
 const mongoose = require('mongoose');
 const path = require('path');
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');
 const Contact = mongoose.model('Contact');

--- a/modules/contacts/tests/server/contact.server.model.tests.js
+++ b/modules/contacts/tests/server/contact.server.model.tests.js
@@ -3,7 +3,6 @@
  */
 const should = require('should');
 const mongoose = require('mongoose');
-const path = require('path');
 const utils = require('../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');

--- a/modules/contacts/tests/server/contact.server.routes.tests.js
+++ b/modules/contacts/tests/server/contact.server.routes.tests.js
@@ -2,10 +2,10 @@ const should = require('should');
 const request = require('supertest');
 const path = require('path');
 const mongoose = require('mongoose');
-const express = require(path.resolve('./config/lib/express'));
-const agenda = require(path.resolve('./config/lib/agenda'));
-const testutils = require(path.resolve('./testutils/server/server.testutil'));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const express = require('../../../../config/lib/express');
+const agenda = require('../../../../config/lib/agenda');
+const testutils = require('../../../../testutils/server/server.testutil');
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');
 const Contact = mongoose.model('Contact');

--- a/modules/contacts/tests/server/contact.server.routes.tests.js
+++ b/modules/contacts/tests/server/contact.server.routes.tests.js
@@ -1,6 +1,5 @@
 const should = require('should');
 const request = require('supertest');
-const path = require('path');
 const mongoose = require('mongoose');
 const express = require('../../../../config/lib/express');
 const agenda = require('../../../../config/lib/agenda');

--- a/modules/core/server/controllers/analytics.server.controller.js
+++ b/modules/core/server/controllers/analytics.server.controller.js
@@ -2,7 +2,6 @@
  * Module dependencies.
  */
 const url = require('url');
-const path = require('path');
 const log = require('../../../../config/lib/logger');
 
 /**

--- a/modules/core/server/controllers/analytics.server.controller.js
+++ b/modules/core/server/controllers/analytics.server.controller.js
@@ -3,7 +3,7 @@
  */
 const url = require('url');
 const path = require('path');
-const log = require(path.resolve('./config/lib/logger'));
+const log = require('../../../../config/lib/logger');
 
 /**
  * Append UTM parameters to URL for Analytics

--- a/modules/core/server/controllers/core.server.controller.js
+++ b/modules/core/server/controllers/core.server.controller.js
@@ -1,19 +1,11 @@
 const path = require('path');
 const errorService = require('../services/error.server.service');
-const userProfile = require(path.resolve(
-  './modules/users/server/controllers/users.profile.server.controller',
-));
-const textService = require(path.resolve(
-  './modules/core/server/services/text.server.service',
-));
-const config = require(path.resolve('./config/config'));
-const log = require(path.resolve('./config/lib/logger'));
-const languagesObject = require(path.resolve(
-  'config/languages/languages.json',
-));
-const languagesArray = require(path.resolve(
-  'config/languages/languages-array.json',
-));
+const userProfile = require('../../../users/server/controllers/users.profile.server.controller');
+const textService = require('../services/text.server.service');
+const config = require('../../../../config/config');
+const log = require('../../../../config/lib/logger');
+const languagesObject = require('../../../../config/languages/languages.json');
+const languagesArray = require('../../../../config/languages/languages-array.json');
 
 /**
  * Render the main application page

--- a/modules/core/server/controllers/core.server.controller.js
+++ b/modules/core/server/controllers/core.server.controller.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const errorService = require('../services/error.server.service');
 const userProfile = require('../../../users/server/controllers/users.profile.server.controller');
 const textService = require('../services/text.server.service');

--- a/modules/core/server/jobs/send-email.server.job.js
+++ b/modules/core/server/jobs/send-email.server.job.js
@@ -1,6 +1,5 @@
 const _ = require('lodash');
 const nodemailer = require('nodemailer');
-const path = require('path');
 const config = require('../../../../config/config');
 const log = require('../../../../config/lib/logger');
 

--- a/modules/core/server/jobs/send-email.server.job.js
+++ b/modules/core/server/jobs/send-email.server.job.js
@@ -1,8 +1,8 @@
 const _ = require('lodash');
 const nodemailer = require('nodemailer');
 const path = require('path');
-const config = require(path.resolve('./config/config'));
-const log = require(path.resolve('./config/lib/logger'));
+const config = require('../../../../config/config');
+const log = require('../../../../config/lib/logger');
 
 module.exports = function (job, done) {
   const smtpTransport = nodemailer.createTransport(config.mailer.options);

--- a/modules/core/server/jobs/send-push-message.server.job.js
+++ b/modules/core/server/jobs/send-push-message.server.job.js
@@ -1,14 +1,10 @@
 const path = require('path');
 const async = require('async');
-const firebaseMessaging = require(path.resolve(
-  './config/lib/firebase-messaging',
-));
-const exponentNotifications = require(path.resolve(
-  './config/lib/exponent-notifications',
-));
+const firebaseMessaging = require('../../../../config/lib/firebase-messaging');
+const exponentNotifications = require('../../../../config/lib/exponent-notifications');
 const mongoose = require('mongoose');
 const User = mongoose.model('User');
-const log = require(path.resolve('./config/lib/logger'));
+const log = require('../../../../config/lib/logger');
 
 const UNREGISTERED_TOKEN_ERROR_CODE =
   'messaging/registration-token-not-registered';

--- a/modules/core/server/jobs/send-push-message.server.job.js
+++ b/modules/core/server/jobs/send-push-message.server.job.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const async = require('async');
 const firebaseMessaging = require('../../../../config/lib/firebase-messaging');
 const exponentNotifications = require('../../../../config/lib/exponent-notifications');

--- a/modules/core/server/routes/core.server.routes.js
+++ b/modules/core/server/routes/core.server.routes.js
@@ -4,9 +4,7 @@
 const _ = require('lodash');
 const path = require('path');
 const core = require('../controllers/core.server.controller');
-const tribes = require(path.resolve(
-  './modules/tribes/server/controllers/tribes.server.controller',
-));
+const tribes = require('../../../tribes/server/controllers/tribes.server.controller');
 
 module.exports = function (app) {
   const redirect = function (src, dst) {

--- a/modules/core/server/routes/core.server.routes.js
+++ b/modules/core/server/routes/core.server.routes.js
@@ -2,7 +2,6 @@
  * Module dependencies.
  */
 const _ = require('lodash');
-const path = require('path');
 const core = require('../controllers/core.server.controller');
 const tribes = require('../../../tribes/server/controllers/tribes.server.controller');
 

--- a/modules/core/server/services/email.server.service.js
+++ b/modules/core/server/services/email.server.service.js
@@ -7,16 +7,12 @@ const async = require('async');
 const juice = require('juice');
 const moment = require('moment');
 const autolinker = require('autolinker');
-const analyticsHandler = require(path.resolve(
-  './modules/core/server/controllers/analytics.server.controller',
-));
-const textService = require(path.resolve(
-  './modules/core/server/services/text.server.service',
-));
-const render = require(path.resolve('./config/lib/render'));
-const agenda = require(path.resolve('./config/lib/agenda'));
-const config = require(path.resolve('./config/config'));
-const log = require(path.resolve('./config/lib/logger'));
+const analyticsHandler = require('../controllers/analytics.server.controller');
+const textService = require('./text.server.service');
+const render = require('../../../../config/lib/render');
+const agenda = require('../../../../config/lib/agenda');
+const config = require('../../../../config/config');
+const log = require('../../../../config/lib/logger');
 const url = (config.https ? 'https' : 'http') + '://' + config.domain;
 
 /**

--- a/modules/core/server/services/error.server.service.js
+++ b/modules/core/server/services/error.server.service.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const log = require('../../../../config/lib/logger');
 
 // Default error message when unsure how to respond

--- a/modules/core/server/services/error.server.service.js
+++ b/modules/core/server/services/error.server.service.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const log = require(path.resolve('./config/lib/logger'));
+const log = require('../../../../config/lib/logger');
 
 // Default error message when unsure how to respond
 const defaultErrorMessage =

--- a/modules/core/server/services/file-upload.service.js
+++ b/modules/core/server/services/file-upload.service.js
@@ -5,10 +5,8 @@ const path = require('path');
 const mmmagic = require('mmmagic');
 
 // Internal dependencies
-const config = require(path.resolve('./config/config'));
-const errorService = require(path.resolve(
-  './modules/core/server/services/error.server.service',
-));
+const config = require('../../../../config/config');
+const errorService = require('./error.server.service');
 
 /**
  * Upload file handler and validator using Multer and Mmmagic.

--- a/modules/core/server/services/file-upload.service.js
+++ b/modules/core/server/services/file-upload.service.js
@@ -1,7 +1,6 @@
 // External dependencies
 const multer = require('multer');
 const os = require('os');
-const path = require('path');
 const mmmagic = require('mmmagic');
 
 // Internal dependencies

--- a/modules/core/server/services/push.server.service.js
+++ b/modules/core/server/services/push.server.service.js
@@ -1,5 +1,4 @@
 const _ = require('lodash');
-const path = require('path');
 const agenda = require('../../../../config/lib/agenda');
 const config = require('../../../../config/config');
 const url = (config.https ? 'https' : 'http') + '://' + config.domain;

--- a/modules/core/server/services/push.server.service.js
+++ b/modules/core/server/services/push.server.service.js
@@ -1,11 +1,9 @@
 const _ = require('lodash');
 const path = require('path');
-const agenda = require(path.resolve('./config/lib/agenda'));
-const config = require(path.resolve('./config/config'));
+const agenda = require('../../../../config/lib/agenda');
+const config = require('../../../../config/config');
 const url = (config.https ? 'https' : 'http') + '://' + config.domain;
-const analyticsHandler = require(path.resolve(
-  './modules/core/server/controllers/analytics.server.controller',
-));
+const analyticsHandler = require('../controllers/analytics.server.controller');
 
 exports.notifyPushDeviceAdded = function (user, platform, callback) {
   if (_.get(user, 'pushRegistration', []).length === 0) return callback();

--- a/modules/core/server/services/spam.server.service.js
+++ b/modules/core/server/services/spam.server.service.js
@@ -1,8 +1,8 @@
 const path = require('path');
 
 const AkismetClient = require('akismet-api').AkismetClient;
-const config = require(path.resolve('./config/config'));
-const log = require(path.resolve('./config/lib/logger'));
+const config = require('../../../../config/config');
+const log = require('../../../../config/lib/logger');
 
 exports.check = async message => {
   if (!config.akismet.enabled) {

--- a/modules/core/server/services/spam.server.service.js
+++ b/modules/core/server/services/spam.server.service.js
@@ -1,5 +1,3 @@
-const path = require('path');
-
 const AkismetClient = require('akismet-api').AkismetClient;
 const config = require('../../../../config/config');
 const log = require('../../../../config/lib/logger');

--- a/modules/core/tests/server/core.server.config.tests.js
+++ b/modules/core/tests/server/core.server.config.tests.js
@@ -4,8 +4,8 @@
 const mongoose = require('mongoose');
 const path = require('path');
 const request = require('supertest');
-const express = require(path.resolve('./config/lib/express'));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const express = require('../../../../config/lib/express');
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 const Tribe = mongoose.model('Tribe');
 const User = mongoose.model('User');

--- a/modules/core/tests/server/core.server.config.tests.js
+++ b/modules/core/tests/server/core.server.config.tests.js
@@ -2,7 +2,6 @@
  * Module dependencies.
  */
 const mongoose = require('mongoose');
-const path = require('path');
 const request = require('supertest');
 const express = require('../../../../config/lib/express');
 const utils = require('../../../../testutils/server/data.server.testutil');

--- a/modules/core/tests/server/core.server.routes.tests.js
+++ b/modules/core/tests/server/core.server.routes.tests.js
@@ -1,6 +1,5 @@
 const _ = require('lodash');
 const request = require('supertest');
-const path = require('path');
 const mongoose = require('mongoose');
 const express = require('../../../../config/lib/express');
 const config = require('../../../../config/config');

--- a/modules/core/tests/server/core.server.routes.tests.js
+++ b/modules/core/tests/server/core.server.routes.tests.js
@@ -2,8 +2,8 @@ const _ = require('lodash');
 const request = require('supertest');
 const path = require('path');
 const mongoose = require('mongoose');
-const express = require(path.resolve('./config/lib/express'));
-const config = require(path.resolve('./config/config'));
+const express = require('../../../../config/lib/express');
+const config = require('../../../../config/config');
 const should = require('should');
 
 /**

--- a/modules/core/tests/server/jobs/send-email.server.job.tests.js
+++ b/modules/core/tests/server/jobs/send-email.server.job.tests.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const mongoose = require('mongoose');
-const testutils = require(path.resolve('./testutils/server/server.testutil'));
+const testutils = require('../../../../../testutils/server/server.testutil');
 
 /**
  * Globals
@@ -11,9 +11,7 @@ describe('job: send email', function () {
   const sentEmails = testutils.catchEmails();
 
   before(function () {
-    sendEmailJobHandler = require(path.resolve(
-      './modules/core/server/jobs/send-email.server.job',
-    ));
+    sendEmailJobHandler = require('../../../server/jobs/send-email.server.job');
   });
 
   it('will send an email', function (done) {

--- a/modules/core/tests/server/jobs/send-email.server.job.tests.js
+++ b/modules/core/tests/server/jobs/send-email.server.job.tests.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const mongoose = require('mongoose');
 const testutils = require('../../../../../testutils/server/server.testutil');
 

--- a/modules/core/tests/server/jobs/send-push-message.server.job.tests.js
+++ b/modules/core/tests/server/jobs/send-push-message.server.job.tests.js
@@ -5,7 +5,7 @@ const proxyquire = require('proxyquire');
 const should = require('should');
 
 // Internal dependencies
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const utils = require('../../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');
 

--- a/modules/core/tests/server/services/email.server.service.tests.js
+++ b/modules/core/tests/server/services/email.server.service.tests.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const should = require('should');
 const testutils = require('../../../../../testutils/server/server.testutil');
 const config = require('../../../../../config/config');

--- a/modules/core/tests/server/services/email.server.service.tests.js
+++ b/modules/core/tests/server/services/email.server.service.tests.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const should = require('should');
-const testutils = require(path.resolve('./testutils/server/server.testutil'));
-const config = require(path.resolve('./config/config'));
+const testutils = require('../../../../../testutils/server/server.testutil');
+const config = require('../../../../../config/config');
 
 let emailService;
 
@@ -9,9 +9,7 @@ describe('Service: email', function () {
   const jobs = testutils.catchJobs();
 
   before(function () {
-    emailService = require(path.resolve(
-      './modules/core/server/services/email.server.service',
-    ));
+    emailService = require('../../../server/services/email.server.service');
   });
 
   it('can send signup email confirmation', function (done) {

--- a/modules/core/tests/server/services/push.server.service.tests.js
+++ b/modules/core/tests/server/services/push.server.service.tests.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const config = require('../../../../../config/config');
 const url = (config.https ? 'https' : 'http') + '://' + config.domain;
 const testutils = require('../../../../../testutils/server/server.testutil');

--- a/modules/core/tests/server/services/push.server.service.tests.js
+++ b/modules/core/tests/server/services/push.server.service.tests.js
@@ -1,7 +1,7 @@
 const path = require('path');
-const config = require(path.resolve('./config/config'));
+const config = require('../../../../../config/config');
 const url = (config.https ? 'https' : 'http') + '://' + config.domain;
-const testutils = require(path.resolve('./testutils/server/server.testutil'));
+const testutils = require('../../../../../testutils/server/server.testutil');
 
 describe('Service: push', function () {
   const jobs = testutils.catchJobs();
@@ -9,9 +9,7 @@ describe('Service: push', function () {
   let pushService;
 
   before(function () {
-    pushService = require(path.resolve(
-      './modules/core/server/services/push.server.service',
-    ));
+    pushService = require('../../../server/services/push.server.service');
   });
 
   it('can send a user notification', function (done) {

--- a/modules/core/tests/server/services/text.server.service.tests.js
+++ b/modules/core/tests/server/services/text.server.service.tests.js
@@ -1,7 +1,5 @@
 const path = require('path');
-const textService = require(path.resolve(
-  './modules/core/server/services/text.server.service',
-));
+const textService = require('../../../server/services/text.server.service');
 
 require('should');
 

--- a/modules/core/tests/server/services/text.server.service.tests.js
+++ b/modules/core/tests/server/services/text.server.service.tests.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const textService = require('../../../server/services/text.server.service');
 
 require('should');

--- a/modules/core/tests/server/worker.tests.js
+++ b/modules/core/tests/server/worker.tests.js
@@ -1,5 +1,4 @@
 const _ = require('lodash');
-const path = require('path');
 const sinon = require('sinon');
 
 describe('Worker tests', function () {

--- a/modules/core/tests/server/worker.tests.js
+++ b/modules/core/tests/server/worker.tests.js
@@ -3,8 +3,8 @@ const path = require('path');
 const sinon = require('sinon');
 
 describe('Worker tests', function () {
-  const agenda = require(path.resolve('./config/lib/agenda'));
-  const worker = require(path.resolve('./config/lib/worker'));
+  const agenda = require('../../../../config/lib/agenda');
+  const worker = require('../../../../config/lib/worker');
 
   const workerOptions = {
     maxAttempts: 3,

--- a/modules/experiences/server/controllers/experiences.server.controller.js
+++ b/modules/experiences/server/controllers/experiences.server.controller.js
@@ -1,6 +1,5 @@
 const mongoose = require('mongoose');
 const _ = require('lodash');
-const path = require('path');
 const util = require('util');
 const config = require('../../../../config/config');
 const textService = require('../../../core/server/services/text.server.service');

--- a/modules/experiences/server/controllers/experiences.server.controller.js
+++ b/modules/experiences/server/controllers/experiences.server.controller.js
@@ -2,22 +2,12 @@ const mongoose = require('mongoose');
 const _ = require('lodash');
 const path = require('path');
 const util = require('util');
-const config = require(path.resolve('./config/config'));
-const textService = require(path.resolve(
-  './modules/core/server/services/text.server.service',
-));
-const errorService = require(path.resolve(
-  './modules/core/server/services/error.server.service',
-));
-const emailService = require(path.resolve(
-  './modules/core/server/services/email.server.service',
-));
-const pushService = require(path.resolve(
-  './modules/core/server/services/push.server.service',
-));
-const userProfile = require(path.resolve(
-  './modules/users/server/controllers/users.profile.server.controller',
-));
+const config = require('../../../../config/config');
+const textService = require('../../../core/server/services/text.server.service');
+const errorService = require('../../../core/server/services/error.server.service');
+const emailService = require('../../../core/server/services/email.server.service');
+const pushService = require('../../../core/server/services/push.server.service');
+const userProfile = require('../../../users/server/controllers/users.profile.server.controller');
 const Experience = mongoose.model('Experience');
 const User = mongoose.model('User');
 

--- a/modules/experiences/server/jobs/experiences-publish.server.job.js
+++ b/modules/experiences/server/jobs/experiences-publish.server.job.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const mongoose = require('mongoose');
 const moment = require('moment');
-const config = require(path.resolve('./config/config'));
+const config = require('../../../../config/config');
 const Experience = mongoose.model('Experience');
 
 /**

--- a/modules/experiences/server/jobs/experiences-publish.server.job.js
+++ b/modules/experiences/server/jobs/experiences-publish.server.job.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const mongoose = require('mongoose');
 const moment = require('moment');
 const config = require('../../../../config/config');

--- a/modules/experiences/server/policies/experiences.server.policy.js
+++ b/modules/experiences/server/policies/experiences.server.policy.js
@@ -1,5 +1,4 @@
 let acl = require('acl');
-const path = require('path');
 const errorService = require('../../../core/server/services/error.server.service');
 
 acl = new acl(new acl.memoryBackend());

--- a/modules/experiences/server/policies/experiences.server.policy.js
+++ b/modules/experiences/server/policies/experiences.server.policy.js
@@ -1,8 +1,6 @@
 let acl = require('acl');
 const path = require('path');
-const errorService = require(path.resolve(
-  './modules/core/server/services/error.server.service',
-));
+const errorService = require('../../../core/server/services/error.server.service');
 
 acl = new acl(new acl.memoryBackend());
 

--- a/modules/experiences/server/routes/experiences.server.routes.js
+++ b/modules/experiences/server/routes/experiences.server.routes.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const config = require(path.resolve('./config/config'));
+const config = require('../../../../config/config');
 const experiencesPolicy = require('../policies/experiences.server.policy');
 const experiences = require('../controllers/experiences.server.controller');
 

--- a/modules/experiences/server/routes/experiences.server.routes.js
+++ b/modules/experiences/server/routes/experiences.server.routes.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const config = require('../../../../config/config');
 const experiencesPolicy = require('../policies/experiences.server.policy');
 const experiences = require('../controllers/experiences.server.controller');

--- a/modules/experiences/tests/server/experience-count.server.routes.tests.js
+++ b/modules/experiences/tests/server/experience-count.server.routes.tests.js
@@ -2,8 +2,8 @@ const mongoose = require('mongoose');
 const path = require('path');
 const should = require('should');
 const request = require('supertest');
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
-const express = require(path.resolve('./config/lib/express'));
+const utils = require('../../../../testutils/server/data.server.testutil');
+const express = require('../../../../config/lib/express');
 
 describe('Read count of experiences received by user', () => {
   // GET /experiences/count?userTo=:UserId

--- a/modules/experiences/tests/server/experience-count.server.routes.tests.js
+++ b/modules/experiences/tests/server/experience-count.server.routes.tests.js
@@ -1,5 +1,4 @@
 const mongoose = require('mongoose');
-const path = require('path');
 const should = require('should');
 const request = require('supertest');
 const utils = require('../../../../testutils/server/data.server.testutil');

--- a/modules/experiences/tests/server/experience-create.server.routes.tests.js
+++ b/modules/experiences/tests/server/experience-create.server.routes.tests.js
@@ -5,10 +5,10 @@ const sinon = require('sinon');
 const mongoose = require('mongoose');
 const faker = require('faker');
 const Experience = mongoose.model('Experience');
-const testutils = require(path.resolve('./testutils/server/server.testutil'));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
-const express = require(path.resolve('./config/lib/express'));
-const config = require(path.resolve('./config/config'));
+const testutils = require('../../../../testutils/server/server.testutil');
+const utils = require('../../../../testutils/server/data.server.testutil');
+const express = require('../../../../config/lib/express');
+const config = require('../../../../config/config');
 
 describe('Create an experience', () => {
   // user can leave an experience to anyone

--- a/modules/experiences/tests/server/experience-create.server.routes.tests.js
+++ b/modules/experiences/tests/server/experience-create.server.routes.tests.js
@@ -1,6 +1,5 @@
 const should = require('should');
 const request = require('supertest');
-const path = require('path');
 const sinon = require('sinon');
 const mongoose = require('mongoose');
 const faker = require('faker');

--- a/modules/experiences/tests/server/experience-read-many.server.routes.tests.js
+++ b/modules/experiences/tests/server/experience-read-many.server.routes.tests.js
@@ -1,5 +1,4 @@
 const mongoose = require('mongoose');
-const path = require('path');
 const request = require('supertest');
 const should = require('should');
 const sinon = require('sinon');

--- a/modules/experiences/tests/server/experience-read-many.server.routes.tests.js
+++ b/modules/experiences/tests/server/experience-read-many.server.routes.tests.js
@@ -3,11 +3,9 @@ const path = require('path');
 const request = require('supertest');
 const should = require('should');
 const sinon = require('sinon');
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
-const userProfile = require(path.resolve(
-  './modules/users/server/controllers/users.profile.server.controller',
-));
-const express = require(path.resolve('./config/lib/express'));
+const utils = require('../../../../testutils/server/data.server.testutil');
+const userProfile = require('../../../users/server/controllers/users.profile.server.controller');
+const express = require('../../../../config/lib/express');
 
 describe('Read experiences by userTo Id', () => {
   // GET /experiences?userFrom=:UserId&userTo=:UserId

--- a/modules/experiences/tests/server/experience-read-mine.server.routes.tests.js
+++ b/modules/experiences/tests/server/experience-read-mine.server.routes.tests.js
@@ -1,5 +1,4 @@
 const mongoose = require('mongoose');
-const path = require('path');
 const request = require('supertest');
 const should = require('should');
 const sinon = require('sinon');

--- a/modules/experiences/tests/server/experience-read-mine.server.routes.tests.js
+++ b/modules/experiences/tests/server/experience-read-mine.server.routes.tests.js
@@ -3,8 +3,8 @@ const path = require('path');
 const request = require('supertest');
 const should = require('should');
 const sinon = require('sinon');
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
-const express = require(path.resolve('./config/lib/express'));
+const utils = require('../../../../testutils/server/data.server.testutil');
+const express = require('../../../../config/lib/express');
 
 describe('Read my experience to userTo Id', () => {
   // GET /my-experience&userTo=:UserId

--- a/modules/experiences/tests/server/experience-read-one.server.routes.tests.js
+++ b/modules/experiences/tests/server/experience-read-one.server.routes.tests.js
@@ -1,6 +1,5 @@
 const _ = require('lodash');
 const mongoose = require('mongoose');
-const path = require('path');
 const request = require('supertest');
 const should = require('should');
 const sinon = require('sinon');

--- a/modules/experiences/tests/server/experience-read-one.server.routes.tests.js
+++ b/modules/experiences/tests/server/experience-read-one.server.routes.tests.js
@@ -4,11 +4,9 @@ const path = require('path');
 const request = require('supertest');
 const should = require('should');
 const sinon = require('sinon');
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
-const userProfile = require(path.resolve(
-  './modules/users/server/controllers/users.profile.server.controller',
-));
-const express = require(path.resolve('./config/lib/express'));
+const utils = require('../../../../testutils/server/data.server.testutil');
+const userProfile = require('../../../users/server/controllers/users.profile.server.controller');
+const express = require('../../../../config/lib/express');
 
 describe('Read a single experience by experience id', () => {
   // GET /experiences/:experienceId

--- a/modules/experiences/tests/server/experience.server.jobs.tests.js
+++ b/modules/experiences/tests/server/experience.server.jobs.tests.js
@@ -4,9 +4,9 @@ const path = require('path');
 const should = require('should');
 const sinon = require('sinon');
 const util = require('util');
-const config = require(path.resolve('./config/config'));
+const config = require('../../../../config/config');
 const jobPublishExperience = require('../../server/jobs/experiences-publish.server.job');
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const utils = require('../../../../testutils/server/data.server.testutil');
 const Experience = mongoose.model('Experience');
 
 describe('Job: Set experience to public after a given period of time', () => {

--- a/modules/experiences/tests/server/experience.server.jobs.tests.js
+++ b/modules/experiences/tests/server/experience.server.jobs.tests.js
@@ -1,6 +1,5 @@
 const moment = require('moment');
 const mongoose = require('mongoose');
-const path = require('path');
 const should = require('should');
 const sinon = require('sinon');
 const util = require('util');

--- a/modules/experiences/tests/server/experience.server.model.tests.js
+++ b/modules/experiences/tests/server/experience.server.model.tests.js
@@ -1,6 +1,5 @@
 const should = require('should');
 const mongoose = require('mongoose');
-const path = require('path');
 const utils = require('../../../../testutils/server/data.server.testutil');
 const User = mongoose.model('User');
 const Experience = mongoose.model('Experience');

--- a/modules/experiences/tests/server/experience.server.model.tests.js
+++ b/modules/experiences/tests/server/experience.server.model.tests.js
@@ -1,7 +1,7 @@
 const should = require('should');
 const mongoose = require('mongoose');
 const path = require('path');
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const utils = require('../../../../testutils/server/data.server.testutil');
 const User = mongoose.model('User');
 const Experience = mongoose.model('Experience');
 

--- a/modules/messages/server/controllers/messages.server.controller.js
+++ b/modules/messages/server/controllers/messages.server.controller.js
@@ -2,7 +2,6 @@
  * Module dependencies.
  */
 const _ = require('lodash');
-const path = require('path');
 const async = require('async');
 const sanitizeHtml = require('sanitize-html');
 const paginate = require('express-paginate');

--- a/modules/messages/server/controllers/messages.server.controller.js
+++ b/modules/messages/server/controllers/messages.server.controller.js
@@ -8,29 +8,15 @@ const sanitizeHtml = require('sanitize-html');
 const paginate = require('express-paginate');
 const moment = require('moment');
 const mongoose = require('mongoose');
-const config = require(path.resolve('./config/config'));
-const log = require(path.resolve('./config/lib/logger'));
-const messageToStatsService = require(path.resolve(
-  './modules/messages/server/services/message-to-stats.server.service',
-));
-const messageStatService = require(path.resolve(
-  './modules/messages/server/services/message-stat.server.service',
-));
-const errorService = require(path.resolve(
-  './modules/core/server/services/error.server.service',
-));
-const textService = require(path.resolve(
-  './modules/core/server/services/text.server.service',
-));
-const spamService = require(path.resolve(
-  './modules/core/server/services/spam.server.service',
-));
-const userProfile = require(path.resolve(
-  './modules/users/server/controllers/users.profile.server.controller',
-));
-const statService = require(path.resolve(
-  './modules/stats/server/services/stats.server.service',
-));
+const config = require('../../../../config/config');
+const log = require('../../../../config/lib/logger');
+const messageToStatsService = require('../services/message-to-stats.server.service');
+const messageStatService = require('../services/message-stat.server.service');
+const errorService = require('../../../core/server/services/error.server.service');
+const textService = require('../../../core/server/services/text.server.service');
+const spamService = require('../../../core/server/services/spam.server.service');
+const userProfile = require('../../../users/server/controllers/users.profile.server.controller');
+const statService = require('../../../stats/server/services/stats.server.service');
 
 const Message = mongoose.model('Message');
 const Thread = mongoose.model('Thread');

--- a/modules/messages/server/jobs/message-unread.server.job.js
+++ b/modules/messages/server/jobs/message-unread.server.job.js
@@ -29,14 +29,10 @@
  */
 const _ = require('lodash');
 const path = require('path');
-const pushService = require(path.resolve(
-  './modules/core/server/services/push.server.service',
-));
-const emailService = require(path.resolve(
-  './modules/core/server/services/email.server.service',
-));
-const log = require(path.resolve('./config/lib/logger'));
-const config = require(path.resolve('./config/config'));
+const pushService = require('../../../core/server/services/push.server.service');
+const emailService = require('../../../core/server/services/email.server.service');
+const log = require('../../../../config/lib/logger');
+const config = require('../../../../config/config');
 const async = require('async');
 const moment = require('moment');
 const mongoose = require('mongoose');

--- a/modules/messages/server/jobs/message-unread.server.job.js
+++ b/modules/messages/server/jobs/message-unread.server.job.js
@@ -28,7 +28,6 @@
  * Module dependencies.
  */
 const _ = require('lodash');
-const path = require('path');
 const pushService = require('../../../core/server/services/push.server.service');
 const emailService = require('../../../core/server/services/email.server.service');
 const log = require('../../../../config/lib/logger');

--- a/modules/messages/server/policies/messages.server.policy.js
+++ b/modules/messages/server/policies/messages.server.policy.js
@@ -2,7 +2,6 @@
  * Module dependencies.
  */
 let acl = require('acl');
-const path = require('path');
 const errorService = require('../../../core/server/services/error.server.service');
 
 // Using the memory backend

--- a/modules/messages/server/policies/messages.server.policy.js
+++ b/modules/messages/server/policies/messages.server.policy.js
@@ -3,9 +3,7 @@
  */
 let acl = require('acl');
 const path = require('path');
-const errorService = require(path.resolve(
-  './modules/core/server/services/error.server.service',
-));
+const errorService = require('../../../core/server/services/error.server.service');
 
 // Using the memory backend
 acl = new acl(new acl.memoryBackend());

--- a/modules/messages/server/services/message-to-stats.server.service.js
+++ b/modules/messages/server/services/message-to-stats.server.service.js
@@ -7,17 +7,13 @@
  */
 const path = require('path');
 const async = require('async');
-const config = require(path.resolve('./config/config'));
+const config = require('../../../../config/config');
 const mongoose = require('mongoose');
-const log = require(path.resolve('./config/lib/logger'));
-const statService = require(path.resolve(
-  './modules/stats/server/services/stats.server.service',
-));
-const textService = require(path.resolve(
-  './modules/core/server/services/text.server.service',
-));
+const log = require('../../../../config/lib/logger');
+const statService = require('../../../stats/server/services/stats.server.service');
+const textService = require('../../../core/server/services/text.server.service');
 
-require(path.resolve('./modules/messages/server/models/message.server.model'));
+require('../models/message.server.model');
 
 const Message = mongoose.model('Message');
 

--- a/modules/messages/server/services/message-to-stats.server.service.js
+++ b/modules/messages/server/services/message-to-stats.server.service.js
@@ -5,7 +5,6 @@
 /**
  * Module dependencies.
  */
-const path = require('path');
 const async = require('async');
 const config = require('../../../../config/config');
 const mongoose = require('mongoose');

--- a/modules/messages/tests/server/jobs/message-unread.server.job.tests.js
+++ b/modules/messages/tests/server/jobs/message-unread.server.job.tests.js
@@ -5,7 +5,7 @@ const path = require('path');
 // should = require('should'),
 const moment = require('moment');
 const sinon = require('sinon');
-const testutils = require(path.resolve('./testutils/server/server.testutil'));
+const testutils = require('../../../../../testutils/server/server.testutil');
 const mongoose = require('mongoose');
 const User = mongoose.model('User');
 const Message = mongoose.model('Message');
@@ -27,9 +27,7 @@ describe('Job: message unread', function () {
   const jobs = testutils.catchJobs();
 
   before(function () {
-    messageUnreadJobHandler = require(path.resolve(
-      './modules/messages/server/jobs/message-unread.server.job',
-    ));
+    messageUnreadJobHandler = require('../../../server/jobs/message-unread.server.job');
   });
 
   // Create an user

--- a/modules/messages/tests/server/jobs/message-unread.server.job.tests.js
+++ b/modules/messages/tests/server/jobs/message-unread.server.job.tests.js
@@ -1,7 +1,6 @@
 /**
  * Module dependencies.
  */
-const path = require('path');
 // should = require('should'),
 const moment = require('moment');
 const sinon = require('sinon');

--- a/modules/messages/tests/server/message-stat-integration.server.service.tests.js
+++ b/modules/messages/tests/server/message-stat-integration.server.service.tests.js
@@ -1,6 +1,5 @@
 const mongoose = require('mongoose');
 const should = require('should');
-const path = require('path');
 const _ = require('lodash');
 const sinon = require('sinon');
 const config = require('../../../../config/config');

--- a/modules/messages/tests/server/message-stat-integration.server.service.tests.js
+++ b/modules/messages/tests/server/message-stat-integration.server.service.tests.js
@@ -3,14 +3,10 @@ const should = require('should');
 const path = require('path');
 const _ = require('lodash');
 const sinon = require('sinon');
-const config = require(path.resolve('./config/config'));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
-const messageStatService = require(path.resolve(
-  './modules/messages/server/services/message-stat.server.service',
-));
-const messageController = require(path.resolve(
-  './modules/messages/server/controllers/messages.server.controller',
-));
+const config = require('../../../../config/config');
+const utils = require('../../../../testutils/server/data.server.testutil');
+const messageStatService = require('../../server/services/message-stat.server.service');
+const messageController = require('../../server/controllers/messages.server.controller');
 
 const User = mongoose.model('User');
 const EventEmitter = require('events');

--- a/modules/messages/tests/server/message-stat.server.model.tests.js
+++ b/modules/messages/tests/server/message-stat.server.model.tests.js
@@ -3,7 +3,6 @@
  */
 const should = require('should');
 const mongoose = require('mongoose');
-const path = require('path');
 const utils = require('../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');

--- a/modules/messages/tests/server/message-stat.server.model.tests.js
+++ b/modules/messages/tests/server/message-stat.server.model.tests.js
@@ -4,7 +4,7 @@
 const should = require('should');
 const mongoose = require('mongoose');
 const path = require('path');
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');
 const Message = mongoose.model('Message');

--- a/modules/messages/tests/server/message-stat.server.routes.tests.js
+++ b/modules/messages/tests/server/message-stat.server.routes.tests.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const should = require('should');
 const async = require('async');
 const request = require('supertest');

--- a/modules/messages/tests/server/message-stat.server.routes.tests.js
+++ b/modules/messages/tests/server/message-stat.server.routes.tests.js
@@ -3,8 +3,8 @@ const should = require('should');
 const async = require('async');
 const request = require('supertest');
 const mongoose = require('mongoose');
-const express = require(path.resolve('./config/lib/express'));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const express = require('../../../../config/lib/express');
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');
 const MessageStat = mongoose.model('MessageStat');

--- a/modules/messages/tests/server/message-stat.server.service.tests.js
+++ b/modules/messages/tests/server/message-stat.server.service.tests.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const should = require('should');
 const async = require('async');
 const mongoose = require('mongoose');

--- a/modules/messages/tests/server/message-stat.server.service.tests.js
+++ b/modules/messages/tests/server/message-stat.server.service.tests.js
@@ -2,10 +2,8 @@ const path = require('path');
 const should = require('should');
 const async = require('async');
 const mongoose = require('mongoose');
-const messageStatService = require(path.resolve(
-  './modules/messages/server/services/message-stat.server.service',
-));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const messageStatService = require('../../server/services/message-stat.server.service');
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');
 const Message = mongoose.model('Message');

--- a/modules/messages/tests/server/message-to-stats-integration.server.service.tests.js
+++ b/modules/messages/tests/server/message-to-stats-integration.server.service.tests.js
@@ -3,14 +3,12 @@ const should = require('should');
 const path = require('path');
 const _ = require('lodash');
 const sinon = require('sinon');
-const config = require(path.resolve('./config/config'));
+const config = require('../../../../config/config');
 const EventEmitter = require('events');
 const influx = require('influx');
 const Promise = require('promise');
-const messageController = require(path.resolve(
-  './modules/messages/server/controllers/messages.server.controller',
-));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const messageController = require('../../server/controllers/messages.server.controller');
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');
 

--- a/modules/messages/tests/server/message-to-stats-integration.server.service.tests.js
+++ b/modules/messages/tests/server/message-to-stats-integration.server.service.tests.js
@@ -1,6 +1,5 @@
 const mongoose = require('mongoose');
 const should = require('should');
-const path = require('path');
 const _ = require('lodash');
 const sinon = require('sinon');
 const config = require('../../../../config/config');

--- a/modules/messages/tests/server/message-to-stats.server.service.tests.js
+++ b/modules/messages/tests/server/message-to-stats.server.service.tests.js
@@ -2,7 +2,6 @@
  * Module dependencies.
  */
 const mongoose = require('mongoose');
-const path = require('path');
 const _ = require('lodash');
 const async = require('async');
 const config = require('../../../../config/config');

--- a/modules/messages/tests/server/message-to-stats.server.service.tests.js
+++ b/modules/messages/tests/server/message-to-stats.server.service.tests.js
@@ -5,11 +5,9 @@ const mongoose = require('mongoose');
 const path = require('path');
 const _ = require('lodash');
 const async = require('async');
-const config = require(path.resolve('./config/config'));
-const messageToStatsService = require(path.resolve(
-  './modules/messages/server/services/message-to-stats.server.service',
-));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const config = require('../../../../config/config');
+const messageToStatsService = require('../../server/services/message-to-stats.server.service');
+const utils = require('../../../../testutils/server/data.server.testutil');
 require('should');
 
 const User = mongoose.model('User');

--- a/modules/messages/tests/server/message.server.model.tests.js
+++ b/modules/messages/tests/server/message.server.model.tests.js
@@ -3,7 +3,6 @@
  */
 const should = require('should');
 const mongoose = require('mongoose');
-const path = require('path');
 const utils = require('../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');

--- a/modules/messages/tests/server/message.server.model.tests.js
+++ b/modules/messages/tests/server/message.server.model.tests.js
@@ -4,7 +4,7 @@
 const should = require('should');
 const mongoose = require('mongoose');
 const path = require('path');
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');
 const Message = mongoose.model('Message');

--- a/modules/messages/tests/server/message.server.routes.tests.js
+++ b/modules/messages/tests/server/message.server.routes.tests.js
@@ -5,9 +5,9 @@ const request = require('supertest');
 const path = require('path');
 const moment = require('moment');
 const mongoose = require('mongoose');
-const config = require(path.resolve('./config/config'));
-const express = require(path.resolve('./config/lib/express'));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const config = require('../../../../config/config');
+const express = require('../../../../config/lib/express');
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');
 const Message = mongoose.model('Message');

--- a/modules/messages/tests/server/message.server.routes.tests.js
+++ b/modules/messages/tests/server/message.server.routes.tests.js
@@ -2,7 +2,6 @@ const _ = require('lodash');
 const should = require('should');
 const async = require('async');
 const request = require('supertest');
-const path = require('path');
 const moment = require('moment');
 const mongoose = require('mongoose');
 const config = require('../../../../config/config');

--- a/modules/offers/server/controllers/offers.server.controller.js
+++ b/modules/offers/server/controllers/offers.server.controller.js
@@ -4,20 +4,12 @@
 const _ = require('lodash');
 const path = require('path');
 const async = require('async');
-const config = require(path.resolve('./config/config'));
-const errorService = require(path.resolve(
-  './modules/core/server/services/error.server.service',
-));
-const userProfile = require(path.resolve(
-  './modules/users/server/controllers/users.profile.server.controller',
-));
-const tribes = require(path.resolve(
-  './modules/tribes/server/controllers/tribes.server.controller',
-));
-const textService = require(path.resolve(
-  './modules/core/server/services/text.server.service',
-));
-const log = require(path.resolve('./config/lib/logger'));
+const config = require('../../../../config/config');
+const errorService = require('../../../core/server/services/error.server.service');
+const userProfile = require('../../../users/server/controllers/users.profile.server.controller');
+const tribes = require('../../../tribes/server/controllers/tribes.server.controller');
+const textService = require('../../../core/server/services/text.server.service');
+const log = require('../../../../config/lib/logger');
 const sanitizeHtml = require('sanitize-html');
 const moment = require('moment');
 const mongoose = require('mongoose');
@@ -549,7 +541,7 @@ exports.list = function (req, res) {
 
   // Languages filter
   if (filters.hasArrayFilter('languages')) {
-    let languages = require(path.resolve('./config/languages/languages.json'));
+    let languages = require('../../../../config/languages/languages.json');
 
     // Above json `languages` object contains language names, but we need just keys.
     languages = _.keys(languages);

--- a/modules/offers/server/controllers/offers.server.controller.js
+++ b/modules/offers/server/controllers/offers.server.controller.js
@@ -2,7 +2,6 @@
  * Module dependencies.
  */
 const _ = require('lodash');
-const path = require('path');
 const async = require('async');
 const config = require('../../../../config/config');
 const errorService = require('../../../core/server/services/error.server.service');

--- a/modules/offers/server/jobs/reactivate-hosts.server.job.js
+++ b/modules/offers/server/jobs/reactivate-hosts.server.job.js
@@ -9,7 +9,6 @@
 /**
  * Module dependencies.
  */
-const path = require('path');
 const emailService = require('../../../core/server/services/email.server.service');
 const config = require('../../../../config/config');
 const async = require('async');

--- a/modules/offers/server/jobs/reactivate-hosts.server.job.js
+++ b/modules/offers/server/jobs/reactivate-hosts.server.job.js
@@ -10,13 +10,11 @@
  * Module dependencies.
  */
 const path = require('path');
-const emailService = require(path.resolve(
-  './modules/core/server/services/email.server.service',
-));
-const config = require(path.resolve('./config/config'));
+const emailService = require('../../../core/server/services/email.server.service');
+const config = require('../../../../config/config');
 const async = require('async');
 const moment = require('moment');
-const log = require(path.resolve('./config/lib/logger'));
+const log = require('../../../../config/lib/logger');
 const mongoose = require('mongoose');
 const Offer = mongoose.model('Offer');
 

--- a/modules/offers/server/models/offer.server.model.js
+++ b/modules/offers/server/models/offer.server.model.js
@@ -4,9 +4,7 @@
 const _ = require('lodash');
 const path = require('path');
 const mongoose = require('mongoose');
-const textService = require(path.resolve(
-  './modules/core/server/services/text.server.service',
-));
+const textService = require('../../../core/server/services/text.server.service');
 const Schema = mongoose.Schema;
 
 /**

--- a/modules/offers/server/models/offer.server.model.js
+++ b/modules/offers/server/models/offer.server.model.js
@@ -2,7 +2,6 @@
  * Module dependencies.
  */
 const _ = require('lodash');
-const path = require('path');
 const mongoose = require('mongoose');
 const textService = require('../../../core/server/services/text.server.service');
 const Schema = mongoose.Schema;

--- a/modules/offers/server/policies/offers.server.policy.js
+++ b/modules/offers/server/policies/offers.server.policy.js
@@ -2,7 +2,6 @@
  * Module dependencies.
  */
 let acl = require('acl');
-const path = require('path');
 const errorService = require('../../../core/server/services/error.server.service');
 
 // Using the memory backend

--- a/modules/offers/server/policies/offers.server.policy.js
+++ b/modules/offers/server/policies/offers.server.policy.js
@@ -3,9 +3,7 @@
  */
 let acl = require('acl');
 const path = require('path');
-const errorService = require(path.resolve(
-  './modules/core/server/services/error.server.service',
-));
+const errorService = require('../../../core/server/services/error.server.service');
 
 // Using the memory backend
 acl = new acl(new acl.memoryBackend());

--- a/modules/offers/tests/server/jobs/reactivate-hosts.server.job.tests.js
+++ b/modules/offers/tests/server/jobs/reactivate-hosts.server.job.tests.js
@@ -3,8 +3,8 @@
  */
 const path = require('path');
 const should = require('should');
-const testutils = require(path.resolve('./testutils/server/server.testutil'));
-const config = require(path.resolve('./config/config'));
+const testutils = require('../../../../../testutils/server/server.testutil');
+const config = require('../../../../../config/config');
 const moment = require('moment');
 const mongoose = require('mongoose');
 const User = mongoose.model('User');
@@ -23,9 +23,7 @@ describe('Job: reactivate members with hosting offer status set to "no"', functi
   const jobs = testutils.catchJobs();
 
   before(function () {
-    reactivateHostsJobHandler = require(path.resolve(
-      './modules/offers/server/jobs/reactivate-hosts.server.job',
-    ));
+    reactivateHostsJobHandler = require('../../../server/jobs/reactivate-hosts.server.job');
   });
 
   // Create user

--- a/modules/offers/tests/server/jobs/reactivate-hosts.server.job.tests.js
+++ b/modules/offers/tests/server/jobs/reactivate-hosts.server.job.tests.js
@@ -1,7 +1,6 @@
 /**
  * Module dependencies.
  */
-const path = require('path');
 const should = require('should');
 const testutils = require('../../../../../testutils/server/server.testutil');
 const config = require('../../../../../config/config');

--- a/modules/offers/tests/server/offer-search.server.routes.tests.js
+++ b/modules/offers/tests/server/offer-search.server.routes.tests.js
@@ -1,7 +1,6 @@
 const _ = require('lodash');
 const should = require('should');
 const request = require('supertest');
-const path = require('path');
 const async = require('async');
 const moment = require('moment');
 const mongoose = require('mongoose');

--- a/modules/offers/tests/server/offer-search.server.routes.tests.js
+++ b/modules/offers/tests/server/offer-search.server.routes.tests.js
@@ -5,8 +5,8 @@ const path = require('path');
 const async = require('async');
 const moment = require('moment');
 const mongoose = require('mongoose');
-const express = require(path.resolve('./config/lib/express'));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const express = require('../../../../config/lib/express');
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');
 const Offer = mongoose.model('Offer');

--- a/modules/offers/tests/server/offer.server.model.tests.js
+++ b/modules/offers/tests/server/offer.server.model.tests.js
@@ -4,7 +4,7 @@
 const should = require('should');
 const mongoose = require('mongoose');
 const path = require('path');
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');
 const Offer = mongoose.model('Offer');

--- a/modules/offers/tests/server/offer.server.model.tests.js
+++ b/modules/offers/tests/server/offer.server.model.tests.js
@@ -3,7 +3,6 @@
  */
 const should = require('should');
 const mongoose = require('mongoose');
-const path = require('path');
 const utils = require('../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');

--- a/modules/offers/tests/server/offer.server.routes.tests.js
+++ b/modules/offers/tests/server/offer.server.routes.tests.js
@@ -4,8 +4,8 @@ const path = require('path');
 const async = require('async');
 const moment = require('moment');
 const mongoose = require('mongoose');
-const express = require(path.resolve('./config/lib/express'));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const express = require('../../../../config/lib/express');
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');
 const Offer = mongoose.model('Offer');

--- a/modules/offers/tests/server/offer.server.routes.tests.js
+++ b/modules/offers/tests/server/offer.server.routes.tests.js
@@ -1,6 +1,5 @@
 const should = require('should');
 const request = require('supertest');
-const path = require('path');
 const async = require('async');
 const moment = require('moment');
 const mongoose = require('mongoose');

--- a/modules/pages/server/controllers/pages.volunteers.server.controller.js
+++ b/modules/pages/server/controllers/pages.volunteers.server.controller.js
@@ -1,7 +1,6 @@
 /**
  * Module dependencies.
  */
-const path = require('path');
 const _ = require('lodash');
 const mongoose = require('mongoose');
 const errorService = require('../../../core/server/services/error.server.service');

--- a/modules/pages/server/controllers/pages.volunteers.server.controller.js
+++ b/modules/pages/server/controllers/pages.volunteers.server.controller.js
@@ -4,9 +4,7 @@
 const path = require('path');
 const _ = require('lodash');
 const mongoose = require('mongoose');
-const errorService = require(path.resolve(
-  './modules/core/server/services/error.server.service',
-));
+const errorService = require('../../../core/server/services/error.server.service');
 
 const User = mongoose.model('User');
 

--- a/modules/references-thread/server/controllers/reference-thread.server.controller.js
+++ b/modules/references-thread/server/controllers/reference-thread.server.controller.js
@@ -1,7 +1,6 @@
 /**
  * Module dependencies.
  */
-const path = require('path');
 const async = require('async');
 const mongoose = require('mongoose');
 

--- a/modules/references-thread/server/controllers/reference-thread.server.controller.js
+++ b/modules/references-thread/server/controllers/reference-thread.server.controller.js
@@ -5,13 +5,9 @@ const path = require('path');
 const async = require('async');
 const mongoose = require('mongoose');
 
-const errorService = require(path.resolve(
-  './modules/core/server/services/error.server.service',
-));
-const statService = require(path.resolve(
-  './modules/stats/server/services/stats.server.service',
-));
-const log = require(path.resolve('./config/lib/logger'));
+const errorService = require('../../../core/server/services/error.server.service');
+const statService = require('../../../stats/server/services/stats.server.service');
+const log = require('../../../../config/lib/logger');
 
 const Message = mongoose.model('Message');
 const Thread = mongoose.model('Thread');

--- a/modules/references-thread/server/policies/reference-thread.server.policy.js
+++ b/modules/references-thread/server/policies/reference-thread.server.policy.js
@@ -2,7 +2,6 @@
  * Module dependencies.
  */
 let acl = require('acl');
-const path = require('path');
 const errorService = require('../../../core/server/services/error.server.service');
 
 // Using the memory backend

--- a/modules/references-thread/server/policies/reference-thread.server.policy.js
+++ b/modules/references-thread/server/policies/reference-thread.server.policy.js
@@ -3,9 +3,7 @@
  */
 let acl = require('acl');
 const path = require('path');
-const errorService = require(path.resolve(
-  './modules/core/server/services/error.server.service',
-));
+const errorService = require('../../../core/server/services/error.server.service');
 
 // Using the memory backend
 acl = new acl(new acl.memoryBackend());

--- a/modules/references-thread/tests/server/reference-thread.server.model.tests.js
+++ b/modules/references-thread/tests/server/reference-thread.server.model.tests.js
@@ -4,7 +4,7 @@
 const should = require('should');
 const mongoose = require('mongoose');
 const path = require('path');
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');
 const Thread = mongoose.model('Thread');

--- a/modules/references-thread/tests/server/reference-thread.server.model.tests.js
+++ b/modules/references-thread/tests/server/reference-thread.server.model.tests.js
@@ -3,7 +3,6 @@
  */
 const should = require('should');
 const mongoose = require('mongoose');
-const path = require('path');
 const utils = require('../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');

--- a/modules/references-thread/tests/server/reference-thread.server.routes.tests.js
+++ b/modules/references-thread/tests/server/reference-thread.server.routes.tests.js
@@ -4,8 +4,8 @@ const request = require('supertest');
 const path = require('path');
 const moment = require('moment');
 const mongoose = require('mongoose');
-const express = require(path.resolve('./config/lib/express'));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const express = require('../../../../config/lib/express');
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');
 const Message = mongoose.model('Message');

--- a/modules/references-thread/tests/server/reference-thread.server.routes.tests.js
+++ b/modules/references-thread/tests/server/reference-thread.server.routes.tests.js
@@ -1,7 +1,6 @@
 const should = require('should');
 const async = require('async');
 const request = require('supertest');
-const path = require('path');
 const moment = require('moment');
 const mongoose = require('mongoose');
 const express = require('../../../../config/lib/express');

--- a/modules/sparkpost/server/controllers/sparkpost-webhooks.server.controller.js
+++ b/modules/sparkpost/server/controllers/sparkpost-webhooks.server.controller.js
@@ -14,14 +14,10 @@ const path = require('path');
 const async = require('async');
 const basicAuth = require('basic-auth');
 const speakingurl = require('speakingurl');
-const log = require(path.resolve('./config/lib/logger'));
-const errorService = require(path.resolve(
-  './modules/core/server/services/error.server.service',
-));
-const statService = require(path.resolve(
-  './modules/stats/server/services/stats.server.service',
-));
-const config = require(path.resolve('./config/config'));
+const log = require('../../../../config/lib/logger');
+const errorService = require('../../../core/server/services/error.server.service');
+const statService = require('../../../stats/server/services/stats.server.service');
+const config = require('../../../../config/config');
 
 /**
  * Receive Sparkpost events webhook batch

--- a/modules/sparkpost/server/controllers/sparkpost-webhooks.server.controller.js
+++ b/modules/sparkpost/server/controllers/sparkpost-webhooks.server.controller.js
@@ -10,7 +10,6 @@
  * Module dependencies.
  */
 const _ = require('lodash');
-const path = require('path');
 const async = require('async');
 const basicAuth = require('basic-auth');
 const speakingurl = require('speakingurl');

--- a/modules/sparkpost/tests/server/sparkpost-webhooks.server.controller.tests.js
+++ b/modules/sparkpost/tests/server/sparkpost-webhooks.server.controller.tests.js
@@ -1,7 +1,6 @@
 // test whether the daily statistics job reaches influxdb via Stats api
 
 const should = require('should');
-const path = require('path');
 const influx = require('influx');
 const sinon = require('sinon');
 const config = require('../../../../config/config');

--- a/modules/sparkpost/tests/server/sparkpost-webhooks.server.controller.tests.js
+++ b/modules/sparkpost/tests/server/sparkpost-webhooks.server.controller.tests.js
@@ -4,10 +4,8 @@ const should = require('should');
 const path = require('path');
 const influx = require('influx');
 const sinon = require('sinon');
-const config = require(path.resolve('./config/config'));
-const sparkpostWebhooks = require(path.resolve(
-  './modules/sparkpost/server/controllers/sparkpost-webhooks.server.controller',
-));
+const config = require('../../../../config/config');
+const sparkpostWebhooks = require('../../server/controllers/sparkpost-webhooks.server.controller');
 
 describe('Sparkpost Webhooks - Integration Test', function () {
   // restoring the stubs

--- a/modules/sparkpost/tests/server/sparkpost.server.routes.tests.js
+++ b/modules/sparkpost/tests/server/sparkpost.server.routes.tests.js
@@ -1,8 +1,8 @@
 const request = require('supertest');
 const path = require('path');
 const mongoose = require('mongoose');
-const express = require(path.resolve('./config/lib/express'));
-const config = require(path.resolve('./config/config'));
+const express = require('../../../../config/lib/express');
+const config = require('../../../../config/config');
 
 /**
  * Globals

--- a/modules/sparkpost/tests/server/sparkpost.server.routes.tests.js
+++ b/modules/sparkpost/tests/server/sparkpost.server.routes.tests.js
@@ -1,5 +1,4 @@
 const request = require('supertest');
-const path = require('path');
 const mongoose = require('mongoose');
 const express = require('../../../../config/lib/express');
 const config = require('../../../../config/config');

--- a/modules/statistics/server/controllers/statistics.server.controller.js
+++ b/modules/statistics/server/controllers/statistics.server.controller.js
@@ -4,12 +4,8 @@
 const _ = require('lodash');
 const path = require('path');
 const moment = require('moment');
-const errorService = require(path.resolve(
-  './modules/core/server/services/error.server.service',
-));
-const statService = require(path.resolve(
-  './modules/stats/server/services/stats.server.service',
-));
+const errorService = require('../../../core/server/services/error.server.service');
+const statService = require('../../../stats/server/services/stats.server.service');
 const async = require('async');
 const semver = require('semver');
 const mongoose = require('mongoose');

--- a/modules/statistics/server/controllers/statistics.server.controller.js
+++ b/modules/statistics/server/controllers/statistics.server.controller.js
@@ -2,7 +2,6 @@
  * Module dependencies.
  */
 const _ = require('lodash');
-const path = require('path');
 const moment = require('moment');
 const errorService = require('../../../core/server/services/error.server.service');
 const statService = require('../../../stats/server/services/stats.server.service');

--- a/modules/statistics/server/jobs/daily-statistics.server.job.js
+++ b/modules/statistics/server/jobs/daily-statistics.server.job.js
@@ -11,13 +11,9 @@
  */
 const async = require('async');
 const path = require('path');
-const statsService = require(path.resolve(
-  './modules/stats/server/services/stats.server.service',
-));
-const statistics = require(path.resolve(
-  './modules/statistics/server/controllers/statistics.server.controller',
-));
-const log = require(path.resolve('./config/lib/logger'));
+const statsService = require('../../../stats/server/services/stats.server.service');
+const statistics = require('../controllers/statistics.server.controller');
+const log = require('../../../../config/lib/logger');
 
 module.exports = function (job, agendaDone) {
   let totalUserCount;

--- a/modules/statistics/server/jobs/daily-statistics.server.job.js
+++ b/modules/statistics/server/jobs/daily-statistics.server.job.js
@@ -10,7 +10,6 @@
  * Module dependencies.
  */
 const async = require('async');
-const path = require('path');
 const statsService = require('../../../stats/server/services/stats.server.service');
 const statistics = require('../controllers/statistics.server.controller');
 const log = require('../../../../config/lib/logger');

--- a/modules/statistics/tests/server/jobs/daily-statistics.server.job.tests.js
+++ b/modules/statistics/tests/server/jobs/daily-statistics.server.job.tests.js
@@ -1,7 +1,6 @@
 // test whether the daily statistics job reaches influxdb via Stats api
 
 const should = require('should');
-const path = require('path');
 const influx = require('influx');
 const sinon = require('sinon');
 

--- a/modules/statistics/tests/server/jobs/daily-statistics.server.job.tests.js
+++ b/modules/statistics/tests/server/jobs/daily-statistics.server.job.tests.js
@@ -5,10 +5,8 @@ const path = require('path');
 const influx = require('influx');
 const sinon = require('sinon');
 
-const config = require(path.resolve('./config/config'));
-const statsJob = require(path.resolve(
-  './modules/statistics/server/jobs/daily-statistics.server.job',
-));
+const config = require('../../../../../config/config');
+const statsJob = require('../../../server/jobs/daily-statistics.server.job');
 
 describe('Daily Statistics Job - Unit Test', function () {
   afterEach(function () {

--- a/modules/statistics/tests/server/statistics.server.routes.tests.js
+++ b/modules/statistics/tests/server/statistics.server.routes.tests.js
@@ -1,5 +1,4 @@
 const request = require('supertest');
-const path = require('path');
 const mongoose = require('mongoose');
 const express = require('../../../../config/lib/express');
 const utils = require('../../../../testutils/server/data.server.testutil');

--- a/modules/statistics/tests/server/statistics.server.routes.tests.js
+++ b/modules/statistics/tests/server/statistics.server.routes.tests.js
@@ -1,8 +1,8 @@
 const request = require('supertest');
 const path = require('path');
 const mongoose = require('mongoose');
-const express = require(path.resolve('./config/lib/express'));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const express = require('../../../../config/lib/express');
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 require('should');
 

--- a/modules/stats/server/services/influx.server.service.js
+++ b/modules/stats/server/services/influx.server.service.js
@@ -4,8 +4,8 @@
 const path = require('path');
 const Influx = require('influx');
 const _ = require('lodash');
-const config = require(path.resolve('./config/config'));
-const log = require(path.resolve('./config/lib/logger'));
+const config = require('../../../../config/config');
+const log = require('../../../../config/lib/logger');
 
 /**
  * Get InfluxDB Client

--- a/modules/stats/server/services/influx.server.service.js
+++ b/modules/stats/server/services/influx.server.service.js
@@ -1,7 +1,6 @@
 /**
  * Module dependencies.
  */
-const path = require('path');
 const Influx = require('influx');
 const _ = require('lodash');
 const config = require('../../../../config/config');

--- a/modules/stats/server/services/stats.server.service.js
+++ b/modules/stats/server/services/stats.server.service.js
@@ -25,8 +25,7 @@
  * Module dependencies.
  */
 const _ = require('lodash');
-// path = require('path'),
-// config = require(path.resolve('./config/config')),
+// const config = require('../../../../config/config');
 const influxService = require('./influx.server.service.js');
 
 /**

--- a/modules/stats/tests/server/services/influx.server.service.tests.js
+++ b/modules/stats/tests/server/services/influx.server.service.tests.js
@@ -4,10 +4,8 @@ const sinon = require('sinon');
 const influx = require('influx');
 const Promise = require('promise');
 // influx = require('influx'),
-const influxService = require(path.resolve(
-  './modules/stats/server/services/influx.server.service',
-));
-const config = require(path.resolve('./config/config'));
+const influxService = require('../../../server/services/influx.server.service');
+const config = require('../../../../../config/config');
 
 describe('Service: influx', function () {
   // restore the stubbed services

--- a/modules/stats/tests/server/services/influx.server.service.tests.js
+++ b/modules/stats/tests/server/services/influx.server.service.tests.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const should = require('should');
 const sinon = require('sinon');
 const influx = require('influx');

--- a/modules/stats/tests/server/services/stats.server.service.tests.js
+++ b/modules/stats/tests/server/services/stats.server.service.tests.js
@@ -1,5 +1,4 @@
 const should = require('should');
-const path = require('path');
 const statsService = require('../../../server/services/stats.server.service');
 const influxService = require('../../../server/services/influx.server.service');
 const sinon = require('sinon');

--- a/modules/stats/tests/server/services/stats.server.service.tests.js
+++ b/modules/stats/tests/server/services/stats.server.service.tests.js
@@ -1,11 +1,7 @@
 const should = require('should');
 const path = require('path');
-const statsService = require(path.resolve(
-  './modules/stats/server/services/stats.server.service',
-));
-const influxService = require(path.resolve(
-  './modules/stats/server/services/influx.server.service',
-));
+const statsService = require('../../../server/services/stats.server.service');
+const influxService = require('../../../server/services/influx.server.service');
 const sinon = require('sinon');
 
 describe('General Stats API Service Unit Tests', function () {

--- a/modules/stats/tests/server/stats-api-integration.server.tests.js
+++ b/modules/stats/tests/server/stats-api-integration.server.tests.js
@@ -2,7 +2,6 @@
 // the correct data will arrive to the InfluxDB endpoint
 
 const should = require('should');
-const path = require('path');
 const influx = require('influx');
 const sinon = require('sinon');
 

--- a/modules/stats/tests/server/stats-api-integration.server.tests.js
+++ b/modules/stats/tests/server/stats-api-integration.server.tests.js
@@ -6,10 +6,8 @@ const path = require('path');
 const influx = require('influx');
 const sinon = require('sinon');
 
-const statsService = require(path.resolve(
-  './modules/stats/server/services/stats.server.service',
-));
-const config = require(path.resolve('./config/config'));
+const statsService = require('../../server/services/stats.server.service');
+const config = require('../../../../config/config');
 
 describe('Stat API integration tests', function () {
   // restoring stubs

--- a/modules/support/server/controllers/support.server.controller.js
+++ b/modules/support/server/controllers/support.server.controller.js
@@ -1,7 +1,6 @@
 /**
  * Module dependencies.
  */
-const path = require('path');
 const textService = require('../../../core/server/services/text.server.service');
 const emailService = require('../../../core/server/services/email.server.service');
 const statService = require('../../../stats/server/services/stats.server.service');

--- a/modules/support/server/controllers/support.server.controller.js
+++ b/modules/support/server/controllers/support.server.controller.js
@@ -2,17 +2,11 @@
  * Module dependencies.
  */
 const path = require('path');
-const textService = require(path.resolve(
-  './modules/core/server/services/text.server.service',
-));
-const emailService = require(path.resolve(
-  './modules/core/server/services/email.server.service',
-));
-const statService = require(path.resolve(
-  './modules/stats/server/services/stats.server.service',
-));
-const log = require(path.resolve('./config/lib/logger'));
-const config = require(path.resolve('./config/config'));
+const textService = require('../../../core/server/services/text.server.service');
+const emailService = require('../../../core/server/services/email.server.service');
+const statService = require('../../../stats/server/services/stats.server.service');
+const log = require('../../../../config/lib/logger');
+const config = require('../../../../config/config');
 const mongoose = require('mongoose');
 const SupportRequest = mongoose.model('SupportRequest');
 const validator = require('validator');

--- a/modules/support/tests/server/model.server.model.tests.js
+++ b/modules/support/tests/server/model.server.model.tests.js
@@ -4,7 +4,7 @@
 const should = require('should');
 const mongoose = require('mongoose');
 const path = require('path');
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');
 const SupportRequest = mongoose.model('SupportRequest');

--- a/modules/support/tests/server/model.server.model.tests.js
+++ b/modules/support/tests/server/model.server.model.tests.js
@@ -3,7 +3,6 @@
  */
 const should = require('should');
 const mongoose = require('mongoose');
-const path = require('path');
 const utils = require('../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');

--- a/modules/support/tests/server/support.server.routes.tests.js
+++ b/modules/support/tests/server/support.server.routes.tests.js
@@ -1,5 +1,4 @@
 const mongoose = require('mongoose');
-const path = require('path');
 const request = require('supertest');
 const should = require('should');
 const config = require('../../../../config/config');

--- a/modules/support/tests/server/support.server.routes.tests.js
+++ b/modules/support/tests/server/support.server.routes.tests.js
@@ -2,10 +2,10 @@ const mongoose = require('mongoose');
 const path = require('path');
 const request = require('supertest');
 const should = require('should');
-const config = require(path.resolve('./config/config'));
-const express = require(path.resolve('./config/lib/express'));
-const testutils = require(path.resolve('./testutils/server/server.testutil'));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const config = require('../../../../config/config');
+const express = require('../../../../config/lib/express');
+const testutils = require('../../../../testutils/server/server.testutil');
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 /**
  * Support routes tests

--- a/modules/tribes/server/controllers/tribes.server.controller.js
+++ b/modules/tribes/server/controllers/tribes.server.controller.js
@@ -1,7 +1,6 @@
 /**
  * Module dependencies.
  */
-const path = require('path');
 const errorService = require('../../../core/server/services/error.server.service');
 const paginate = require('express-paginate');
 const mongoose = require('mongoose');

--- a/modules/tribes/server/controllers/tribes.server.controller.js
+++ b/modules/tribes/server/controllers/tribes.server.controller.js
@@ -2,9 +2,7 @@
  * Module dependencies.
  */
 const path = require('path');
-const errorService = require(path.resolve(
-  './modules/core/server/services/error.server.service',
-));
+const errorService = require('../../../core/server/services/error.server.service');
 const paginate = require('express-paginate');
 const mongoose = require('mongoose');
 const Tribe = mongoose.model('Tribe');

--- a/modules/tribes/server/models/tribe.server.model.js
+++ b/modules/tribes/server/models/tribe.server.model.js
@@ -1,7 +1,6 @@
 /**
  * Module dependencies.
  */
-const path = require('path');
 const config = require('../../../../config/config');
 const mongoose = require('mongoose');
 const moment = require('moment');

--- a/modules/tribes/server/models/tribe.server.model.js
+++ b/modules/tribes/server/models/tribe.server.model.js
@@ -2,7 +2,7 @@
  * Module dependencies.
  */
 const path = require('path');
-const config = require(path.resolve('./config/config'));
+const config = require('../../../../config/config');
 const mongoose = require('mongoose');
 const moment = require('moment');
 const mongoosePaginate = require('mongoose-paginate');

--- a/modules/tribes/server/policies/tribes.server.policy.js
+++ b/modules/tribes/server/policies/tribes.server.policy.js
@@ -2,7 +2,6 @@
  * Module dependencies.
  */
 let acl = require('acl');
-const path = require('path');
 const errorService = require('../../../core/server/services/error.server.service');
 
 // Using the memory backend

--- a/modules/tribes/server/policies/tribes.server.policy.js
+++ b/modules/tribes/server/policies/tribes.server.policy.js
@@ -3,9 +3,7 @@
  */
 let acl = require('acl');
 const path = require('path');
-const errorService = require(path.resolve(
-  './modules/core/server/services/error.server.service',
-));
+const errorService = require('../../../core/server/services/error.server.service');
 
 // Using the memory backend
 acl = new acl(new acl.memoryBackend());

--- a/modules/tribes/tests/server/tribes.server.model.tests.js
+++ b/modules/tribes/tests/server/tribes.server.model.tests.js
@@ -5,8 +5,8 @@ const path = require('path');
 const should = require('should');
 const mongoose = require('mongoose');
 const validator = require('validator');
-const config = require(path.resolve('./config/config'));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const config = require('../../../../config/config');
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 const Tribe = mongoose.model('Tribe');
 

--- a/modules/tribes/tests/server/tribes.server.model.tests.js
+++ b/modules/tribes/tests/server/tribes.server.model.tests.js
@@ -1,7 +1,6 @@
 /**
  * Module dependencies.
  */
-const path = require('path');
 const should = require('should');
 const mongoose = require('mongoose');
 const validator = require('validator');

--- a/modules/tribes/tests/server/tribes.server.routes.tests.js
+++ b/modules/tribes/tests/server/tribes.server.routes.tests.js
@@ -2,8 +2,8 @@ const should = require('should');
 const request = require('supertest');
 const path = require('path');
 const mongoose = require('mongoose');
-const express = require(path.resolve('./config/lib/express'));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const express = require('../../../../config/lib/express');
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');
 const Tribe = mongoose.model('Tribe');

--- a/modules/tribes/tests/server/tribes.server.routes.tests.js
+++ b/modules/tribes/tests/server/tribes.server.routes.tests.js
@@ -1,6 +1,5 @@
 const should = require('should');
 const request = require('supertest');
-const path = require('path');
 const mongoose = require('mongoose');
 const express = require('../../../../config/lib/express');
 const utils = require('../../../../testutils/server/data.server.testutil');

--- a/modules/users/server/config/strategies/facebook.js
+++ b/modules/users/server/config/strategies/facebook.js
@@ -6,7 +6,7 @@ const path = require('path');
 const passport = require('passport');
 const FacebookStrategy = require('passport-facebook').Strategy;
 const usersAuthentication = require('../../controllers/users.authentication.server.controller');
-const log = require(path.resolve('./config/lib/logger'));
+const log = require('../../../../../config/lib/logger');
 
 module.exports = function (config) {
   // Get config parameters for the strategy

--- a/modules/users/server/config/strategies/facebook.js
+++ b/modules/users/server/config/strategies/facebook.js
@@ -2,7 +2,6 @@
  * Module dependencies.
  */
 const _ = require('lodash');
-const path = require('path');
 const passport = require('passport');
 const FacebookStrategy = require('passport-facebook').Strategy;
 const usersAuthentication = require('../../controllers/users.authentication.server.controller');

--- a/modules/users/server/config/users.config.server.js
+++ b/modules/users/server/config/users.config.server.js
@@ -4,10 +4,8 @@
 const passport = require('passport');
 const User = require('mongoose').model('User');
 const path = require('path');
-const config = require(path.resolve('./config/config'));
-const usersSuspended = require(path.resolve(
-  './modules/users/server/controllers/users.suspended.server.controller',
-));
+const config = require('../../../../config/config');
+const usersSuspended = require('../controllers/users.suspended.server.controller');
 
 module.exports = function (app) {
   // Serialize sessions

--- a/modules/users/server/controllers/users.authentication.server.controller.js
+++ b/modules/users/server/controllers/users.authentication.server.controller.js
@@ -3,24 +3,14 @@
  */
 const _ = require('lodash');
 const path = require('path');
-const errorService = require(path.resolve(
-  './modules/core/server/services/error.server.service',
-));
-const emailService = require(path.resolve(
-  './modules/core/server/services/email.server.service',
-));
-const userProfile = require(path.resolve(
-  './modules/users/server/controllers/users.profile.server.controller',
-));
-const authenticationService = require(path.resolve(
-  './modules/users/server/services/authentication.server.service',
-));
-const statService = require(path.resolve(
-  './modules/stats/server/services/stats.server.service',
-));
-const facebook = require(path.resolve('./config/lib/facebook-api.js'));
-const config = require(path.resolve('./config/config'));
-const log = require(path.resolve('./config/lib/logger'));
+const errorService = require('../../../core/server/services/error.server.service');
+const emailService = require('../../../core/server/services/email.server.service');
+const userProfile = require('./users.profile.server.controller');
+const authenticationService = require('../services/authentication.server.service');
+const statService = require('../../../stats/server/services/stats.server.service');
+const facebook = require('../../../../config/lib/facebook-api.js');
+const config = require('../../../../config/config');
+const log = require('../../../../config/lib/logger');
 const moment = require('moment');
 const passport = require('passport');
 const async = require('async');

--- a/modules/users/server/controllers/users.authentication.server.controller.js
+++ b/modules/users/server/controllers/users.authentication.server.controller.js
@@ -2,7 +2,6 @@
  * Module dependencies.
  */
 const _ = require('lodash');
-const path = require('path');
 const errorService = require('../../../core/server/services/error.server.service');
 const emailService = require('../../../core/server/services/email.server.service');
 const userProfile = require('./users.profile.server.controller');

--- a/modules/users/server/controllers/users.avatar.server.controller.js
+++ b/modules/users/server/controllers/users.avatar.server.controller.js
@@ -5,14 +5,10 @@ const mkdirRecursive = require('mkdir-recursive');
 const mongoose = require('mongoose');
 const path = require('path');
 
-const log = require(path.resolve('./config/lib/logger'));
-const config = require(path.resolve('./config/config'));
-const fileUpload = require(path.resolve(
-  './modules/core/server/services/file-upload.service',
-));
-const errorService = require(path.resolve(
-  './modules/core/server/services/error.server.service',
-));
+const log = require('../../../../config/lib/logger');
+const config = require('../../../../config/config');
+const fileUpload = require('../../../core/server/services/file-upload.service');
+const errorService = require('../../../core/server/services/error.server.service');
 
 const User = mongoose.model('User');
 

--- a/modules/users/server/controllers/users.block.server.controller.js
+++ b/modules/users/server/controllers/users.block.server.controller.js
@@ -2,12 +2,10 @@
  * Module dependencies.
  */
 const path = require('path');
-const errorService = require(path.resolve(
-  './modules/core/server/services/error.server.service',
-));
+const errorService = require('../../../core/server/services/error.server.service');
 const mongoose = require('mongoose');
 const User = mongoose.model('User');
-const log = require(path.resolve('./config/lib/logger'));
+const log = require('../../../../config/lib/logger');
 
 /**
  * Get the list of blocked users by the logged in user

--- a/modules/users/server/controllers/users.block.server.controller.js
+++ b/modules/users/server/controllers/users.block.server.controller.js
@@ -1,7 +1,6 @@
 /**
  * Module dependencies.
  */
-const path = require('path');
 const errorService = require('../../../core/server/services/error.server.service');
 const mongoose = require('mongoose');
 const User = mongoose.model('User');

--- a/modules/users/server/controllers/users.lastseen.server.controller.js
+++ b/modules/users/server/controllers/users.lastseen.server.controller.js
@@ -5,7 +5,7 @@ const mongoose = require('mongoose');
 const moment = require('moment');
 const path = require('path');
 const User = mongoose.model('User');
-const config = require(path.resolve('config/config'));
+const config = require('../../../../config/config');
 
 /**
  * When user is logged in, update her last seen to Now in database

--- a/modules/users/server/controllers/users.lastseen.server.controller.js
+++ b/modules/users/server/controllers/users.lastseen.server.controller.js
@@ -3,7 +3,6 @@
  */
 const mongoose = require('mongoose');
 const moment = require('moment');
-const path = require('path');
 const User = mongoose.model('User');
 const config = require('../../../../config/config');
 

--- a/modules/users/server/controllers/users.password.server.controller.js
+++ b/modules/users/server/controllers/users.password.server.controller.js
@@ -1,7 +1,6 @@
 /**
  * Module dependencies.
  */
-const path = require('path');
 const errorService = require('../../../core/server/services/error.server.service');
 const analyticsHandler = require('../../../core/server/controllers/analytics.server.controller');
 const emailService = require('../../../core/server/services/email.server.service');

--- a/modules/users/server/controllers/users.password.server.controller.js
+++ b/modules/users/server/controllers/users.password.server.controller.js
@@ -2,22 +2,12 @@
  * Module dependencies.
  */
 const path = require('path');
-const errorService = require(path.resolve(
-  './modules/core/server/services/error.server.service',
-));
-const analyticsHandler = require(path.resolve(
-  './modules/core/server/controllers/analytics.server.controller',
-));
-const emailService = require(path.resolve(
-  './modules/core/server/services/email.server.service',
-));
-const profileHandler = require(path.resolve(
-  './modules/users/server/controllers/users.profile.server.controller',
-));
-const statService = require(path.resolve(
-  './modules/stats/server/services/stats.server.service',
-));
-const log = require(path.resolve('./config/lib/logger'));
+const errorService = require('../../../core/server/services/error.server.service');
+const analyticsHandler = require('../../../core/server/controllers/analytics.server.controller');
+const emailService = require('../../../core/server/services/email.server.service');
+const profileHandler = require('./users.profile.server.controller');
+const statService = require('../../../stats/server/services/stats.server.service');
+const log = require('../../../../config/lib/logger');
 const async = require('async');
 const crypto = require('crypto');
 const mongoose = require('mongoose');

--- a/modules/users/server/controllers/users.profile.server.controller.js
+++ b/modules/users/server/controllers/users.profile.server.controller.js
@@ -3,40 +3,20 @@
  */
 const _ = require('lodash');
 const path = require('path');
-const locales = require(path.resolve('./config/shared/locales'));
-const errorService = require(path.resolve(
-  './modules/core/server/services/error.server.service',
-));
-const textService = require(path.resolve(
-  './modules/core/server/services/text.server.service',
-));
-const tribesHandler = require(path.resolve(
-  './modules/tribes/server/controllers/tribes.server.controller',
-));
-const contactHandler = require(path.resolve(
-  './modules/contacts/server/controllers/contacts.server.controller',
-));
-const messageHandler = require(path.resolve(
-  './modules/messages/server/controllers/messages.server.controller',
-));
-const offerHandler = require(path.resolve(
-  './modules/offers/server/controllers/offers.server.controller',
-));
-const emailService = require(path.resolve(
-  './modules/core/server/services/email.server.service',
-));
-const pushService = require(path.resolve(
-  './modules/core/server/services/push.server.service',
-));
-const statService = require(path.resolve(
-  './modules/stats/server/services/stats.server.service',
-));
-const log = require(path.resolve('./config/lib/logger'));
+const locales = require('../../../../config/shared/locales');
+const errorService = require('../../../core/server/services/error.server.service');
+const textService = require('../../../core/server/services/text.server.service');
+const tribesHandler = require('../../../tribes/server/controllers/tribes.server.controller');
+const contactHandler = require('../../../contacts/server/controllers/contacts.server.controller');
+const messageHandler = require('../../../messages/server/controllers/messages.server.controller');
+const offerHandler = require('../../../offers/server/controllers/offers.server.controller');
+const emailService = require('../../../core/server/services/email.server.service');
+const pushService = require('../../../core/server/services/push.server.service');
+const statService = require('../../../stats/server/services/stats.server.service');
+const log = require('../../../../config/lib/logger');
 const del = require('del');
-const messageStatService = require(path.resolve(
-  './modules/messages/server/services/message-stat.server.service',
-));
-const config = require(path.resolve('./config/config'));
+const messageStatService = require('../../../messages/server/services/message-stat.server.service');
+const config = require('../../../../config/config');
 const async = require('async');
 const crypto = require('crypto');
 const sanitizeHtml = require('sanitize-html');

--- a/modules/users/server/controllers/users.suspended.server.controller.js
+++ b/modules/users/server/controllers/users.suspended.server.controller.js
@@ -3,9 +3,7 @@
  */
 const _ = require('lodash');
 const path = require('path');
-const errorService = require(path.resolve(
-  './modules/core/server/services/error.server.service',
-));
+const errorService = require('../../../core/server/services/error.server.service');
 
 /**
  * Handle invalidating sessions of suspended users

--- a/modules/users/server/controllers/users.suspended.server.controller.js
+++ b/modules/users/server/controllers/users.suspended.server.controller.js
@@ -2,7 +2,6 @@
  * Module dependencies.
  */
 const _ = require('lodash');
-const path = require('path');
 const errorService = require('../../../core/server/services/error.server.service');
 
 /**

--- a/modules/users/server/jobs/user-finish-signup.server.job.js
+++ b/modules/users/server/jobs/user-finish-signup.server.job.js
@@ -13,11 +13,9 @@
  */
 const _ = require('lodash');
 const path = require('path');
-const emailService = require(path.resolve(
-  './modules/core/server/services/email.server.service',
-));
-const config = require(path.resolve('./config/config'));
-const log = require(path.resolve('./config/lib/logger'));
+const emailService = require('../../../core/server/services/email.server.service');
+const config = require('../../../../config/config');
+const log = require('../../../../config/lib/logger');
 const async = require('async');
 const moment = require('moment');
 const mongoose = require('mongoose');

--- a/modules/users/server/jobs/user-finish-signup.server.job.js
+++ b/modules/users/server/jobs/user-finish-signup.server.job.js
@@ -12,7 +12,6 @@
  * Module dependencies.
  */
 const _ = require('lodash');
-const path = require('path');
 const emailService = require('../../../core/server/services/email.server.service');
 const config = require('../../../../config/config');
 const log = require('../../../../config/lib/logger');

--- a/modules/users/server/jobs/user-welcome-sequence-first.server.job.js
+++ b/modules/users/server/jobs/user-welcome-sequence-first.server.job.js
@@ -10,7 +10,6 @@
  * Module dependencies.
  */
 const _ = require('lodash');
-const path = require('path');
 const log = require('../../../../config/lib/logger');
 const emailService = require('../../../core/server/services/email.server.service');
 const config = require('../../../../config/config');

--- a/modules/users/server/jobs/user-welcome-sequence-first.server.job.js
+++ b/modules/users/server/jobs/user-welcome-sequence-first.server.job.js
@@ -11,11 +11,9 @@
  */
 const _ = require('lodash');
 const path = require('path');
-const log = require(path.resolve('./config/lib/logger'));
-const emailService = require(path.resolve(
-  './modules/core/server/services/email.server.service',
-));
-const config = require(path.resolve('./config/config'));
+const log = require('../../../../config/lib/logger');
+const emailService = require('../../../core/server/services/email.server.service');
+const config = require('../../../../config/config');
 const async = require('async');
 const moment = require('moment');
 const mongoose = require('mongoose');

--- a/modules/users/server/jobs/user-welcome-sequence-second.server.job.js
+++ b/modules/users/server/jobs/user-welcome-sequence-second.server.job.js
@@ -10,7 +10,6 @@
  * Module dependencies.
  */
 const _ = require('lodash');
-const path = require('path');
 const log = require('../../../../config/lib/logger');
 const emailService = require('../../../core/server/services/email.server.service');
 const config = require('../../../../config/config');

--- a/modules/users/server/jobs/user-welcome-sequence-second.server.job.js
+++ b/modules/users/server/jobs/user-welcome-sequence-second.server.job.js
@@ -11,11 +11,9 @@
  */
 const _ = require('lodash');
 const path = require('path');
-const log = require(path.resolve('./config/lib/logger'));
-const emailService = require(path.resolve(
-  './modules/core/server/services/email.server.service',
-));
-const config = require(path.resolve('./config/config'));
+const log = require('../../../../config/lib/logger');
+const emailService = require('../../../core/server/services/email.server.service');
+const config = require('../../../../config/config');
 const async = require('async');
 const moment = require('moment');
 const mongoose = require('mongoose');

--- a/modules/users/server/jobs/user-welcome-sequence-third.server.job.js
+++ b/modules/users/server/jobs/user-welcome-sequence-third.server.job.js
@@ -10,7 +10,6 @@
  * Module dependencies.
  */
 const _ = require('lodash');
-const path = require('path');
 const log = require('../../../../config/lib/logger');
 const emailService = require('../../../core/server/services/email.server.service');
 const config = require('../../../../config/config');

--- a/modules/users/server/jobs/user-welcome-sequence-third.server.job.js
+++ b/modules/users/server/jobs/user-welcome-sequence-third.server.job.js
@@ -11,11 +11,9 @@
  */
 const _ = require('lodash');
 const path = require('path');
-const log = require(path.resolve('./config/lib/logger'));
-const emailService = require(path.resolve(
-  './modules/core/server/services/email.server.service',
-));
-const config = require(path.resolve('./config/config'));
+const log = require('../../../../config/lib/logger');
+const emailService = require('../../../core/server/services/email.server.service');
+const config = require('../../../../config/config');
 const async = require('async');
 const moment = require('moment');
 const mongoose = require('mongoose');

--- a/modules/users/server/models/user.server.model.js
+++ b/modules/users/server/models/user.server.model.js
@@ -2,7 +2,6 @@
  * Module dependencies.
  */
 const _ = require('lodash');
-const path = require('path');
 const textService = require('../../../core/server/services/text.server.service');
 const languages = require('../../../../config/languages/languages.json');
 const authenticationService = require('../services/authentication.server.service');

--- a/modules/users/server/models/user.server.model.js
+++ b/modules/users/server/models/user.server.model.js
@@ -3,13 +3,9 @@
  */
 const _ = require('lodash');
 const path = require('path');
-const textService = require(path.resolve(
-  './modules/core/server/services/text.server.service',
-));
-const languages = require(path.resolve('./config/languages/languages.json'));
-const authenticationService = require(path.resolve(
-  './modules/users/server/services/authentication.server.service',
-));
+const textService = require('../../../core/server/services/text.server.service');
+const languages = require('../../../../config/languages/languages.json');
+const authenticationService = require('../services/authentication.server.service');
 const crypto = require('crypto');
 const mongoose = require('mongoose');
 const uniqueValidation = require('mongoose-beautiful-unique-validation');

--- a/modules/users/server/policies/users.server.policy.js
+++ b/modules/users/server/policies/users.server.policy.js
@@ -2,7 +2,6 @@
  * Module dependencies.
  */
 let acl = require('acl');
-const path = require('path');
 const errorService = require('../../../core/server/services/error.server.service');
 
 // Using the memory backend

--- a/modules/users/server/policies/users.server.policy.js
+++ b/modules/users/server/policies/users.server.policy.js
@@ -3,9 +3,7 @@
  */
 let acl = require('acl');
 const path = require('path');
-const errorService = require(path.resolve(
-  './modules/core/server/services/error.server.service',
-));
+const errorService = require('../../../core/server/services/error.server.service');
 
 // Using the memory backend
 acl = new acl(new acl.memoryBackend());

--- a/modules/users/server/services/authentication.server.service.js
+++ b/modules/users/server/services/authentication.server.service.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const config = require('../../../../config/config');
 
 exports.generateEmailToken = function (user, saltBuffer) {

--- a/modules/users/server/services/authentication.server.service.js
+++ b/modules/users/server/services/authentication.server.service.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const config = require(path.resolve('./config/config'));
+const config = require('../../../../config/config');
 
 exports.generateEmailToken = function (user, saltBuffer) {
   const email = user.emailTemporary || user.email;

--- a/modules/users/tests/server/jobs/user-finish-signup.server.job.tests.js
+++ b/modules/users/tests/server/jobs/user-finish-signup.server.job.tests.js
@@ -2,7 +2,6 @@
  * Module dependencies.
  */
 const _ = require('lodash');
-const path = require('path');
 const should = require('should');
 const testutils = require('../../../../../testutils/server/server.testutil');
 const config = require('../../../../../config/config');

--- a/modules/users/tests/server/jobs/user-finish-signup.server.job.tests.js
+++ b/modules/users/tests/server/jobs/user-finish-signup.server.job.tests.js
@@ -4,8 +4,8 @@
 const _ = require('lodash');
 const path = require('path');
 const should = require('should');
-const testutils = require(path.resolve('./testutils/server/server.testutil'));
-const config = require(path.resolve('./config/config'));
+const testutils = require('../../../../../testutils/server/server.testutil');
+const config = require('../../../../../config/config');
 const moment = require('moment');
 const mongoose = require('mongoose');
 const User = mongoose.model('User');
@@ -23,9 +23,7 @@ describe('Job: user finish signup', function () {
   const jobs = testutils.catchJobs();
 
   before(function () {
-    userFinishSignupJobHandler = require(path.resolve(
-      './modules/users/server/jobs/user-finish-signup.server.job',
-    ));
+    userFinishSignupJobHandler = require('../../../server/jobs/user-finish-signup.server.job');
   });
 
   // Create an unconfirmed user

--- a/modules/users/tests/server/jobs/user-welcome-sequence-first.server.job.tests.js
+++ b/modules/users/tests/server/jobs/user-welcome-sequence-first.server.job.tests.js
@@ -2,8 +2,8 @@
  * Module dependencies.
  */
 const path = require('path');
-const testutils = require(path.resolve('./testutils/server/server.testutil'));
-const config = require(path.resolve('./config/config'));
+const testutils = require('../../../../../testutils/server/server.testutil');
+const config = require('../../../../../config/config');
 const moment = require('moment');
 const mongoose = require('mongoose');
 const User = mongoose.model('User');
@@ -25,15 +25,9 @@ describe('Job: welcome sequence, first email', function () {
   const jobs = testutils.catchJobs();
 
   before(function () {
-    userWelcomeSequenceFirstJobHandler = require(path.resolve(
-      './modules/users/server/jobs/user-welcome-sequence-first.server.job',
-    ));
-    userWelcomeSequenceSecondJobHandler = require(path.resolve(
-      './modules/users/server/jobs/user-welcome-sequence-second.server.job',
-    ));
-    userWelcomeSequenceThirdJobHandler = require(path.resolve(
-      './modules/users/server/jobs/user-welcome-sequence-third.server.job',
-    ));
+    userWelcomeSequenceFirstJobHandler = require('../../../server/jobs/user-welcome-sequence-first.server.job');
+    userWelcomeSequenceSecondJobHandler = require('../../../server/jobs/user-welcome-sequence-second.server.job');
+    userWelcomeSequenceThirdJobHandler = require('../../../server/jobs/user-welcome-sequence-third.server.job');
   });
 
   // Create time points to test that welcome sequence is sent in correct time

--- a/modules/users/tests/server/jobs/user-welcome-sequence-first.server.job.tests.js
+++ b/modules/users/tests/server/jobs/user-welcome-sequence-first.server.job.tests.js
@@ -1,7 +1,6 @@
 /**
  * Module dependencies.
  */
-const path = require('path');
 const testutils = require('../../../../../testutils/server/server.testutil');
 const config = require('../../../../../config/config');
 const moment = require('moment');

--- a/modules/users/tests/server/jobs/user-welcome-sequence-second.server.job.tests.js
+++ b/modules/users/tests/server/jobs/user-welcome-sequence-second.server.job.tests.js
@@ -2,8 +2,8 @@
  * Module dependencies.
  */
 const path = require('path');
-const testutils = require(path.resolve('./testutils/server/server.testutil'));
-const config = require(path.resolve('./config/config'));
+const testutils = require('../../../../../testutils/server/server.testutil');
+const config = require('../../../../../config/config');
 const moment = require('moment');
 const mongoose = require('mongoose');
 const User = mongoose.model('User');
@@ -26,15 +26,9 @@ describe('Job: welcome sequence, second email', function () {
   const jobs = testutils.catchJobs();
 
   before(function () {
-    userWelcomeSequenceFirstJobHandler = require(path.resolve(
-      './modules/users/server/jobs/user-welcome-sequence-first.server.job',
-    ));
-    userWelcomeSequenceSecondJobHandler = require(path.resolve(
-      './modules/users/server/jobs/user-welcome-sequence-second.server.job',
-    ));
-    userWelcomeSequenceThirdJobHandler = require(path.resolve(
-      './modules/users/server/jobs/user-welcome-sequence-third.server.job',
-    ));
+    userWelcomeSequenceFirstJobHandler = require('../../../server/jobs/user-welcome-sequence-first.server.job');
+    userWelcomeSequenceSecondJobHandler = require('../../../server/jobs/user-welcome-sequence-second.server.job');
+    userWelcomeSequenceThirdJobHandler = require('../../../server/jobs/user-welcome-sequence-third.server.job');
   });
 
   // Create time points to test that welcome sequence is sent in correct time

--- a/modules/users/tests/server/jobs/user-welcome-sequence-second.server.job.tests.js
+++ b/modules/users/tests/server/jobs/user-welcome-sequence-second.server.job.tests.js
@@ -1,7 +1,6 @@
 /**
  * Module dependencies.
  */
-const path = require('path');
 const testutils = require('../../../../../testutils/server/server.testutil');
 const config = require('../../../../../config/config');
 const moment = require('moment');

--- a/modules/users/tests/server/jobs/user-welcome-sequence-third.server.job.tests.js
+++ b/modules/users/tests/server/jobs/user-welcome-sequence-third.server.job.tests.js
@@ -2,8 +2,8 @@
  * Module dependencies.
  */
 const path = require('path');
-const testutils = require(path.resolve('./testutils/server/server.testutil'));
-const config = require(path.resolve('./config/config'));
+const testutils = require('../../../../../testutils/server/server.testutil');
+const config = require('../../../../../config/config');
 const moment = require('moment');
 const mongoose = require('mongoose');
 const User = mongoose.model('User');
@@ -26,15 +26,9 @@ describe('Job: welcome sequence, third email', function () {
   const jobs = testutils.catchJobs();
 
   before(function () {
-    userWelcomeSequenceFirstJobHandler = require(path.resolve(
-      './modules/users/server/jobs/user-welcome-sequence-first.server.job',
-    ));
-    userWelcomeSequenceSecondJobHandler = require(path.resolve(
-      './modules/users/server/jobs/user-welcome-sequence-second.server.job',
-    ));
-    userWelcomeSequenceThirdJobHandler = require(path.resolve(
-      './modules/users/server/jobs/user-welcome-sequence-third.server.job',
-    ));
+    userWelcomeSequenceFirstJobHandler = require('../../../server/jobs/user-welcome-sequence-first.server.job');
+    userWelcomeSequenceSecondJobHandler = require('../../../server/jobs/user-welcome-sequence-second.server.job');
+    userWelcomeSequenceThirdJobHandler = require('../../../server/jobs/user-welcome-sequence-third.server.job');
   });
 
   // Create time points to test that welcome sequence is sent in correct time

--- a/modules/users/tests/server/jobs/user-welcome-sequence-third.server.job.tests.js
+++ b/modules/users/tests/server/jobs/user-welcome-sequence-third.server.job.tests.js
@@ -1,7 +1,6 @@
 /**
  * Module dependencies.
  */
-const path = require('path');
 const testutils = require('../../../../../testutils/server/server.testutil');
 const config = require('../../../../../config/config');
 const moment = require('moment');

--- a/modules/users/tests/server/search-users.server.routes.tests.js
+++ b/modules/users/tests/server/search-users.server.routes.tests.js
@@ -5,11 +5,9 @@ const path = require('path');
 const sinon = require('sinon');
 const mongoose = require('mongoose');
 const should = require('should');
-const config = require(path.resolve('./config/config'));
-const userHandler = require(path.resolve(
-  './modules/users/server/controllers/users.profile.server.controller',
-));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const config = require('../../../../config/config');
+const userHandler = require('../../server/controllers/users.profile.server.controller');
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');
 
@@ -24,7 +22,7 @@ describe('Search users: GET /users?search=string', function () {
     sinon.stub(config.limits, 'paginationLimit').value(limit);
 
     // the limit is used in this config, so we needed to stub limit before importing this
-    const express = require(path.resolve('./config/lib/express'));
+    const express = require('../../../../config/lib/express');
     // Get application
     const app = express.init(mongoose.connection);
     agent = request.agent(app);

--- a/modules/users/tests/server/search-users.server.routes.tests.js
+++ b/modules/users/tests/server/search-users.server.routes.tests.js
@@ -1,7 +1,6 @@
 const request = require('supertest');
 const async = require('async');
 const _ = require('lodash');
-const path = require('path');
 const sinon = require('sinon');
 const mongoose = require('mongoose');
 const should = require('should');

--- a/modules/users/tests/server/user-avatar.server.routes.tests.js
+++ b/modules/users/tests/server/user-avatar.server.routes.tests.js
@@ -1,5 +1,4 @@
 const request = require('supertest');
-const path = require('path');
 const mongoose = require('mongoose');
 
 const config = require('../../../../config/config');

--- a/modules/users/tests/server/user-avatar.server.routes.tests.js
+++ b/modules/users/tests/server/user-avatar.server.routes.tests.js
@@ -2,9 +2,9 @@ const request = require('supertest');
 const path = require('path');
 const mongoose = require('mongoose');
 
-const config = require(path.resolve('./config/config'));
-const express = require(path.resolve('./config/lib/express'));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const config = require('../../../../config/config');
+const express = require('../../../../config/lib/express');
+const utils = require('../../../../testutils/server/data.server.testutil');
 require('should');
 
 describe('User Avatar CRUD tests', () => {

--- a/modules/users/tests/server/user-block.server.routes.tests.js
+++ b/modules/users/tests/server/user-block.server.routes.tests.js
@@ -1,6 +1,5 @@
 const should = require('should');
 const request = require('supertest');
-const path = require('path');
 const mongoose = require('mongoose');
 const User = mongoose.model('User');
 const express = require('../../../../config/lib/express');

--- a/modules/users/tests/server/user-block.server.routes.tests.js
+++ b/modules/users/tests/server/user-block.server.routes.tests.js
@@ -3,8 +3,8 @@ const request = require('supertest');
 const path = require('path');
 const mongoose = require('mongoose');
 const User = mongoose.model('User');
-const express = require(path.resolve('./config/lib/express'));
-const log = require(path.resolve('./config/lib/logger'));
+const express = require('../../../../config/lib/express');
+const log = require('../../../../config/lib/logger');
 
 /**
  * Globals

--- a/modules/users/tests/server/user-change-locale.server.routes.tests.js
+++ b/modules/users/tests/server/user-change-locale.server.routes.tests.js
@@ -1,5 +1,4 @@
 const mongoose = require('mongoose');
-const path = require('path');
 const request = require('supertest');
 const should = require('should');
 const utils = require('../../../../testutils/server/data.server.testutil');

--- a/modules/users/tests/server/user-change-locale.server.routes.tests.js
+++ b/modules/users/tests/server/user-change-locale.server.routes.tests.js
@@ -2,8 +2,8 @@ const mongoose = require('mongoose');
 const path = require('path');
 const request = require('supertest');
 const should = require('should');
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
-const express = require(path.resolve('./config/lib/express'));
+const utils = require('../../../../testutils/server/data.server.testutil');
+const express = require('../../../../config/lib/express');
 const User = mongoose.model('User');
 
 const app = express.init(mongoose.connection);

--- a/modules/users/tests/server/user-lastseen.server.tests.js
+++ b/modules/users/tests/server/user-lastseen.server.tests.js
@@ -1,5 +1,4 @@
 const request = require('supertest');
-const path = require('path');
 const moment = require('moment');
 const mongoose = require('mongoose');
 const should = require('should');

--- a/modules/users/tests/server/user-lastseen.server.tests.js
+++ b/modules/users/tests/server/user-lastseen.server.tests.js
@@ -4,9 +4,9 @@ const moment = require('moment');
 const mongoose = require('mongoose');
 const should = require('should');
 const sinon = require('sinon');
-const config = require(path.resolve('./config/config'));
-const express = require(path.resolve('./config/lib/express'));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const config = require('../../../../config/config');
+const express = require('../../../../config/lib/express');
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');
 

--- a/modules/users/tests/server/user-password.server.routes.tests.js
+++ b/modules/users/tests/server/user-password.server.routes.tests.js
@@ -2,8 +2,8 @@ const should = require('should');
 const request = require('supertest');
 const path = require('path');
 const mongoose = require('mongoose');
-const express = require(path.resolve('./config/lib/express'));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const express = require('../../../../config/lib/express');
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');
 

--- a/modules/users/tests/server/user-password.server.routes.tests.js
+++ b/modules/users/tests/server/user-password.server.routes.tests.js
@@ -1,6 +1,5 @@
 const should = require('should');
 const request = require('supertest');
-const path = require('path');
 const mongoose = require('mongoose');
 const express = require('../../../../config/lib/express');
 const utils = require('../../../../testutils/server/data.server.testutil');

--- a/modules/users/tests/server/user-profile.server.routes.tests.js
+++ b/modules/users/tests/server/user-profile.server.routes.tests.js
@@ -3,9 +3,9 @@ const request = require('supertest');
 const path = require('path');
 const mongoose = require('mongoose');
 const moment = require('moment');
-const config = require(path.resolve('./config/config'));
-const express = require(path.resolve('./config/lib/express'));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const config = require('../../../../config/config');
+const express = require('../../../../config/lib/express');
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');
 

--- a/modules/users/tests/server/user-profile.server.routes.tests.js
+++ b/modules/users/tests/server/user-profile.server.routes.tests.js
@@ -1,6 +1,5 @@
 const should = require('should');
 const request = require('supertest');
-const path = require('path');
 const mongoose = require('mongoose');
 const moment = require('moment');
 const config = require('../../../../config/config');

--- a/modules/users/tests/server/user-removal.server.routes.tests.js
+++ b/modules/users/tests/server/user-removal.server.routes.tests.js
@@ -5,12 +5,10 @@ const sinon = require('sinon');
 const request = require('supertest');
 const path = require('path');
 const mongoose = require('mongoose');
-const config = require(path.resolve('./config/config'));
-const express = require(path.resolve('./config/lib/express'));
-const testutils = require(path.resolve('./testutils/server/server.testutil'));
-const dataUtils = require(path.resolve(
-  './testutils/server/data.server.testutil',
-));
+const config = require('../../../../config/config');
+const express = require('../../../../config/lib/express');
+const testutils = require('../../../../testutils/server/server.testutil');
+const dataUtils = require('../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');
 const Contact = mongoose.model('Contact');

--- a/modules/users/tests/server/user-signup-validate.server.routes.tests.js
+++ b/modules/users/tests/server/user-signup-validate.server.routes.tests.js
@@ -2,9 +2,9 @@ const should = require('should');
 const request = require('supertest');
 const path = require('path');
 const mongoose = require('mongoose');
-const express = require(path.resolve('./config/lib/express'));
-const config = require(path.resolve('./config/config'));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const express = require('../../../../config/lib/express');
+const config = require('../../../../config/config');
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');
 

--- a/modules/users/tests/server/user-signup-validate.server.routes.tests.js
+++ b/modules/users/tests/server/user-signup-validate.server.routes.tests.js
@@ -1,6 +1,5 @@
 const should = require('should');
 const request = require('supertest');
-const path = require('path');
 const mongoose = require('mongoose');
 const express = require('../../../../config/lib/express');
 const config = require('../../../../config/config');

--- a/modules/users/tests/server/user-signup.server.routes.tests.js
+++ b/modules/users/tests/server/user-signup.server.routes.tests.js
@@ -1,6 +1,5 @@
 const should = require('should');
 const request = require('supertest');
-const path = require('path');
 const mongoose = require('mongoose');
 const express = require('../../../../config/lib/express');
 const testutils = require('../../../../testutils/server/server.testutil');

--- a/modules/users/tests/server/user-signup.server.routes.tests.js
+++ b/modules/users/tests/server/user-signup.server.routes.tests.js
@@ -2,11 +2,9 @@ const should = require('should');
 const request = require('supertest');
 const path = require('path');
 const mongoose = require('mongoose');
-const express = require(path.resolve('./config/lib/express'));
-const testutils = require(path.resolve('./testutils/server/server.testutil'));
-const dataUtils = require(path.resolve(
-  './testutils/server/data.server.testutil',
-));
+const express = require('../../../../config/lib/express');
+const testutils = require('../../../../testutils/server/server.testutil');
+const dataUtils = require('../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');
 

--- a/modules/users/tests/server/user-tribe.server.routes.tests.js
+++ b/modules/users/tests/server/user-tribe.server.routes.tests.js
@@ -2,8 +2,8 @@ const should = require('should');
 const request = require('supertest');
 const path = require('path');
 const mongoose = require('mongoose');
-const express = require(path.resolve('./config/lib/express'));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const express = require('../../../../config/lib/express');
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');
 const Tribe = mongoose.model('Tribe');

--- a/modules/users/tests/server/user-tribe.server.routes.tests.js
+++ b/modules/users/tests/server/user-tribe.server.routes.tests.js
@@ -1,6 +1,5 @@
 const should = require('should');
 const request = require('supertest');
-const path = require('path');
 const mongoose = require('mongoose');
 const express = require('../../../../config/lib/express');
 const utils = require('../../../../testutils/server/data.server.testutil');

--- a/modules/users/tests/server/user.server.model.tests.js
+++ b/modules/users/tests/server/user.server.model.tests.js
@@ -4,8 +4,8 @@
 const path = require('path');
 const should = require('should');
 const mongoose = require('mongoose');
-const config = require(path.resolve('./config/config'));
-const utils = require(path.resolve('./testutils/server/data.server.testutil'));
+const config = require('../../../../config/config');
+const utils = require('../../../../testutils/server/data.server.testutil');
 
 const User = mongoose.model('User');
 

--- a/modules/users/tests/server/user.server.model.tests.js
+++ b/modules/users/tests/server/user.server.model.tests.js
@@ -1,7 +1,6 @@
 /**
  * Module dependencies.
  */
-const path = require('path');
 const should = require('should');
 const mongoose = require('mongoose');
 const config = require('../../../../config/config');

--- a/scripts/db-maintenance/create-missing-message-stats.js
+++ b/scripts/db-maintenance/create-missing-message-stats.js
@@ -31,8 +31,7 @@ var searchMessagesParam = {
   // */
 };
 
-var path = require('path'),
-    chalk = require('chalk'),
+var chalk = require('chalk'),
     async = require('async'),
     config = require('../../config/config'),
     configMongoose = require('../../config/lib/mongoose'),

--- a/scripts/db-maintenance/create-missing-message-stats.js
+++ b/scripts/db-maintenance/create-missing-message-stats.js
@@ -34,16 +34,13 @@ var searchMessagesParam = {
 var path = require('path'),
     chalk = require('chalk'),
     async = require('async'),
-    config = require(path.resolve('./config/config')),
-    configMongoose = require(path.resolve('./config/lib/mongoose')),
+    config = require('../../config/config'),
+    configMongoose = require('../../config/lib/mongoose'),
     mongoose = require('mongoose'),
-    messageModels = require(path.resolve(
-      './modules/messages/server/models/message.server.model')),
-    messageStatModels = require(path.resolve(
-      './modules/messages/server/models/message-stat.server.model')),
+    messageModels = require('../../modules/messages/server/models/message.server.model'),
+    messageStatModels = require('../../modules/messages/server/models/message-stat.server.model'),
     Message = mongoose.model('Message'),
-    messageStatService = require(path.resolve(
-      './modules/messages/server/services/message-stat.server.service'));
+    messageStatService = require('../../modules/messages/server/services/message-stat.server.service');
 
     // the expression below uses ES6 Promises, so it shouldn't belong here.
     // there is a warning when one doesn't provide one's own library.

--- a/scripts/db-maintenance/remove-duplicate-contacts.js
+++ b/scripts/db-maintenance/remove-duplicate-contacts.js
@@ -8,12 +8,12 @@
 
 var path = require('path'),
     async = require('async'),
-    config = require(path.resolve('./config/config')),
-    configMongoose = require(path.resolve('./config/lib/mongoose')),
-    configExpress = require(path.resolve('./config/lib/express')),
+    config = require('../../config/config'),
+    configMongoose = require('../../config/lib/mongoose'),
+    configExpress = require('../../config/lib/express'),
     chalk = require('chalk'),
     mongoose = require('mongoose'),
-    contactsModels = require(path.resolve('./modules/contacts/server/models/contacts.server.model')),
+    contactsModels = require('../../modules/contacts/server/models/contacts.server.model'),
     Contact = mongoose.model('Contact');
 
 console.log(chalk.white('--'));

--- a/scripts/db-maintenance/remove-duplicate-contacts.js
+++ b/scripts/db-maintenance/remove-duplicate-contacts.js
@@ -6,8 +6,7 @@
  * NODE_ENV=development node scripts/db-maintenance/remove-duplicate-contacts.js
  */
 
-var path = require('path'),
-    async = require('async'),
+var async = require('async'),
     config = require('../../config/config'),
     configMongoose = require('../../config/lib/mongoose'),
     configExpress = require('../../config/lib/express'),

--- a/scripts/exportEmailsAsEml.js
+++ b/scripts/exportEmailsAsEml.js
@@ -18,8 +18,8 @@ var path = require('path'),
     async = require('async'),
     chalk = require('chalk'),
     nodemailer = require('nodemailer'),
-    config = require(path.resolve('./config/config')),
-    emailService = require(path.resolve('./modules/core/server/services/email.server.service'));
+    config = require('../config/config'),
+    emailService = require('../modules/core/server/services/email.server.service');
 
 // Default temp folder
 var tempFolder = (process.argv[2] == null) ? path.resolve('./tmp/renderedEmails') : process.argv[2];

--- a/scripts/influxdb/fill-member-count-to-influx.js
+++ b/scripts/influxdb/fill-member-count-to-influx.js
@@ -2,11 +2,11 @@ var _ = require('lodash'),
     path = require('path'),
     async = require('async'),
     moment = require('moment'),
-    mongooseService = require(path.resolve('./config/lib/mongoose')),
+    mongooseService = require('../../config/lib/mongoose'),
     mongoose = require('mongoose'),
-    statsService = require(path.resolve('./modules/stats/server/services/stats.server.service'));
+    statsService = require('../../modules/stats/server/services/stats.server.service');
 
-require(path.resolve('./modules/users/server/models/user.server.model'));
+require('../../modules/users/server/models/user.server.model');
 var User = mongoose.model('User');
 
 var cumulativeUserCount = 0;

--- a/scripts/influxdb/fill-member-count-to-influx.js
+++ b/scripts/influxdb/fill-member-count-to-influx.js
@@ -1,5 +1,4 @@
 var _ = require('lodash'),
-    path = require('path'),
     async = require('async'),
     moment = require('moment'),
     mongooseService = require('../../config/lib/mongoose'),

--- a/scripts/influxdb/fill-messages-to-influx.js
+++ b/scripts/influxdb/fill-messages-to-influx.js
@@ -1,11 +1,11 @@
 var path = require('path'),
     chalk = require('chalk'),
     async = require('async'),
-    config = require(path.resolve('./config/config')),
-    configMongoose = require(path.resolve('./config/lib/mongoose')),
+    config = require('../../config/config'),
+    configMongoose = require('../../config/lib/mongoose'),
     mongoose = require('mongoose'),
-    messageToInflux = require(path.resolve('./modules/messages/server/services/message-to-influx.server.service')),
-    messageModels = require(path.resolve('./modules/messages/server/models/message.server.model')),
+    messageToInflux = require('../../modules/messages/server/services/message-to-influx.server.service'),
+    messageModels = require('../../modules/messages/server/models/message.server.model'),
     Message = mongoose.model('Message');
 
     // the expression below uses ES6 Promises, so it shouldn't belong here.

--- a/scripts/influxdb/fill-messages-to-influx.js
+++ b/scripts/influxdb/fill-messages-to-influx.js
@@ -1,5 +1,4 @@
-var path = require('path'),
-    chalk = require('chalk'),
+var chalk = require('chalk'),
     async = require('async'),
     config = require('../../config/config'),
     configMongoose = require('../../config/lib/mongoose'),

--- a/scripts/influxdb/fill-signups-to-influx.js
+++ b/scripts/influxdb/fill-signups-to-influx.js
@@ -16,8 +16,7 @@
 /**
  * Script dependencies
  */
-var path = require('path'),
-    async = require('async'),
+var async = require('async'),
     mongoose = require('mongoose'),
     argv = require('yargs').argv,
     mongooseHelper = require('../../config/lib/mongoose'),

--- a/scripts/influxdb/fill-signups-to-influx.js
+++ b/scripts/influxdb/fill-signups-to-influx.js
@@ -20,10 +20,10 @@ var path = require('path'),
     async = require('async'),
     mongoose = require('mongoose'),
     argv = require('yargs').argv,
-    mongooseHelper = require(path.resolve('./config/lib/mongoose')),
-    statService = require(path.resolve('./modules/stats/server/services/stats.server.service'));
+    mongooseHelper = require('../../config/lib/mongoose'),
+    statService = require('../../modules/stats/server/services/stats.server.service');
 
-require(path.resolve('./modules/users/server/models/user.server.model'));
+require('../../modules/users/server/models/user.server.model');
 
 var User = mongoose.model('User');
 

--- a/testutils/server/server.testutil.js
+++ b/testutils/server/server.testutil.js
@@ -1,8 +1,6 @@
 /**
  * Utility helpers for testing backend code
  */
-
-const path = require('path');
 const config = require('../../config/config');
 const agenda = require('../../config/lib/agenda');
 

--- a/testutils/server/server.testutil.js
+++ b/testutils/server/server.testutil.js
@@ -3,8 +3,8 @@
  */
 
 const path = require('path');
-const config = require(path.resolve('./config/config'));
-const agenda = require(path.resolve('./config/lib/agenda'));
+const config = require('../../config/config');
+const agenda = require('../../config/lib/agenda');
 
 /**
  * Helper for testing Agenda jobs

--- a/worker.js
+++ b/worker.js
@@ -7,7 +7,6 @@ const config = require('./config/config');
 const async = require('async');
 const mongooseService = require('./config/lib/mongoose');
 const worker = require('./config/lib/worker');
-const path = require('path');
 const log = require('./config/lib/logger');
 const Sentry = require('@sentry/node');
 

--- a/worker.js
+++ b/worker.js
@@ -8,7 +8,7 @@ const async = require('async');
 const mongooseService = require('./config/lib/mongoose');
 const worker = require('./config/lib/worker');
 const path = require('path');
-const log = require(path.resolve('./config/lib/logger'));
+const log = require('./config/lib/logger');
 const Sentry = require('@sentry/node');
 
 if (config.sentry.enabled) {


### PR DESCRIPTION
The jscodeshift code used for the transformation:

```js
const path = require('path');

export default function transformer(file, api) {
  const j = api.jscodeshift;

  return j(file.source)
    .find(j.CallExpression, {callee: {type: "Identifier", name: "require"}})
    .filter(callExpr => {  // has path.resolve() as an argument
      return callExpr.value.arguments[0].type === "CallExpression" // call expression (not a literal)
        && callExpr.value.arguments[0].callee.property.name === "resolve"
        && callExpr.value.arguments[0].arguments[0].type === "Literal";
    })
    .forEach(callExpr => {
      const originalPath = callExpr.value.arguments[0].arguments[0].value;
      const absolutePath = path.resolve(originalPath);
      const relativePath = path.relative(path.dirname(file.path), absolutePath);

      // files from the same directory resulted in 'Error: Cannot find module' if './' was not added
      callExpr.value.arguments[0] = j.literal(relativePath.startsWith('.') ? relativePath : "./" + relativePath);
    })
    .toSource({quote: 'single'});
}
```

A step towards #2486 
