### PR TITLE
Fix: add missing query client to language list in messages

### DIFF
--- a/modules/users/client/components/Monkeybox.js
+++ b/modules/users/client/components/Monkeybox.js
@@ -51,6 +51,8 @@ TribesInCommon.propTypes = {
   otherUser: userType.isRequired,
 };
 
+// Required by LanguageList
+// @TODO: move this to higher up in the React tree once we no longer deal with Angular
 const queryClient = new QueryClient();
 
 export default function Monkeybox({ user, otherUser }) {

--- a/modules/users/client/components/Monkeybox.js
+++ b/modules/users/client/components/Monkeybox.js
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 
 // Internal dependencies
 import { userType } from '@/modules/users/client/users.prop-types';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import Avatar from '@/modules/users/client/components/Avatar.component';
 import LanguageList from './LanguageList';
 
@@ -50,27 +51,31 @@ TribesInCommon.propTypes = {
   otherUser: userType.isRequired,
 };
 
+const queryClient = new QueryClient();
+
 export default function Monkeybox({ user, otherUser }) {
   const { t } = useTranslation('users');
   return (
-    <div className="monkeybox panel panel-default">
-      <div className="panel-body">
-        <Avatar user={user} size={64} />
-        <h3>
-          <a href={`/profile/${user.username}`}>{user.displayName}</a>
-        </h3>
-        <TribesInCommon user={user} otherUser={otherUser} />
-        {user.languages.length > 0 && (
-          <div className="monkeybox-section">
-            <h4>{t('Languages')}</h4>
-            <LanguageList
-              className="list-unstyled"
-              languages={user.languages}
-            />
-          </div>
-        )}
+    <QueryClientProvider client={queryClient}>
+      <div className="monkeybox panel panel-default">
+        <div className="panel-body">
+          <Avatar user={user} size={64} />
+          <h3>
+            <a href={`/profile/${user.username}`}>{user.displayName}</a>
+          </h3>
+          <TribesInCommon user={user} otherUser={otherUser} />
+          {user.languages.length > 0 && (
+            <div className="monkeybox-section">
+              <h4>{t('Languages')}</h4>
+              <LanguageList
+                className="list-unstyled"
+                languages={user.languages}
+              />
+            </div>
+          )}
+        </div>
       </div>
-    </div>
+    </QueryClientProvider>
   );
 }
 


### PR DESCRIPTION
#### Proposed Changes

* Add missing Query Provider for language list in the message thread

In https://github.com/Trustroots/trustroots/pull/2494 I missed one Query provider when the language list was used; my test user didn't have messages so when smoke testing the change, message thread worked. My bad!

#### Testing Instructions

* Have user with some languages in their profile
* Have a message thread with that user
* Observe no longer crashing message thread when languages are listed
    ![image](https://user-images.githubusercontent.com/87168/149673926-89127534-7c74-4356-bb80-a0e8c7cb9f82.png)


Fixes https://github.com/Trustroots/trustroots/issues/2511
