### PR TITLE
Fix: 2nd attempt at query provider issue

### DIFF
--- a/modules/messages/client/components/Thread.component.js
+++ b/modules/messages/client/components/Thread.component.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { useMediaQuery } from 'react-responsive';
 import { useTranslation } from 'react-i18next';
+import { QueryClient, QueryClientProvider } from 'react-query';
 
 import {
   getRouteParams,
@@ -24,6 +25,10 @@ import LoadingIndicator from '@/modules/core/client/components/LoadingIndicator'
 import ReferenceThread from '@/modules/references-thread/client/components/ReferenceThread';
 import plainTextLength from '@/modules/core/client/filters/plain-text-length.client.filter';
 import { update as updateUnreadMessageCount } from '@/modules/messages/client/services/unread-message-count.client.service';
+
+// Required by LanguageList in Monkeybox component
+// @TODO: move this to higher up in the React tree once we no longer deal with Angular
+const queryClient = new QueryClient();
 
 const api = {
   messages: messagesAPI,
@@ -344,7 +349,9 @@ export default function Thread({ user, profileMinimumLength }) {
         </div>
         {otherUser && !isExtraSmall && !removed && (
           <div className="col-sm-3 text-center">
-            <Monkeybox user={otherUser} otherUser={user} />
+            <QueryClientProvider client={queryClient}>
+              <Monkeybox user={otherUser} otherUser={user} />
+            </QueryClientProvider>
             {messages.length > 0 && (
               <ReferenceThread userToId={otherUser._id} />
             )}

--- a/modules/users/client/components/Monkeybox.js
+++ b/modules/users/client/components/Monkeybox.js
@@ -5,7 +5,6 @@ import { useTranslation } from 'react-i18next';
 
 // Internal dependencies
 import { userType } from '@/modules/users/client/users.prop-types';
-import { QueryClient, QueryClientProvider } from 'react-query';
 import Avatar from '@/modules/users/client/components/Avatar.component';
 import LanguageList from './LanguageList';
 
@@ -51,33 +50,27 @@ TribesInCommon.propTypes = {
   otherUser: userType.isRequired,
 };
 
-// Required by LanguageList
-// @TODO: move this to higher up in the React tree once we no longer deal with Angular
-const queryClient = new QueryClient();
-
 export default function Monkeybox({ user, otherUser }) {
   const { t } = useTranslation('users');
   return (
-    <QueryClientProvider client={queryClient}>
-      <div className="monkeybox panel panel-default">
-        <div className="panel-body">
-          <Avatar user={user} size={64} />
-          <h3>
-            <a href={`/profile/${user.username}`}>{user.displayName}</a>
-          </h3>
-          <TribesInCommon user={user} otherUser={otherUser} />
-          {user.languages.length > 0 && (
-            <div className="monkeybox-section">
-              <h4>{t('Languages')}</h4>
-              <LanguageList
-                className="list-unstyled"
-                languages={user.languages}
-              />
-            </div>
-          )}
-        </div>
+    <div className="monkeybox panel panel-default">
+      <div className="panel-body">
+        <Avatar user={user} size={64} />
+        <h3>
+          <a href={`/profile/${user.username}`}>{user.displayName}</a>
+        </h3>
+        <TribesInCommon user={user} otherUser={otherUser} />
+        {user.languages.length > 0 && (
+          <div className="monkeybox-section">
+            <h4>{t('Languages')}</h4>
+            <LanguageList
+              className="list-unstyled"
+              languages={user.languages}
+            />
+          </div>
+        )}
       </div>
-    </QueryClientProvider>
+    </div>
   );
 }
 


### PR DESCRIPTION
2nd attempt at fixing https://github.com/Trustroots/trustroots/issues/2511 (previous in https://github.com/Trustroots/trustroots/pull/2517)

This time moved 1 level up in React tree, to start from the highest point with Angular.

The previous fix worked locally but didn't work in production. I'm not entirely sure, as I can't replicate the issue locally when building production build either.

