### PR TITLE
Add filter option: can accommodate multiple guests #2513 

### DIFF
--- a/modules/offers/server/controllers/offers.server.controller.js
+++ b/modules/offers/server/controllers/offers.server.controller.js
@@ -608,6 +608,21 @@ exports.list = function (req, res) {
     }
   }
 
+  // offer maxGuests filter
+  if (filters.hasObjectFilter('offer')) {
+    // Accept only valid values, ignore the rest
+    // @link https://lodash.com/docs/#filter
+    const maxGuestsReq = filters.offer.maxGuests;
+
+    query.push({
+      $match: {
+        maxGuests: {
+          $gte: maxGuestsReq,
+        },
+      },
+    });
+  }
+
   // Filter out users that do not share any circles with the authenticated user
   // and chose to not appear in those searches.
   const showOnlyInMyCirclesQueries = [{ showOnlyInMyCircles: false }];

--- a/modules/search/client/controllers/search.client.controller.js
+++ b/modules/search/client/controllers/search.client.controller.js
@@ -101,6 +101,18 @@ function SearchController(
       },
     );
 
+    // Watch for changes at tribes filters
+    $scope.$watchCollection(
+      'search.filters.offer',
+      function (newOfferFilters, oldOfferFilters) {
+        if (!angular.equals(newOfferFilters, oldOfferFilters)) {
+          // Save new value to cache
+          FiltersService.set('offer', newOfferFilters);
+          onFiltersUpdated();
+        }
+      },
+    );
+
     // `SearchMap` controller sends these signals down to this controller
     $scope.$on('search.loadingOffer', function () {
       vm.offer = false;

--- a/modules/search/client/services/filters.client.service.js
+++ b/modules/search/client/services/filters.client.service.js
@@ -13,6 +13,7 @@ function FiltersService($log, Authentication, locker) {
     seen: {
       months: 6,
     },
+    offer: { maxGuests: 1 },
   };
 
   // Make cache id unique for this user

--- a/modules/search/client/views/search-sidebar-filters.client.view.html
+++ b/modules/search/client/views/search-sidebar-filters.client.view.html
@@ -6,6 +6,52 @@
   </div>
   <!-- /Offer type filter -->
 
+  <!-- Number of People offer maxGuests filter -->
+  <fieldset class="offer-maxguests">
+    <legend>
+      <h4 id="maxGuests">How many persons can the host accommodate?</h4>
+    </legend>
+    <div class="input-group input-group-stepper">
+      <span class="input-group-btn">
+        <button
+          type="button"
+          class="btn btn-lg btn-inverse-primary btn-round"
+          ng-click="search.filters.offer.maxGuests = search.filters.offer.maxGuests - 1"
+          ng-disabled="search.filters.offer.maxGuests <= 1"
+          aria-hidden="true"
+        >
+          <i class="icon-minus"></i>
+        </button>
+      </span>
+      <input
+        type="number"
+        aria-labelledby="maxGuests"
+        aria-required="true"
+        ng-disabled="!search.filters.offer"
+        ng-model="search.filters.offer.maxGuests"
+        class="form-control input-lg input-plain text-center font-brand-regular"
+        maxlength="2"
+        min="1"
+        max="10"
+        size="2"
+        step="1"
+        pattern="[0-9]{1,2}"
+      />
+      <span class="input-group-btn">
+        <button
+          type="button"
+          class="btn btn-lg btn-inverse-primary btn-round"
+          ng-click="search.filters.offer.maxGuests = search.filters.offer.maxGuests + 1"
+          ng-disabled="search.filters.offer.maxGuests >= 10"
+          aria-hidden="true"
+        >
+          <i class="icon-plus"></i>
+        </button>
+      </span>
+    </div>
+  </fieldset>
+  <!-- /Number of People offer maxGuests filter -->
+
   <hr class="hr-gray hr-tight" />
 
   <!-- Tribes type filter -->


### PR DESCRIPTION
Through support:

It would be great if in the filters exited an option such as "hosts that can accommodate more than 1 person", it would be much easier to find someone who can host more people.

[bug 2513]

- on /search below "Hosts or meetups ?" have added a inc and dec buttons
- Text is "How many persons can the host accommodate?"
- based on the selected value the search is modified for maxGuests
- html filedset is taken from existing code

#### Testing Instructions

/search page from side bar select / increment / decrement the number of people which the host can accept.
