### PR TITLE
Bugfix: Remove "Read more" on small screens

### DIFF
--- a/modules/core/client/components/NavigationLoggedOut.js
+++ b/modules/core/client/components/NavigationLoggedOut.js
@@ -30,7 +30,7 @@ export default function NavigationLoggedOut({ currentPath }) {
         {currentPath !== '/' && (
           <a
             aria-label={t('Read more about Trustroots')}
-            className="btn btn-link header-more-text"
+            className="btn btn-link header-more-text hidden-xs"
             href="/"
           >
             {t('Read more')}


### PR DESCRIPTION
Header was overflowing on mobile

#### Proposed Changes

* removed it on mobile

#### Testing Instructions

* run locally and check

Before:
![image](https://user-images.githubusercontent.com/31655082/230664811-8df1f70a-8163-4e70-902c-93acc449c097.png)

After:
![image](https://user-images.githubusercontent.com/31655082/230665020-c43e256f-cc65-44b3-8d3f-90f6b315ddaf.png)

