### PR TITLE
Reuse mapbox-gl Map to decrease costs

### DIFF
--- a/modules/core/client/components/Map/index.js
+++ b/modules/core/client/components/Map/index.js
@@ -32,6 +32,7 @@ export default function Map(props) {
 
   return (
     <ReactMapGL
+      reuseMaps
       dragRotate={false}
       height={320}
       mapboxApiAccessToken={MAPBOX_TOKEN}

--- a/modules/search/client/components/SearchMap.component.js
+++ b/modules/search/client/components/SearchMap.component.js
@@ -413,6 +413,7 @@ export default function SearchMap({
 
   return (
     <ReactMapGL
+      reuseMaps
       className="search-map"
       dragRotate={false}
       height="100%"


### PR DESCRIPTION
#### Proposed Changes

Add `reuseMaps` parameter to react-map-gl maps. It may decrease mapbox-gl `Map` loads and [thus decrease costs](https://docs.mapbox.com/mapbox-gl-js/guides/pricing/?utm_medium=pricing).
https://visgl.github.io/react-map-gl/docs/get-started/tips-and-tricks#minimize-cost-from-frequent-re-mounting

#### Testing Instructions

* Check that the app still works and loads maps. Whether this improves the cost issue, we'll have to wait and see.
