### PR TITLE
Update FaqFoundation.component.js

### DIFF
--- a/modules/pages/client/components/FaqFoundation.component.js
+++ b/modules/pages/client/components/FaqFoundation.component.js
@@ -10,19 +10,10 @@ export default function FaqFoundation() {
       <div className="faq-question" id="what-is-your-legal-status">
         <h3>{t("What's your legal status?")}</h3>
         <Trans t={t} ns="pages">
-          As of May 2022{' '}
-          <a href="https://find-and-update.company-information.service.gov.uk/company/09489825/filing-history">
-            Trustroots Foundation is dissolved
-          </a>
-          . What does it mean for the community? We don’t know exactly yet!
-        </Trans>
-        <br />
-        <br />
-        <Trans t={t} ns="pages">
-          Prior to that, the website was owned and operated by{' '}
-          <a href="/foundation">Trustroots Foundation</a>, a non-profit Limited
-          by Guarantee (LBG) under section 60 exemption, registered in the
-          United Kingdom in March 2015.
+          The website is owned and operated by{' '}
+          <a href="/foundation">Trustroots Foundation</a>, a non-profit
+          Limited by Guarantee (LBG) under section 60 exemption, registered in
+          the United Kingdom since March 2015. However, the Trustroots Foundation has been inactive since the 24th of May 2022. This is why we are considering to either establish a new foundation, migrating to a p2p decentralized solution or reactivating the existing foundation one to resume its operations. Meanwhile, a small core team, consisting of members who have been involved with Trustroots since its early days, is currently managing the <a href="https://team.trustroots.org/Server.html">server and user database</a>.
         </Trans>
       </div>
 
@@ -123,6 +114,13 @@ export default function FaqFoundation() {
         .
       </div>
 
+      <div className="faq-question" id="who-are-the-board">
+        <h3>{t('Who are the board?')}</h3>
+        <Trans t={t} ns="pages">
+          <a href="/foundation#board">We</a>: Mikael and Natalia.
+        </Trans>
+      </div>
+
       <div
         className="faq-question"
         id="how-do-you-want-to-make-the-project-financially-sustainable"
@@ -134,7 +132,7 @@ export default function FaqFoundation() {
           <a href="/contribute">Donations</a> and grants are the most likely
           ways. There are many inspiring organisations out there serving as
           great examples:{' '}
-          <a href="http://www.abgefahren-ev.de/">Abgefahren e.V.</a>{' '}
+          <a href="http://www.abgefahren-ev.de/">Abgefahren e.V.</a>,{' '}
           (Hitchwiki), <a href="https://www.bevolunteer.org/">BeVolunteer</a>,{' '}
           <a href="https://servas.org/">Servas</a>,{' '}
           <a href="https://wwoof.net/">WWOOF</a> and many more. Again, if you


### PR DESCRIPTION
It's been a year since we found out that the Trustroots foundation was dissolved, and it's about time that we update the FAQ to reflect this change. 

I'd like to suggest keeping the update short and straight to the point. Previous proposals didn't quite hit the mark in terms of clear communication. They seemed more like what some of us volunteers thought the problem was, but not everyone.

Furthermore, I believe it's crucial to focus on working towards the minimum outcome that we can all agree upon, rather than engaging in discussions about everyone's individual opinions on the matter.

So, here's my suggestion: let's make some minor adjustments to effectively convey the main message that, I think, would be good to communicate, which is that it's important to emphasize that, for the community, things remain unchanged. However, behind the scenes, discussions take place among different volunteer groups to explore possible future paths.

Fixes #2585
