### PR TITLE
Upgrade Node version in extract-i18n github workflow

### DIFF
--- a/.github/workflows/extract-i18n.yml
+++ b/.github/workflows/extract-i18n.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 16
       - name: Cache Node.js modules
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
#### Proposed Changes

* Upgrade Node to v16 in extract-i18n github workflow

One of the dependencies, listr2, [expects Node v16](https://github.com/listr2/listr2/blob/a55543d886afc88573bf67a37ae8a91d4b0deafa/package.json#L15), otherwise fails

#### Testing Instructions

* we'll see whether the extraction of translation strings passes after merge (i suspect that there will be permissions error, but that's another issue)

Fixes https://github.com/Trustroots/trustroots/actions/runs/6618933992/job/17978426609#step:8:329
