### PR TITLE
implement shadowban ghost-send and suppress message-related delivery

### DIFF
--- a/modules/contacts/server/controllers/contacts.server.controller.js
+++ b/modules/contacts/server/controllers/contacts.server.controller.js
@@ -90,7 +90,7 @@ exports.add = function (req, res) {
 
       // Find friend
       function (messageHTML, messagePlain, done) {
-        User.findById(req.body.friendUserId, 'email displayName').exec(
+        User.findById(req.body.friendUserId, 'email displayName roles').exec(
           function (err, friend) {
             if (!friend)
               return done(

--- a/modules/core/server/services/email.server.service.js
+++ b/modules/core/server/services/email.server.service.js
@@ -14,6 +14,12 @@ const agenda = require('../../../../config/lib/agenda');
 const config = require('../../../../config/config');
 const log = require('../../../../config/lib/logger');
 const url = (config.https ? 'https' : 'http') + '://' + config.domain;
+const restrictedRoles = ['suspended', 'shadowban'];
+
+function hasRestrictedRole(user) {
+  const roles = _.get(user, 'roles', []);
+  return _.intersection(roles, restrictedRoles).length > 0;
+}
 
 /**
  * Get a randomized name from a list of support volunteer names.
@@ -31,6 +37,10 @@ exports.sendMessagesUnread = function (
   notification,
   callback,
 ) {
+  if (hasRestrictedRole(userFrom) || hasRestrictedRole(userTo)) {
+    return callback();
+  }
+
   // Is the notification the first one?
   // If not, we send a different subject.
   const isFirst = !(notification.notificationCount > 0);
@@ -84,6 +94,10 @@ exports.sendConfirmContact = function (
   messageText,
   callback,
 ) {
+  if (hasRestrictedRole(user) || hasRestrictedRole(friend)) {
+    return callback();
+  }
+
   const meURL = url + '/profile/' + user.username;
   const urlConfirm = url + '/contact-confirm/' + contact._id;
   const campaign = 'confirm-contact';

--- a/modules/core/server/services/email.server.service.js
+++ b/modules/core/server/services/email.server.service.js
@@ -13,13 +13,8 @@ const render = require('../../../../config/lib/render');
 const agenda = require('../../../../config/lib/agenda');
 const config = require('../../../../config/config');
 const log = require('../../../../config/lib/logger');
+const userRolesService = require('../../../users/server/services/user-roles.server.service');
 const url = (config.https ? 'https' : 'http') + '://' + config.domain;
-const restrictedRoles = ['suspended', 'shadowban'];
-
-function hasRestrictedRole(user) {
-  const roles = _.get(user, 'roles', []);
-  return _.intersection(roles, restrictedRoles).length > 0;
-}
 
 /**
  * Get a randomized name from a list of support volunteer names.
@@ -37,7 +32,10 @@ exports.sendMessagesUnread = function (
   notification,
   callback,
 ) {
-  if (hasRestrictedRole(userFrom) || hasRestrictedRole(userTo)) {
+  if (
+    userRolesService.hasRestrictedMessagingRole(userFrom) ||
+    userRolesService.hasRestrictedMessagingRole(userTo)
+  ) {
     return callback();
   }
 
@@ -94,7 +92,10 @@ exports.sendConfirmContact = function (
   messageText,
   callback,
 ) {
-  if (hasRestrictedRole(user) || hasRestrictedRole(friend)) {
+  if (
+    userRolesService.hasRestrictedMessagingRole(user) ||
+    userRolesService.hasRestrictedMessagingRole(friend)
+  ) {
     return callback();
   }
 

--- a/modules/core/tests/server/services/email.server.service.tests.js
+++ b/modules/core/tests/server/services/email.server.service.tests.js
@@ -185,6 +185,42 @@ describe('Service: email', function () {
     );
   });
 
+  it('suppresses messages unread email for banned participants', function (done) {
+    const userFrom = {
+      _id: 'from-user-id',
+      username: 'userfrom',
+      displayName: 'from name',
+      email: 'from@test.com',
+      roles: ['user', 'shadowban'],
+    };
+    const userTo = {
+      _id: 'to-user-id',
+      username: 'userto',
+      displayName: 'to name',
+      email: 'to@test.com',
+      roles: ['user'],
+    };
+    const notification = {
+      messages: [
+        {
+          id: 'message-id-1',
+          content: 'message content 1',
+        },
+      ],
+    };
+
+    emailService.sendMessagesUnread(
+      userFrom,
+      userTo,
+      notification,
+      function (err) {
+        if (err) return done(err);
+        jobs.length.should.equal(0);
+        done();
+      },
+    );
+  });
+
   it('can send support request email', function (done) {
     const supportRequest = {
       message: 'test-support-message',
@@ -458,6 +494,46 @@ describe('Service: email', function () {
     it('contains the contact confirm url', function () {
       jobs[0].data.html.should.containEql('/contact-confirm/' + contact._id);
       jobs[0].data.text.should.containEql('/contact-confirm/' + contact._id);
+    });
+
+    it('suppresses confirm contact email for banned sender', function (done) {
+      jobs.length = 0;
+      const bannedUser = {
+        ...user,
+        roles: ['user', 'shadowban'],
+      };
+      emailService.sendConfirmContact(
+        bannedUser,
+        friend,
+        contact,
+        messageHTML,
+        messageText,
+        function (err) {
+          if (err) return done(err);
+          jobs.length.should.equal(0);
+          done();
+        },
+      );
+    });
+
+    it('suppresses confirm contact email for banned recipient', function (done) {
+      jobs.length = 0;
+      const bannedFriend = {
+        ...friend,
+        roles: ['user', 'suspended'],
+      };
+      emailService.sendConfirmContact(
+        user,
+        bannedFriend,
+        contact,
+        messageHTML,
+        messageText,
+        function (err) {
+          if (err) return done(err);
+          jobs.length.should.equal(0);
+          done();
+        },
+      );
     });
   });
 });

--- a/modules/messages/server/controllers/messages.server.controller.js
+++ b/modules/messages/server/controllers/messages.server.controller.js
@@ -14,18 +14,13 @@ const messageStatService = require('../services/message-stat.server.service');
 const errorService = require('../../../core/server/services/error.server.service');
 const textService = require('../../../core/server/services/text.server.service');
 const spamService = require('../../../core/server/services/spam.server.service');
+const userRolesService = require('../../../users/server/services/user-roles.server.service');
 const userProfile = require('../../../users/server/controllers/users.profile.server.controller');
 const statService = require('../../../stats/server/services/stats.server.service');
 
 const Message = mongoose.model('Message');
 const Thread = mongoose.model('Thread');
 const User = mongoose.model('User');
-const restrictedRoles = ['suspended', 'shadowban'];
-
-function hasRestrictedMessagingRole(user) {
-  const roles = _.get(user, 'roles', []);
-  return _.intersection(roles, restrictedRoles).length > 0;
-}
 
 // Allowed fields of message object to be set over API
 const messageFields = [
@@ -270,7 +265,9 @@ exports.send = async function (req, res) {
     });
   }
 
-  const senderIsRestricted = hasRestrictedMessagingRole(req.user);
+  const senderIsRestricted = userRolesService.hasRestrictedMessagingRole(
+    req.user,
+  );
 
   // No receiver
   if (!req.body.userTo) {

--- a/modules/messages/server/controllers/messages.server.controller.js
+++ b/modules/messages/server/controllers/messages.server.controller.js
@@ -20,6 +20,12 @@ const statService = require('../../../stats/server/services/stats.server.service
 const Message = mongoose.model('Message');
 const Thread = mongoose.model('Thread');
 const User = mongoose.model('User');
+const restrictedRoles = ['suspended', 'shadowban'];
+
+function hasRestrictedMessagingRole(user) {
+  const roles = _.get(user, 'roles', []);
+  return _.intersection(roles, restrictedRoles).length > 0;
+}
 
 // Allowed fields of message object to be set over API
 const messageFields = [
@@ -264,6 +270,8 @@ exports.send = async function (req, res) {
     });
   }
 
+  const senderIsRestricted = hasRestrictedMessagingRole(req.user);
+
   // No receiver
   if (!req.body.userTo) {
     return res.status(400).send({
@@ -450,7 +458,10 @@ exports.send = async function (req, res) {
         message.content = textService.html(message.content);
 
         message.userFrom = req.user;
-        message.read = false;
+        // "Ghost-send" behavior: restricted senders can still see own messages,
+        // but they are hidden from recipients.
+        message.read = senderIsRestricted;
+        message.shadowHidden = senderIsRestricted;
         message.notified = false;
 
         // Include spam status only if we have definitive yes or no, otherwise it's unknown
@@ -465,6 +476,11 @@ exports.send = async function (req, res) {
 
       // Create/upgrade Thread handle between these two users
       function (message, done) {
+        // Don't update recipient thread/inbox delivery state for shadow-hidden messages.
+        if (message.shadowHidden) {
+          return done(null, message);
+        }
+
         const thread = new Thread();
         thread.updated = Date.now();
         thread.userFrom = message.userFrom;
@@ -636,7 +652,11 @@ exports.threadByUser = function (req, res, next, userId) {
           {
             $or: [
               { userFrom: req.user._id, userTo: userId },
-              { userTo: req.user._id, userFrom: userId },
+              {
+                userTo: req.user._id,
+                userFrom: userId,
+                shadowHidden: { $ne: true },
+              },
             ],
           },
           {
@@ -850,7 +870,10 @@ exports.sync = function (req, res) {
 
         // This is always part of the query
         const queryUsers = {
-          $or: [{ userFrom: req.user._id }, { userTo: req.user._id }],
+          $or: [
+            { userFrom: req.user._id },
+            { userTo: req.user._id, shadowHidden: { $ne: true } },
+          ],
         };
 
         // Filter only by user or also by date?

--- a/modules/messages/server/jobs/message-unread.server.job.js
+++ b/modules/messages/server/jobs/message-unread.server.job.js
@@ -28,7 +28,6 @@
  * Module dependencies.
  */
 const _ = require('lodash');
-const pushService = require('../../../core/server/services/push.server.service');
 const emailService = require('../../../core/server/services/email.server.service');
 const log = require('../../../../config/lib/logger');
 const config = require('../../../../config/config');
@@ -37,6 +36,12 @@ const moment = require('moment');
 const mongoose = require('mongoose');
 const Message = mongoose.model('Message');
 const User = mongoose.model('User');
+const restrictedRoles = ['suspended', 'shadowban'];
+
+function hasRestrictedMessagingRole(user) {
+  const roles = _.get(user, 'roles', []);
+  return _.intersection(roles, restrictedRoles).length > 0;
+}
 
 module.exports = function (job, agendaDone) {
   // read timing of notifications from config
@@ -228,6 +233,7 @@ function sendUnreadMessageReminders(reminder, callback) {
               'email',
               'displayName',
               'username',
+              'roles',
               // Used for web/mobile push notifications:
               'pushRegistration.token',
               'pushRegistration.platform',
@@ -284,6 +290,15 @@ function sendUnreadMessageReminders(reminder, callback) {
                 'Could not find all users relevant for this message to notify about. #j93bvs',
               ),
             );
+          }
+
+          // Suppress reminders related to suspended/shadowbanned profiles.
+          // We still increment notificationCount later to avoid retrying forever.
+          if (
+            hasRestrictedMessagingRole(userFrom) ||
+            hasRestrictedMessagingRole(userTo)
+          ) {
+            return notificationCallback();
           }
 
           // Process email notifications

--- a/modules/messages/server/jobs/message-unread.server.job.js
+++ b/modules/messages/server/jobs/message-unread.server.job.js
@@ -33,15 +33,10 @@ const log = require('../../../../config/lib/logger');
 const config = require('../../../../config/config');
 const async = require('async');
 const moment = require('moment');
+const userRolesService = require('../../../users/server/services/user-roles.server.service');
 const mongoose = require('mongoose');
 const Message = mongoose.model('Message');
 const User = mongoose.model('User');
-const restrictedRoles = ['suspended', 'shadowban'];
-
-function hasRestrictedMessagingRole(user) {
-  const roles = _.get(user, 'roles', []);
-  return _.intersection(roles, restrictedRoles).length > 0;
-}
 
 module.exports = function (job, agendaDone) {
   // read timing of notifications from config
@@ -295,8 +290,8 @@ function sendUnreadMessageReminders(reminder, callback) {
           // Suppress reminders related to suspended/shadowbanned profiles.
           // We still increment notificationCount later to avoid retrying forever.
           if (
-            hasRestrictedMessagingRole(userFrom) ||
-            hasRestrictedMessagingRole(userTo)
+            userRolesService.hasRestrictedMessagingRole(userFrom) ||
+            userRolesService.hasRestrictedMessagingRole(userTo)
           ) {
             return notificationCallback();
           }

--- a/modules/messages/server/models/message.server.model.js
+++ b/modules/messages/server/models/message.server.model.js
@@ -37,6 +37,13 @@ const MessageSchema = new Schema({
     type: Boolean,
     // No default; lack of value means no definitive check has been done
   },
+  // Hidden delivery path used for shadowbanned/suspended senders:
+  // sender can still see own messages, recipients can't.
+  shadowHidden: {
+    type: Boolean,
+    default: false,
+    index: true,
+  },
   /* Count and the latest date of notifications sent to `userTo`
      about unread messages (`read:false`) */
   notificationCount: {

--- a/modules/messages/tests/server/jobs/message-unread.server.job.tests.js
+++ b/modules/messages/tests/server/jobs/message-unread.server.job.tests.js
@@ -242,6 +242,56 @@ describe('Job: message unread', function () {
     });
   });
 
+  it('Suppress reminder emails when sender is shadowbanned', function (done) {
+    message.created = moment().subtract(
+      moment.duration({ minutes: 10, seconds: 1 }),
+    );
+    message.save(function (err) {
+      if (err) return done(err);
+
+      userFrom.roles = ['user', 'shadowban'];
+      userFrom.save(function (err) {
+        if (err) return done(err);
+
+        messageUnreadJobHandler({}, function (err) {
+          if (err) return done(err);
+
+          jobs.length.should.equal(0);
+          Message.find({}, function (err, messages) {
+            if (err) return done(err);
+            messages[0].notificationCount.should.equal(1);
+            done();
+          });
+        });
+      });
+    });
+  });
+
+  it('Suppress reminder emails when recipient is suspended', function (done) {
+    message.created = moment().subtract(
+      moment.duration({ minutes: 10, seconds: 1 }),
+    );
+    message.save(function (err) {
+      if (err) return done(err);
+
+      userTo.roles = ['user', 'suspended'];
+      userTo.save(function (err) {
+        if (err) return done(err);
+
+        messageUnreadJobHandler({}, function (err) {
+          if (err) return done(err);
+
+          jobs.length.should.equal(0);
+          Message.find({}, function (err, messages) {
+            if (err) return done(err);
+            messages[0].notificationCount.should.equal(1);
+            done();
+          });
+        });
+      });
+    });
+  });
+
   it('Ignore notification messages from removed users but do not stop processing other notifications', function (done) {
     const message2 = new Message(_message);
     message2.created = moment().subtract(moment.duration({ minutes: 11 }));

--- a/modules/messages/tests/server/message.server.routes.tests.js
+++ b/modules/messages/tests/server/message.server.routes.tests.js
@@ -166,7 +166,7 @@ describe('Message CRUD tests', function () {
       });
   });
 
-  it('should be able to send and read messages when with role "shadowban"', function (done) {
+  it('should be able to send and read own messages when with role "shadowban"', function (done) {
     userFrom.roles = ['user', 'shadowban'];
 
     userFrom.save(function (saveErr) {
@@ -194,7 +194,6 @@ describe('Message CRUD tests', function () {
                 .end(function (messagesGetErr, messagesGetRes) {
                   should.not.exist(messagesGetErr);
 
-                  // Confirm message is on the list
                   if (
                     !messagesGetRes.body[0] ||
                     !messagesGetRes.body[0].content
@@ -1110,6 +1109,136 @@ describe('Message CRUD tests', function () {
             });
         });
       });
+    });
+  });
+
+  it('should be able to read sync endpoint when with role "shadowban"', function (done) {
+    userFrom.roles = ['user', 'shadowban'];
+
+    userFrom.save(function (saveErr) {
+      should.not.exist(saveErr);
+
+      agent
+        .post('/api/auth/signin')
+        .send(credentials)
+        .expect(200)
+        .end(function (signinErr) {
+          should.not.exist(signinErr);
+
+          agent
+            .post('/api/messages')
+            .send(message)
+            .expect(200)
+            .end(function (messageSaveErr) {
+              should.not.exist(messageSaveErr);
+
+              agent
+                .get('/api/messages-sync')
+                .expect(200)
+                .end(function (syncReadErr, syncReadRes) {
+                  if (syncReadErr) return done(syncReadErr);
+                  should.exist(syncReadRes.body.messages);
+                  should.exist(syncReadRes.body.users);
+                  should.exist(syncReadRes.body.messages[userToId.toString()]);
+                  syncReadRes.body.messages[
+                    userToId.toString()
+                  ].length.should.equal(1);
+                  done();
+                });
+            });
+        });
+    });
+  });
+
+  it('should not deliver shadowbanned sender messages to recipient thread', function (done) {
+    userFrom.roles = ['user', 'shadowban'];
+
+    userFrom.save(function (saveErr) {
+      should.not.exist(saveErr);
+
+      agent
+        .post('/api/auth/signin')
+        .send(credentials)
+        .expect(200)
+        .end(function (signinErr) {
+          should.not.exist(signinErr);
+
+          agent
+            .post('/api/messages')
+            .send(message)
+            .expect(200)
+            .end(function (messageSaveErr) {
+              should.not.exist(messageSaveErr);
+
+              const recipientAgent = request.agent(app);
+              recipientAgent
+                .post('/api/auth/signin')
+                .send({
+                  username: userTo.username,
+                  password: 'password123',
+                })
+                .expect(200)
+                .end(function (recipientSigninErr) {
+                  should.not.exist(recipientSigninErr);
+
+                  recipientAgent
+                    .get('/api/messages/' + userFromId)
+                    .expect(200)
+                    .end(function (messagesGetErr, messagesGetRes) {
+                      should.not.exist(messagesGetErr);
+                      messagesGetRes.body.length.should.equal(0);
+                      done();
+                    });
+                });
+            });
+        });
+    });
+  });
+
+  it('should not deliver shadowbanned sender messages to recipient sync', function (done) {
+    userFrom.roles = ['user', 'shadowban'];
+
+    userFrom.save(function (saveErr) {
+      should.not.exist(saveErr);
+
+      agent
+        .post('/api/auth/signin')
+        .send(credentials)
+        .expect(200)
+        .end(function (signinErr) {
+          should.not.exist(signinErr);
+
+          agent
+            .post('/api/messages')
+            .send(message)
+            .expect(200)
+            .end(function (messageSaveErr) {
+              should.not.exist(messageSaveErr);
+
+              const recipientAgent = request.agent(app);
+              recipientAgent
+                .post('/api/auth/signin')
+                .send({
+                  username: userTo.username,
+                  password: 'password123',
+                })
+                .expect(200)
+                .end(function (recipientSigninErr) {
+                  should.not.exist(recipientSigninErr);
+
+                  recipientAgent
+                    .get('/api/messages-sync')
+                    .expect(200)
+                    .end(function (syncReadErr, syncReadRes) {
+                      if (syncReadErr) return done(syncReadErr);
+                      should.not.exist(
+                        syncReadRes.body.messages[userFromId.toString()],
+                      );
+                      done();
+                    });
+                });
+            });
+        });
     });
   });
 });

--- a/modules/users/server/services/user-roles.server.service.js
+++ b/modules/users/server/services/user-roles.server.service.js
@@ -1,0 +1,22 @@
+const _ = require('lodash');
+
+const restrictedMessagingRoles = ['suspended', 'shadowban'];
+
+function hasRole(user, role) {
+  return _.get(user, 'roles', []).includes(role);
+}
+
+function hasAnyRole(user, roles) {
+  return _.intersection(_.get(user, 'roles', []), roles).length > 0;
+}
+
+function hasRestrictedMessagingRole(user) {
+  return hasAnyRole(user, restrictedMessagingRoles);
+}
+
+module.exports = {
+  restrictedMessagingRoles,
+  hasRole,
+  hasAnyRole,
+  hasRestrictedMessagingRole,
+};


### PR DESCRIPTION
Implement consistent shadowban behavior for messaging: shadowbanned users can continue to send and read their own messages, while delivery remains hidden from recipients. Also suppress message-related email notifications for shadowbanned/suspended participants (unread reminders and contact-confirm emails), and update tests to cover the new behavior.

Made-with: Cursor

#### Proposed Changes

- Add ghost-send behavior for restricted senders in messaging:
  - save messages as sender-visible but recipient-hidden (`shadowHidden`)
  - allow sender thread/sync access while filtering hidden incoming messages from recipient thread/sync
  - avoid recipient thread delivery updates for hidden messages
- Suppress message-related emails when either participant is `shadowban`/`suspended`:
  - unread reminder emails
  - contact-confirm emails
- Expand server tests for:
  - unread reminder suppression
  - contact-confirm suppression
  - shadowban messaging visibility/delivery behavior

#### Testing Instructions

- Run:
  - `NODE_ENV=test ./node_modules/.bin/mocha "modules/core/tests/server/services/email.server.service.tests.js" --exit`
  - `NODE_ENV=test node -r should -e "<bootstrap>"` for `modules/messages/tests/server/jobs/message-unread.server.job.tests.js`
- Verify shadowban behavior manually:
  - shadowbanned user can send and read own thread/sync
  - recipient does not see those messages in thread/sync
  - no unread/contact email is generated for shadowbanned/suspended participants
