### PR TITLE
Make Pages artifact names unique per run attempt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -282,10 +282,13 @@ jobs:
       - name: Upload site
         uses: actions/upload-pages-artifact@v5
         with:
+          name: github-pages-${{ github.run_id }}-${{ github.run_attempt }}
           path: site
       - name: Deploy site
         id: deployment
         uses: actions/deploy-pages@v5
+        with:
+          artifact_name: github-pages-${{ github.run_id }}-${{ github.run_attempt }}
       - name: Upload coverage report
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
## Summary
- Give the GitHub Pages upload artifact a run-attempt-specific name.
- Configure deploy-pages to deploy that same artifact name so reruns do not see duplicate github-pages artifacts.

## Verification
- Parsed .github/workflows/test.yml with js-yaml.
- Ran git diff --check for the workflow file.