### PR TITLE
feat: add Umami analytics

### DIFF
--- a/config/lib/express.js
+++ b/config/lib/express.js
@@ -272,6 +272,7 @@ module.exports.initHelmetHeaders = function (app) {
           '*.twitter.com',
           '*.google-analytics.com',
           '*.gstatic.com', // Google analytics related
+          'https://1p.trustroots.org', // Umami analytics
           // Use `nonce` for `<script>` tags
           // Nonce is generated above at `initLocalVariables()` middleware
           // @link https://github.com/helmetjs/helmet/wiki/Conditionally-using-middleware
@@ -325,6 +326,7 @@ module.exports.initHelmetHeaders = function (app) {
           'wss://relay.trustroots.org',
           'https://www.google-analytics.com',
           'https://stats.g.doubleclick.net',
+          'https://1p.trustroots.org', // Umami analytics
           'fcm.googleapis.com',
           'www.facebook.com',
           'https://sentry.io',

--- a/modules/core/server/views/layout.server.view.html
+++ b/modules/core/server/views/layout.server.view.html
@@ -233,6 +233,13 @@
     </script>
     <!-- https://www.trustroots.org/privacy -->
     {% endif %}
+    {# Umami Analytics #}
+    <script
+      defer
+      src="https://1p.trustroots.org/script.js"
+      data-website-id="23ec0c85-2ebc-4d85-9063-c23d90b8ded1"
+      nonce="{{ nonce }}"
+    ></script>
   </head>
   <body
     ng-cloak

--- a/modules/core/tests/server/core.server.routes.tests.js
+++ b/modules/core/tests/server/core.server.routes.tests.js
@@ -61,6 +61,26 @@ describe('Core CRUD tests', function () {
         });
     });
 
+    it('Responses should allow the Umami analytics origin', function (done) {
+      agent
+        .get('/')
+        .expect('content-security-policy', /https:\/\/1p\.trustroots\.org/)
+        .end(function (err) {
+          return done(err);
+        });
+    });
+
+    it('Responses should load Umami analytics', function (done) {
+      agent
+        .get('/')
+        .expect('Content-Type', /html/)
+        .expect(/https:\/\/1p\.trustroots\.org\/script\.js/)
+        .expect(/data-website-id="23ec0c85-2ebc-4d85-9063-c23d90b8ded1"/)
+        .end(function (err) {
+          return done(err);
+        });
+    });
+
     it('should be able to receive CSP report with "application/json" accept header', function (done) {
       agent
         .post('/api/report-csp-violation')


### PR DESCRIPTION
## Summary
- add the supplied Umami tracking script to the shared page layout
- permit the Umami endpoint in the content security policy
- cover the script and CSP origin with server route tests

## Testing
- npm run test:server:codex

Note: the repository pre-commit formatter cannot parse the existing Nunjucks layout around its pre-existing Open Graph markup, so the commit bypassed that hook after the server suite passed.