### PR TITLE
Fix maps when WebGL is unavailable

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -31,6 +31,41 @@ apps. Set `TRUSTROOTS_DEV_*_HOST_PORT` before rebuilding to customize.
 
 MongoDB is available inside the app container at `mongodb:27017`.
 
+## Testing on a phone
+
+The development server is deliberately available only on the host by default.
+To make it available to devices on your local network, start VS Code from a
+host terminal with this environment variable, then use **Dev Containers:
+Rebuild and Reopen in Container**:
+
+```sh
+TRUSTROOTS_DEV_WEBPACK_BIND_ADDRESS=0.0.0.0 code .
+```
+
+Start the app in the devcontainer as usual:
+
+```sh
+npm start
+```
+
+From a host terminal, print the available phone URLs:
+
+```sh
+node scripts/devcontainer/phone-url.js
+```
+
+Open one of those URLs on a phone connected to the same Wi-Fi network. The
+webpack development server proxies requests to the API inside the devcontainer,
+so port `13000` is the only port that needs to be reachable.
+
+Keep the default binding for ordinary development. When phone testing is
+finished, close VS Code and reopen it normally (without the environment
+variable), then rebuild the devcontainer to return the port to host-only
+access.
+
+If the phone cannot connect, check that it is on the same Wi-Fi network and
+that the host firewall allows incoming connections to port `13000`.
+
 ## Running tests
 
 Run tests directly in the devcontainer terminal (no nested Docker):

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -19,7 +19,10 @@ services:
       - mongodb
       - maildev
     ports:
-      - '127.0.0.1:${TRUSTROOTS_DEV_WEBPACK_HOST_PORT:-13000}:3000'
+      # Keep the dev server private by default. Set
+      # TRUSTROOTS_DEV_WEBPACK_BIND_ADDRESS=0.0.0.0 before rebuilding the
+      # devcontainer to test it from another device on the local network.
+      - '${TRUSTROOTS_DEV_WEBPACK_BIND_ADDRESS:-127.0.0.1}:${TRUSTROOTS_DEV_WEBPACK_HOST_PORT:-13000}:3000'
       - '127.0.0.1:${TRUSTROOTS_DEV_SERVER_HOST_PORT:-13001}:3001'
       - '127.0.0.1:${TRUSTROOTS_DEV_LIVERELOAD_HOST_PORT:-45729}:35729'
       - '127.0.0.1:${TRUSTROOTS_DEV_SERVER_INSPECTOR_HOST_PORT:-15858}:5858'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -404,6 +404,8 @@ jobs:
                 body,
               });
             }
+      - name: Require full client and server coverage
+        run: npm run coverage:check -- --require-full
 
   pages:
     if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ Icon
 .eslintcache
 .nodemonignore
 node_modules/
+/.worktrees/
 .vagrant
 *.pyc
 passenger.*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@ comments, configuration-only changes, and non-breaking dependency updates do
 not require a proposal.
 
 Prefer git worktrees for parallel, exploratory, or potentially disruptive work.
+Create them under `.worktrees/` inside this repository so they remain within
+the workspace boundary.
 
 Both server and client test coverage are currently at 100%; keep them at this
 level. Do not lower coverage thresholds or baselines without a clear reason.

--- a/modules/core/client/components/Map/LeafletMap.js
+++ b/modules/core/client/components/Map/LeafletMap.js
@@ -1,0 +1,109 @@
+// External dependencies
+import L from 'leaflet';
+import PropTypes from 'prop-types';
+import React, { useEffect, useRef } from 'react';
+
+const OSM_TILE_URL = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+const OSM_ATTRIBUTION =
+  '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
+
+/**
+ * Small Leaflet renderer for maps that cannot use WebGL.
+ *
+ * This intentionally uses raster tiles and native Leaflet controls so it can
+ * run in browsers where WebGL is unavailable.
+ */
+export default function LeafletMap({
+  ariaHidden,
+  className,
+  height = 320,
+  location,
+  marker,
+  scrollZoom = true,
+  width = '100%',
+  zoom = 6,
+}) {
+  const containerRef = useRef(null);
+  const mapRef = useRef(null);
+  const markerRef = useRef(null);
+
+  useEffect(() => {
+    const map = L.map(containerRef.current, {
+      scrollWheelZoom: scrollZoom,
+      zoomControl: true,
+    }).setView(location, zoom);
+
+    L.tileLayer(OSM_TILE_URL, {
+      attribution: OSM_ATTRIBUTION,
+      maxZoom: 19,
+    }).addTo(map);
+
+    mapRef.current = map;
+
+    return () => {
+      map.remove();
+      mapRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !location) {
+      return;
+    }
+
+    const current = map.getCenter();
+    if (
+      current.lat !== location[0] ||
+      current.lng !== location[1] ||
+      map.getZoom() !== zoom
+    ) {
+      map.setView(location, zoom);
+    }
+  }, [location, zoom]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !marker?.location) {
+      return;
+    }
+
+    markerRef.current?.remove();
+    markerRef.current = L.circleMarker(marker.location, {
+      color: marker.color,
+      fillColor: marker.color,
+      fillOpacity: 1,
+      radius: 12,
+      weight: 2,
+    }).addTo(map);
+
+    return () => {
+      markerRef.current?.remove();
+      markerRef.current = null;
+    };
+  }, [marker]);
+
+  return (
+    <div
+      aria-hidden={ariaHidden}
+      className={className}
+      data-testid="leaflet-map"
+      ref={containerRef}
+      style={{ height, width }}
+    />
+  );
+}
+
+LeafletMap.propTypes = {
+  ariaHidden: PropTypes.bool,
+  className: PropTypes.string,
+  height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  location: PropTypes.arrayOf(PropTypes.number).isRequired,
+  marker: PropTypes.shape({
+    color: PropTypes.string.isRequired,
+    location: PropTypes.arrayOf(PropTypes.number).isRequired,
+  }),
+  scrollZoom: PropTypes.bool,
+  width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  zoom: PropTypes.number,
+};

--- a/modules/core/client/components/Map/index.js
+++ b/modules/core/client/components/Map/index.js
@@ -9,11 +9,13 @@ import { MAP_STYLE_DEFAULT } from './constants';
 import MapNavigationControl from './MapNavigationControl';
 import MapScaleControl from './MapScaleControl';
 import MapStyleControl from './MapStyleControl';
-import { getMapBoxToken } from '../../utils/map';
+import LeafletMap from './LeafletMap';
+import { getMapBoxToken, isWebGLSupported } from '../../utils/map';
 
 export default function Map(props) {
   const {
     children,
+    fallbackMarker,
     location = [48.6908333333, 9.14055555556], // Default location to Europe when not set
     zoom = 6,
     ...overrideProps // anything else will be passed down to <ReactMapGL> as props
@@ -29,6 +31,21 @@ export default function Map(props) {
   const showMapStyles =
     props.showMapStyles &&
     (!!MAPBOX_TOKEN || process.env.NODE_ENV !== 'production');
+
+  if (!isWebGLSupported()) {
+    return (
+      <LeafletMap
+        ariaHidden={props['aria-hidden']}
+        className={props.className}
+        height={props.height || 320}
+        location={location}
+        marker={fallbackMarker}
+        scrollZoom={props.scrollZoom}
+        width={props.width || '100%'}
+        zoom={zoom}
+      />
+    );
+  }
 
   return (
     <ReactMapGL
@@ -56,8 +73,17 @@ export default function Map(props) {
 }
 
 Map.propTypes = {
+  'aria-hidden': PropTypes.bool,
   children: PropTypes.node,
+  className: PropTypes.string,
+  fallbackMarker: PropTypes.shape({
+    color: PropTypes.string.isRequired,
+    location: PropTypes.arrayOf(PropTypes.number).isRequired,
+  }),
   location: PropTypes.arrayOf(PropTypes.number),
+  height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  scrollZoom: PropTypes.bool,
   showMapStyles: PropTypes.bool,
+  width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   zoom: PropTypes.number,
 };

--- a/modules/core/client/utils/map.js
+++ b/modules/core/client/utils/map.js
@@ -1,2 +1,26 @@
 export const getMapBoxToken = () =>
   typeof window !== 'undefined' && window.settings?.mapbox?.publicKey;
+
+/**
+ * Mapbox GL needs a WebGL context, so callers choose a raster renderer before
+ * mounting it when the browser cannot create one.
+ */
+const getBrowserDocument = () => {
+  /* istanbul ignore next -- the server-side path has no DOM to exercise */
+  return typeof document === 'undefined' ? null : document;
+};
+
+export const isWebGLSupported = (browserDocument = getBrowserDocument()) => {
+  if (!browserDocument) {
+    return false;
+  }
+
+  try {
+    const canvas = browserDocument.createElement('canvas');
+    return Boolean(
+      canvas.getContext?.('webgl') || canvas.getContext?.('experimental-webgl'),
+    );
+  } catch {
+    return false;
+  }
+};

--- a/modules/core/tests/client/components/LeafletMap.client.component.tests.js
+++ b/modules/core/tests/client/components/LeafletMap.client.component.tests.js
@@ -1,0 +1,106 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import L from 'leaflet';
+
+import LeafletMap from '@/modules/core/client/components/Map/LeafletMap';
+
+const mockMap = {
+  getCenter: jest.fn(),
+  getZoom: jest.fn(),
+  remove: jest.fn(),
+  setView: jest.fn(),
+};
+mockMap.setView.mockImplementation(() => mockMap);
+const mockMarker = { remove: jest.fn() };
+
+jest.mock('leaflet', () => ({
+  circleMarker: jest.fn(() => ({
+    addTo: jest.fn(() => mockMarker),
+  })),
+  map: jest.fn(() => mockMap),
+  tileLayer: jest.fn(() => ({ addTo: jest.fn() })),
+}));
+
+beforeEach(() => {
+  mockMap.getCenter.mockReturnValue({ lat: 50.12, lng: 19.89 });
+  mockMap.getZoom.mockReturnValue(11);
+  mockMap.remove.mockClear();
+  mockMap.setView.mockClear();
+  mockMarker.remove.mockClear();
+  L.circleMarker.mockClear();
+  L.map.mockClear();
+  L.tileLayer.mockClear();
+});
+
+describe('<LeafletMap />', () => {
+  it('renders raster tiles and the supplied marker', () => {
+    const { container } = render(
+      <LeafletMap
+        ariaHidden
+        className="offer-location"
+        location={[50.12, 19.89]}
+        marker={{ color: '#11b4da', location: [50.12, 19.89] }}
+        scrollZoom={false}
+        zoom={11}
+      />,
+    );
+
+    expect(container.firstChild).toHaveAttribute('aria-hidden', 'true');
+    expect(L.map).toHaveBeenCalledWith(expect.any(HTMLDivElement), {
+      scrollWheelZoom: false,
+      zoomControl: true,
+    });
+    expect(L.tileLayer).toHaveBeenCalledWith(
+      'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      expect.objectContaining({ maxZoom: 19 }),
+    );
+    expect(L.circleMarker).toHaveBeenCalledWith(
+      [50.12, 19.89],
+      expect.objectContaining({ fillColor: '#11b4da', radius: 12 }),
+    );
+  });
+
+  it('follows a changed location and cleans up the map and marker', () => {
+    const { rerender, unmount } = render(
+      <LeafletMap
+        location={[50.12, 19.89]}
+        marker={{ color: '#11b4da', location: [50.12, 19.89] }}
+        zoom={11}
+      />,
+    );
+
+    rerender(
+      <LeafletMap
+        location={[51.12, 20.89]}
+        marker={{ color: '#58ba58', location: [51.12, 20.89] }}
+        zoom={12}
+      />,
+    );
+
+    expect(mockMap.setView).toHaveBeenCalledWith([51.12, 20.89], 12);
+    expect(mockMarker.remove).toHaveBeenCalled();
+
+    unmount();
+    expect(mockMap.remove).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the default zoom and accepts a map without a marker', () => {
+    render(<LeafletMap location={[50.12, 19.89]} />);
+
+    expect(mockMap.setView).toHaveBeenCalledWith([50.12, 19.89], 6);
+    expect(L.circleMarker).not.toHaveBeenCalled();
+  });
+
+  it('does not update the map when no location is available', () => {
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    render(<LeafletMap location={null} />);
+
+    expect(mockMap.setView).toHaveBeenCalledTimes(1);
+    expect(L.circleMarker).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+});

--- a/modules/core/tests/client/components/Map.client.component.tests.js
+++ b/modules/core/tests/client/components/Map.client.component.tests.js
@@ -4,6 +4,12 @@ import '@testing-library/jest-dom/extend-expect';
 
 import Map from '@/modules/core/client/components/Map';
 
+const mockIsWebGLSupported = jest.fn();
+jest.mock('@/modules/core/client/utils/map', () => ({
+  ...jest.requireActual('@/modules/core/client/utils/map'),
+  isWebGLSupported: () => mockIsWebGLSupported(),
+}));
+
 const mockMapStyleControl = jest.fn();
 jest.mock('react-map-gl', () => {
   const React = require('react');
@@ -21,6 +27,13 @@ jest.mock('@/modules/core/client/components/Map/MapNavigationControl', () =>
 jest.mock('@/modules/core/client/components/Map/MapScaleControl', () =>
   jest.fn(() => <div data-testid="map-scale-control" />),
 );
+const mockLeafletMap = jest.fn();
+jest.mock('@/modules/core/client/components/Map/LeafletMap', () =>
+  jest.fn(props => {
+    mockLeafletMap(props);
+    return <div data-testid="leaflet-map" />;
+  }),
+);
 jest.mock('@/modules/core/client/components/Map/MapStyleControl', () => ({
   __esModule: true,
   default: props => {
@@ -32,6 +45,8 @@ jest.mock('@/modules/core/client/components/Map/MapStyleControl', () => ({
 describe('<Map />', () => {
   beforeEach(() => {
     mockMapStyleControl.mockClear();
+    mockLeafletMap.mockClear();
+    mockIsWebGLSupported.mockReturnValue(true);
   });
 
   it('passes default viewport and renders map chrome', () => {
@@ -54,6 +69,30 @@ describe('<Map />', () => {
     expect(mockMapStyleControl).toHaveBeenCalledWith(
       expect.objectContaining({
         setMapstyle: expect.any(Function),
+      }),
+    );
+  });
+
+  it('uses the raster map when WebGL is unavailable', () => {
+    mockIsWebGLSupported.mockReturnValue(false);
+
+    render(
+      <Map
+        fallbackMarker={{ color: '#11b4da', location: [50.12, 19.89] }}
+        location={[50.12, 19.89]}
+        scrollZoom={false}
+        zoom={11}
+      />,
+    );
+
+    expect(screen.getByTestId('leaflet-map')).toBeInTheDocument();
+    expect(screen.queryByTestId('react-map')).not.toBeInTheDocument();
+    expect(mockLeafletMap).toHaveBeenCalledWith(
+      expect.objectContaining({
+        location: [50.12, 19.89],
+        marker: { color: '#11b4da', location: [50.12, 19.89] },
+        scrollZoom: false,
+        zoom: 11,
       }),
     );
   });

--- a/modules/core/tests/client/utils/map.client.utils.tests.js
+++ b/modules/core/tests/client/utils/map.client.utils.tests.js
@@ -1,0 +1,51 @@
+import { isWebGLSupported } from '@/modules/core/client/utils/map';
+
+describe('map utilities', () => {
+  let createElement;
+
+  beforeEach(() => {
+    createElement = jest.spyOn(document, 'createElement');
+  });
+
+  afterEach(() => {
+    createElement.mockRestore();
+  });
+
+  it('detects an available WebGL context', () => {
+    const getContext = jest.fn(type => (type === 'webgl' ? {} : null));
+    createElement.mockReturnValue({ getContext });
+
+    expect(isWebGLSupported()).toBe(true);
+    expect(createElement).toHaveBeenCalledWith('canvas');
+    expect(getContext).toHaveBeenCalledWith('webgl');
+  });
+
+  it('uses the legacy WebGL context when necessary', () => {
+    const getContext = jest.fn(type =>
+      type === 'experimental-webgl' ? {} : null,
+    );
+    createElement.mockReturnValue({ getContext });
+
+    expect(isWebGLSupported()).toBe(true);
+    expect(getContext).toHaveBeenNthCalledWith(1, 'webgl');
+    expect(getContext).toHaveBeenNthCalledWith(2, 'experimental-webgl');
+  });
+
+  it('returns false when the browser blocks WebGL', () => {
+    createElement.mockReturnValue({ getContext: () => null });
+
+    expect(isWebGLSupported()).toBe(false);
+  });
+
+  it('returns false outside a browser', () => {
+    expect(isWebGLSupported(null)).toBe(false);
+  });
+
+  it('returns false when the browser throws while creating WebGL', () => {
+    createElement.mockImplementation(() => {
+      throw new Error('WebGL blocked');
+    });
+
+    expect(isWebGLSupported()).toBe(false);
+  });
+});

--- a/modules/offers/client/components/OfferLocation.component.js
+++ b/modules/offers/client/components/OfferLocation.component.js
@@ -5,6 +5,7 @@ import React from 'react';
 // Internal dependencies
 import Map from '@/modules/core/client/components/Map/index';
 import OfferLocationOverlay from './OfferLocationOverlay';
+import { getOfferHexColor } from '../utils/markers.js';
 
 export default function OfferLocation({ location, offerStatus, offerType }) {
   if (!location || location.length !== 2) {
@@ -15,6 +16,10 @@ export default function OfferLocation({ location, offerStatus, offerType }) {
     <Map
       aria-hidden
       className="offer-location"
+      fallbackMarker={{
+        color: getOfferHexColor({ offerType, offerStatus }),
+        location,
+      }}
       height={320}
       location={location}
       scrollZoom={false}

--- a/modules/search/client/components/LeafletSearchMap.js
+++ b/modules/search/client/components/LeafletSearchMap.js
@@ -1,0 +1,250 @@
+// External dependencies
+import L from 'leaflet';
+import PropTypes from 'prop-types';
+import React, { useEffect, useRef } from 'react';
+import Supercluster from 'supercluster';
+
+import './leaflet-search-map.less';
+
+// Internal dependencies
+import { CLUSTER_MAX_ZOOM, MIN_ZOOM } from './constants';
+
+const OSM_TILE_URL = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+const OSM_ATTRIBUTION =
+  '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
+const offerColours = {
+  'host-maybe': '#f2ae43',
+  'host-yes': '#58ba58',
+  'meet-yes': '#11b4da',
+};
+
+function getMapState(map) {
+  const bounds = map.getBounds();
+  const centre = map.getCenter();
+
+  return {
+    bounds: {
+      northEast: bounds.getNorthEast(),
+      southWest: bounds.getSouthWest(),
+    },
+    latitude: centre.lat,
+    longitude: centre.lng,
+    zoom: map.getZoom(),
+  };
+}
+
+function createClusterIndex(data, maxZoom) {
+  return new Supercluster({
+    maxZoom,
+    minPoints: 3,
+    radius: 50,
+  }).load(data.features);
+}
+
+function stopMapClick(event) {
+  if (event?.originalEvent) {
+    L.DomEvent.stopPropagation(event.originalEvent);
+  }
+}
+
+function clusterIcon(count, colour) {
+  return L.divIcon({
+    className: 'leaflet-search-cluster',
+    html: `<span style="background:${colour}">${count}</span>`,
+    iconAnchor: [25, 25],
+    iconSize: [50, 50],
+  });
+}
+
+function addClusteredMarkers({
+  colour,
+  group,
+  index,
+  map,
+  onPointClick,
+  pointColour,
+  viewport,
+}) {
+  group.clearLayers();
+
+  if (viewport.zoom <= MIN_ZOOM) {
+    return;
+  }
+
+  const bounds = map.getBounds();
+  const points = index.getClusters(
+    [bounds.getWest(), bounds.getSouth(), bounds.getEast(), bounds.getNorth()],
+    Math.floor(viewport.zoom),
+  );
+
+  points.forEach(point => {
+    const [longitude, latitude] = point.geometry.coordinates;
+
+    if (point.properties.cluster) {
+      const marker = L.marker([latitude, longitude], {
+        icon: clusterIcon(point.properties.point_count_abbreviated, colour),
+        keyboard: true,
+        title: `${point.properties.point_count} results`,
+      });
+
+      marker.on('click', event => {
+        stopMapClick(event);
+        map.setView(
+          [latitude, longitude],
+          Math.min(
+            index.getClusterExpansionZoom(point.properties.cluster_id),
+            CLUSTER_MAX_ZOOM,
+          ),
+        );
+      });
+      group.addLayer(marker);
+      return;
+    }
+
+    const marker = L.circleMarker([latitude, longitude], {
+      color: '#fff',
+      fillColor: pointColour(point),
+      fillOpacity: 1,
+      radius: 10,
+      weight: 2,
+    });
+    marker.on('click', event => {
+      stopMapClick(event);
+      onPointClick(point);
+    });
+    group.addLayer(marker);
+  });
+}
+
+/**
+ * Search-map renderer used where a WebGL map cannot be created.
+ */
+export default function LeafletSearchMap({
+  communityNotes,
+  offers,
+  onCommunityNoteClick,
+  onMapChange,
+  onMapClick,
+  onOfferClick,
+  viewport,
+}) {
+  const containerRef = useRef(null);
+  const mapRef = useRef(null);
+  const groupsRef = useRef(null);
+  const callbacksRef = useRef({
+    onCommunityNoteClick,
+    onMapChange,
+    onMapClick,
+    onOfferClick,
+  });
+
+  useEffect(() => {
+    callbacksRef.current = {
+      onCommunityNoteClick,
+      onMapChange,
+      onMapClick,
+      onOfferClick,
+    };
+  }, [onCommunityNoteClick, onMapChange, onMapClick, onOfferClick]);
+
+  useEffect(() => {
+    const map = L.map(containerRef.current, {
+      zoomControl: true,
+    }).setView([viewport.latitude, viewport.longitude], viewport.zoom);
+    const offerGroup = L.layerGroup().addTo(map);
+    const communityNoteGroup = L.layerGroup().addTo(map);
+
+    L.tileLayer(OSM_TILE_URL, {
+      attribution: OSM_ATTRIBUTION,
+      maxZoom: 19,
+    }).addTo(map);
+
+    const onMoveEnd = () => callbacksRef.current.onMapChange(getMapState(map));
+    map.on('click', () => callbacksRef.current.onMapClick());
+    map.on('moveend', onMoveEnd);
+    mapRef.current = map;
+    groupsRef.current = { communityNoteGroup, offerGroup };
+    onMoveEnd();
+
+    return () => {
+      map.remove();
+      groupsRef.current = null;
+      mapRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    /* istanbul ignore next -- the map ref is initialised by the preceding mount effect */
+    if (!map) {
+      return;
+    }
+
+    const centre = map.getCenter();
+    if (
+      centre.lat !== viewport.latitude ||
+      centre.lng !== viewport.longitude ||
+      map.getZoom() !== viewport.zoom
+    ) {
+      map.setView([viewport.latitude, viewport.longitude], viewport.zoom);
+    }
+  }, [viewport]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    const groups = groupsRef.current;
+    /* istanbul ignore next -- both refs are initialised by the preceding mount effect */
+    if (!map || !groups) {
+      return;
+    }
+
+    const offerIndex = createClusterIndex(offers, CLUSTER_MAX_ZOOM);
+    addClusteredMarkers({
+      colour: 'rgba(18, 181, 145, 0.8)',
+      group: groups.offerGroup,
+      index: offerIndex,
+      map,
+      onPointClick: point =>
+        callbacksRef.current.onOfferClick(point.properties.id),
+      pointColour: point => offerColours[point.properties.offer] || '#ccc',
+      viewport,
+    });
+
+    const communityNoteIndex = createClusterIndex(communityNotes, 14);
+    addClusteredMarkers({
+      colour: 'rgba(25, 118, 210, 0.8)',
+      group: groups.communityNoteGroup,
+      index: communityNoteIndex,
+      map,
+      onPointClick: point => callbacksRef.current.onCommunityNoteClick(point),
+      pointColour: point => (point.properties.verified ? '#1565C0' : '#1976D2'),
+      viewport,
+    });
+  }, [communityNotes, offers, viewport]);
+
+  return (
+    <div
+      className="search-map leaflet-search-map"
+      data-testid="leaflet-search-map"
+      ref={containerRef}
+    />
+  );
+}
+
+LeafletSearchMap.propTypes = {
+  communityNotes: PropTypes.shape({
+    features: PropTypes.array.isRequired,
+  }).isRequired,
+  offers: PropTypes.shape({
+    features: PropTypes.array.isRequired,
+  }).isRequired,
+  onCommunityNoteClick: PropTypes.func.isRequired,
+  onMapChange: PropTypes.func.isRequired,
+  onMapClick: PropTypes.func.isRequired,
+  onOfferClick: PropTypes.func.isRequired,
+  viewport: PropTypes.shape({
+    latitude: PropTypes.number.isRequired,
+    longitude: PropTypes.number.isRequired,
+    zoom: PropTypes.number.isRequired,
+  }).isRequired,
+};

--- a/modules/search/client/components/SearchMap.component.js
+++ b/modules/search/client/components/SearchMap.component.js
@@ -10,7 +10,10 @@ import ReactMapGL, {
 } from 'react-map-gl';
 
 // Internal dependencies
-import { getMapBoxToken } from '@/modules/core/client/utils/map';
+import {
+  getMapBoxToken,
+  isWebGLSupported,
+} from '@/modules/core/client/utils/map';
 import {
   MAP_STYLE_DEFAULT,
   MAP_STYLE_OSM,
@@ -21,6 +24,7 @@ import MapNavigationControl from '@/modules/core/client/components/Map/MapNaviga
 import MapScaleControl from '@/modules/core/client/components/Map/MapScaleControl';
 import MapStyleControl from '@/modules/core/client/components/Map/MapStyleControl';
 import SearchMapNoContent from './SearchMapNoContent';
+import LeafletSearchMap from './LeafletSearchMap';
 import { ensureValidLat, ensureValidLng } from '../utils';
 import {
   clusterCountLayerMapbox,
@@ -149,6 +153,7 @@ export default function SearchMap({
   );
 
   const [viewport, setViewport] = useState(persistentMapLocation);
+  const [webGLSupported] = useState(isWebGLSupported);
   const [mapStyle, setMapstyle] = usePersistentMapStyle(MAP_STYLE_DEFAULT);
   const [map, setMap] = useState();
   const [hoveredOffer, setHoveredOffer] = useState(false);
@@ -161,6 +166,7 @@ export default function SearchMap({
     type: 'FeatureCollection',
     features: [],
   });
+  const [leafletMapState, setLeafletMapState] = useState();
   const communityNotesTimerRef = useRef(null);
   const communityNotesEventsRef = useRef([]);
 
@@ -175,7 +181,8 @@ export default function SearchMap({
   const effectiveMapStyle =
     !MAPBOX_TOKEN && isMapboxStyle ? MAP_STYLE_OSM : mapStyle;
   // If no mapbox token, and we're in production, don't show the style switcher
-  const showMapStyles = !!MAPBOX_TOKEN || process.env.NODE_ENV !== 'production';
+  const showMapStyles =
+    webGLSupported && (!!MAPBOX_TOKEN || process.env.NODE_ENV !== 'production');
   const sourceRef = createRef();
   const mapRef = createRef();
 
@@ -216,23 +223,27 @@ export default function SearchMap({
   /**
    * Hook on map interactions to update features
    */
-  const updateOffers = () => {
+  const updateOffers = leafletState => {
     // Don't fetch if viewing the whole world
-    if (viewport.zoom <= MIN_ZOOM) {
+    const zoom = leafletState?.zoom || viewport.zoom;
+    if (zoom <= MIN_ZOOM) {
       return;
     }
 
     const map = getMapRef();
 
-    if (!map) {
+    const mapBounds = leafletState?.bounds || map?.getBounds();
+    if (!mapBounds) {
       return;
     }
 
     // https://docs.mapbox.com/mapbox-gl-js/api/geography/#lnglatbounds
-    const bounds = map.getBounds();
-    const northEast = bounds.getNorthEast();
-    const southWest = bounds.getSouthWest();
-    const zoom = map.getZoom();
+    const northEast = mapBounds.getNorthEast
+      ? mapBounds.getNorthEast()
+      : mapBounds.northEast;
+    const southWest = mapBounds.getSouthWest
+      ? mapBounds.getSouthWest()
+      : mapBounds.southWest;
 
     // Expand bounding box depending on the zoom level slightly to load more offers over the edge of the viewport
     const boundsBuffer = 10 / zoom;
@@ -272,6 +283,12 @@ export default function SearchMap({
     // The maximum time func is allowed to be delayed before it's invoked:
     { maxWait: 3500 },
   );
+
+  const onLeafletMapChange = mapState => {
+    setLeafletMapState(mapState);
+    onViewPortChange(mapState);
+    debouncedUpdateOffers(mapState);
+  };
 
   /**
    * Update state for a feature on the map
@@ -406,6 +423,26 @@ export default function SearchMap({
   /**
    * React on any clicks on map or layers defined on `interactiveLayerIds` prop
    */
+  function openCommunityNote(feature) {
+    const clickedPlusCode = getPlusCodeFromEvent(feature.properties);
+
+    // Find all notes sharing the same plus code (the "thread")
+    const threadNotes = communityNotesEventsRef.current.filter(event => {
+      const eventPlusCode = getPlusCodeFromRawEvent(event);
+      return eventPlusCode && eventPlusCode === clickedPlusCode;
+    });
+
+    if (onCommunityNoteOpen) {
+      onCommunityNoteOpen({
+        notes:
+          threadNotes.length > 0
+            ? threadNotes
+            : [reconstructEvent(feature.properties)],
+        plusCode: clickedPlusCode,
+      });
+    }
+  }
+
   const onClickMap = event => {
     const { features } = event;
     clearPreviouslySelectedState();
@@ -421,24 +458,7 @@ export default function SearchMap({
 
     // Community notes click — open thread in sidebar
     if (layerId === communityNotesLayer.id) {
-      const feature = features[0];
-      const clickedPlusCode = getPlusCodeFromEvent(feature.properties);
-
-      // Find all notes sharing the same plus code (the "thread")
-      const threadNotes = communityNotesEventsRef.current.filter(event => {
-        const eventPlusCode = getPlusCodeFromRawEvent(event);
-        return eventPlusCode && eventPlusCode === clickedPlusCode;
-      });
-
-      if (onCommunityNoteOpen) {
-        onCommunityNoteOpen({
-          notes:
-            threadNotes.length > 0
-              ? threadNotes
-              : [reconstructEvent(feature.properties)],
-          plusCode: clickedPlusCode,
-        });
-      }
+      openCommunityNote(features[0]);
       return;
     }
 
@@ -511,7 +531,9 @@ export default function SearchMap({
 
   // Load and store Mapbox object for quick reference on render
   useEffect(() => {
-    setMap(getMapRef());
+    if (webGLSupported) {
+      setMap(getMapRef());
+    }
   }, []);
 
   // Apply externally changed bounds object
@@ -531,7 +553,7 @@ export default function SearchMap({
     clearPreviouslyHoveredState();
 
     // Update map offers
-    updateOffers();
+    updateOffers(webGLSupported ? undefined : leafletMapState);
   }, [filters]);
 
   // Subscribe/unsubscribe to community notes based on toggle
@@ -577,6 +599,20 @@ export default function SearchMap({
       });
     }
   }, [location]);
+
+  if (!webGLSupported) {
+    return (
+      <LeafletSearchMap
+        communityNotes={communityNotes}
+        offers={offers}
+        onCommunityNoteClick={openCommunityNote}
+        onMapChange={onLeafletMapChange}
+        onMapClick={onOfferClose}
+        onOfferClick={openOfferById}
+        viewport={viewport}
+      />
+    );
+  }
 
   return (
     <>

--- a/modules/search/client/components/leaflet-search-map.less
+++ b/modules/search/client/components/leaflet-search-map.less
@@ -1,0 +1,22 @@
+.leaflet-search-map {
+  width: 100%;
+  height: 100%;
+  background: #f7f7f7;
+}
+
+.leaflet-search-cluster {
+  background: transparent;
+  border: 0;
+
+  span {
+    display: flex;
+    width: 50px;
+    height: 50px;
+    align-items: center;
+    justify-content: center;
+    border: 2px solid #fff;
+    border-radius: 50%;
+    color: #111;
+    font-weight: bold;
+  }
+}

--- a/modules/search/tests/client/components/LeafletSearchMap.component.tests.js
+++ b/modules/search/tests/client/components/LeafletSearchMap.component.tests.js
@@ -1,0 +1,258 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import L from 'leaflet';
+
+import LeafletSearchMap from '@/modules/search/client/components/LeafletSearchMap';
+
+const mockMapHandlers = {};
+const mockMap = {
+  getBounds: jest.fn(),
+  getCenter: jest.fn(),
+  getZoom: jest.fn(),
+  on: jest.fn((name, handler) => {
+    mockMapHandlers[name] = handler;
+  }),
+  remove: jest.fn(),
+  setView: jest.fn(),
+};
+mockMap.setView.mockImplementation(() => mockMap);
+const mockLayerGroups = [];
+const mockMarkers = [];
+const mockCircleMarkers = [];
+const mockClusterResults = [];
+const mockClusterInstances = [];
+
+jest.mock('leaflet', () => ({
+  DomEvent: { stopPropagation: jest.fn() },
+  circleMarker: jest.fn((location, options) => {
+    const marker = {
+      location,
+      on: jest.fn((name, handler) => {
+        marker.handlers[name] = handler;
+        return marker;
+      }),
+      handlers: {},
+      options,
+    };
+    mockCircleMarkers.push(marker);
+    return marker;
+  }),
+  divIcon: jest.fn(options => options),
+  layerGroup: jest.fn(() => {
+    const group = {
+      addLayer: jest.fn(),
+      addTo: jest.fn(() => group),
+      clearLayers: jest.fn(),
+    };
+    mockLayerGroups.push(group);
+    return group;
+  }),
+  map: jest.fn(() => mockMap),
+  marker: jest.fn((location, options) => {
+    const marker = {
+      location,
+      on: jest.fn((name, handler) => {
+        marker.handlers[name] = handler;
+        return marker;
+      }),
+      handlers: {},
+      options,
+    };
+    mockMarkers.push(marker);
+    return marker;
+  }),
+  tileLayer: jest.fn(() => ({ addTo: jest.fn() })),
+}));
+
+jest.mock('supercluster', () =>
+  jest.fn().mockImplementation(() => {
+    const result = mockClusterResults[mockClusterInstances.length] || [];
+    const instance = {
+      getClusterExpansionZoom: jest.fn(() => 10),
+      getClusters: jest.fn(() => result),
+      load: jest.fn(),
+    };
+    instance.load.mockReturnValue(instance);
+    mockClusterInstances.push(instance);
+    return instance;
+  }),
+);
+
+const bounds = {
+  getEast: () => 14,
+  getNorth: () => 53,
+  getNorthEast: () => ({ lat: 53, lng: 14 }),
+  getSouth: () => 51,
+  getSouthWest: () => ({ lat: 51, lng: 12 }),
+  getWest: () => 12,
+};
+const viewport = { latitude: 52, longitude: 13, zoom: 6 };
+
+function point(id, properties = {}) {
+  return {
+    geometry: { coordinates: [13, 52], type: 'Point' },
+    id,
+    properties,
+    type: 'Feature',
+  };
+}
+
+function cluster() {
+  return {
+    geometry: { coordinates: [13, 52], type: 'Point' },
+    properties: {
+      cluster: true,
+      cluster_id: 42,
+      point_count: 3,
+      point_count_abbreviated: 3,
+    },
+    type: 'Feature',
+  };
+}
+
+function renderMap(props = {}) {
+  return render(
+    <LeafletSearchMap
+      communityNotes={{ features: [] }}
+      offers={{ features: [] }}
+      onCommunityNoteClick={jest.fn()}
+      onMapChange={jest.fn()}
+      onMapClick={jest.fn()}
+      onOfferClick={jest.fn()}
+      viewport={viewport}
+      {...props}
+    />,
+  );
+}
+
+beforeEach(() => {
+  Object.keys(mockMapHandlers).forEach(key => delete mockMapHandlers[key]);
+  mockLayerGroups.length = 0;
+  mockMarkers.length = 0;
+  mockCircleMarkers.length = 0;
+  mockClusterResults.length = 0;
+  mockClusterInstances.length = 0;
+  mockMap.getBounds.mockReturnValue(bounds);
+  mockMap.getCenter.mockReturnValue({ lat: 52, lng: 13 });
+  mockMap.getZoom.mockReturnValue(6);
+  mockMap.setView.mockClear();
+  mockMap.remove.mockClear();
+  mockMap.on.mockClear();
+  L.DomEvent.stopPropagation.mockClear();
+  L.tileLayer.mockClear();
+  L.map.mockClear();
+});
+
+describe('<LeafletSearchMap />', () => {
+  it('renders clustered offers and Community Notes with their actions', () => {
+    const onMapChange = jest.fn();
+    const onMapClick = jest.fn();
+    const onOfferClick = jest.fn();
+    const onCommunityNoteClick = jest.fn();
+    mockClusterResults.push(
+      [cluster(), point(undefined, { id: 'offer-1', offer: 'host-yes' })],
+      [point('note-1', { verified: true })],
+    );
+
+    renderMap({
+      communityNotes: { features: [point('note-1', { verified: true })] },
+      offers: {
+        features: [point(undefined, { id: 'offer-1', offer: 'host-yes' })],
+      },
+      onCommunityNoteClick,
+      onMapChange,
+      onMapClick,
+      onOfferClick,
+    });
+
+    expect(L.map).toHaveBeenCalledWith(expect.any(HTMLDivElement), {
+      zoomControl: true,
+    });
+    expect(L.tileLayer).toHaveBeenCalledWith(
+      'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      expect.objectContaining({ maxZoom: 19 }),
+    );
+    expect(onMapChange).toHaveBeenCalledWith({
+      bounds: {
+        northEast: { lat: 53, lng: 14 },
+        southWest: { lat: 51, lng: 12 },
+      },
+      latitude: 52,
+      longitude: 13,
+      zoom: 6,
+    });
+    expect(mockMarkers).toHaveLength(1);
+    expect(mockCircleMarkers).toHaveLength(2);
+
+    mockMapHandlers.click();
+    expect(onMapClick).toHaveBeenCalledTimes(1);
+
+    mockMarkers[0].handlers.click({ originalEvent: {} });
+    expect(
+      mockClusterInstances[0].getClusterExpansionZoom,
+    ).toHaveBeenCalledWith(42);
+    expect(mockMap.setView).toHaveBeenCalledWith([52, 13], 10);
+
+    mockCircleMarkers[0].handlers.click({ originalEvent: {} });
+    expect(onOfferClick).toHaveBeenCalledWith('offer-1');
+    mockCircleMarkers[1].handlers.click({ originalEvent: {} });
+    expect(onCommunityNoteClick).toHaveBeenCalledWith(
+      point('note-1', { verified: true }),
+    );
+    expect(L.DomEvent.stopPropagation).toHaveBeenCalledTimes(3);
+  });
+
+  it('updates the map from an externally changed viewport and removes it', () => {
+    const { rerender, unmount } = renderMap();
+    mockMap.getCenter.mockReturnValue({ lat: 52, lng: 13 });
+    mockMap.getZoom.mockReturnValue(6);
+
+    rerender(
+      <LeafletSearchMap
+        communityNotes={{ features: [] }}
+        offers={{ features: [] }}
+        onCommunityNoteClick={jest.fn()}
+        onMapChange={jest.fn()}
+        onMapClick={jest.fn()}
+        onOfferClick={jest.fn()}
+        viewport={{ latitude: 53, longitude: 14, zoom: 7 }}
+      />,
+    );
+
+    expect(mockMap.setView).toHaveBeenCalledWith([53, 14], 7);
+
+    unmount();
+    expect(mockMap.remove).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render markers while the map is zoomed out', () => {
+    mockClusterResults.push([point('offer-1')], [point('note-1')]);
+
+    renderMap({
+      communityNotes: { features: [point('note-1')] },
+      offers: { features: [point('offer-1')] },
+      viewport: { ...viewport, zoom: 2 },
+    });
+
+    expect(mockMarkers).toHaveLength(0);
+    expect(mockCircleMarkers).toHaveLength(0);
+    expect(mockLayerGroups[0].clearLayers).toHaveBeenCalledTimes(1);
+    expect(mockLayerGroups[1].clearLayers).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses fallback colours for unknown offers and unverified notes', () => {
+    mockClusterResults.push(
+      [point('offer-1', { offer: 'unknown' })],
+      [point('note-1', { verified: false })],
+    );
+
+    renderMap({
+      communityNotes: { features: [point('note-1', { verified: false })] },
+      offers: { features: [point('offer-1', { offer: 'unknown' })] },
+    });
+
+    expect(mockCircleMarkers[0].options.fillColor).toBe('#ccc');
+    expect(mockCircleMarkers[1].options.fillColor).toBe('#1976D2');
+    expect(() => mockCircleMarkers[0].handlers.click({})).not.toThrow();
+  });
+});

--- a/modules/search/tests/client/components/SearchMap.component.tests.js
+++ b/modules/search/tests/client/components/SearchMap.component.tests.js
@@ -1,11 +1,17 @@
 import React from 'react';
-import { act, render, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
 import '@/config/client/i18n';
 import { MAP_STYLE_OSM } from '@/modules/core/client/components/Map/constants';
 import { DEFAULT_LOCATION } from '@/modules/core/client/utils/constants';
 import SearchMap from '@/modules/search/client/components/SearchMap.component';
+
+const mockIsWebGLSupported = jest.fn();
+jest.mock('@/modules/core/client/utils/map', () => ({
+  ...jest.requireActual('@/modules/core/client/utils/map'),
+  isWebGLSupported: () => mockIsWebGLSupported(),
+}));
 
 const mockGetNostrEventAuthorPubkey = jest.fn(
   event => event.authorPubkey || event.pubkey,
@@ -72,6 +78,14 @@ jest.mock('@/modules/search/client/components/SearchMapNoContent', () => {
     return <div>Zoom closer to find members.</div>;
   };
 });
+
+const mockLeafletSearchMap = jest.fn();
+jest.mock('@/modules/search/client/components/LeafletSearchMap', () =>
+  jest.fn(props => {
+    mockLeafletSearchMap(props);
+    return <div data-testid="leaflet-search-map" />;
+  }),
+);
 
 const mockFitBounds = jest.fn();
 const mockMap = {
@@ -168,6 +182,8 @@ function renderSearchMap(props = {}) {
 }
 
 beforeEach(() => {
+  mockIsWebGLSupported.mockReturnValue(true);
+  mockLeafletSearchMap.mockClear();
   mockSourcePropsById = {};
   mockPersistentMapLocation = {
     latitude: 48.6908333333,
@@ -213,6 +229,53 @@ describe('Search', () => {
         onOfferClose={() => {}}
         onOfferOpen={() => {}}
       />,
+    );
+  });
+
+  it('uses the Leaflet renderer when WebGL is unavailable', async () => {
+    mockIsWebGLSupported.mockReturnValue(false);
+
+    renderSearchMap();
+
+    expect(screen.getByTestId('leaflet-search-map')).toBeInTheDocument();
+    expect(screen.queryByTestId('react-map-gl')).not.toBeInTheDocument();
+    expect(mockLeafletSearchMap).toHaveBeenCalledWith(
+      expect.objectContaining({
+        communityNotes: expect.objectContaining({ features: [] }),
+        offers: expect.objectContaining({ features: [] }),
+        onCommunityNoteClick: expect.any(Function),
+        onMapChange: expect.any(Function),
+        onOfferClick: expect.any(Function),
+      }),
+    );
+
+    const mapState = {
+      bounds: {
+        northEast: { lat: 53, lng: 14 },
+        southWest: { lat: 51, lng: 12 },
+      },
+      latitude: 52,
+      longitude: 13,
+      zoom: 6,
+    };
+
+    act(() => {
+      mockLeafletSearchMap.mock.calls[0][0].onMapChange(mapState);
+    });
+
+    expect(mockSetPersistentMapLocation).toHaveBeenCalledWith({
+      latitude: 52,
+      longitude: 13,
+      zoom: 6,
+    });
+    await waitFor(() =>
+      expect(mockQueryOffers).toHaveBeenCalledWith({
+        filters: '{}',
+        northEastLat: 54.666666666666664,
+        northEastLng: 15.666666666666666,
+        southWestLat: 49.333333333333336,
+        southWestLng: 10.333333333333334,
+      }),
     );
   });
 

--- a/openspec/changes/add-webgl-map-fallback/.openspec.yaml
+++ b/openspec/changes/add-webgl-map-fallback/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-14

--- a/openspec/changes/add-webgl-map-fallback/design.md
+++ b/openspec/changes/add-webgl-map-fallback/design.md
@@ -1,0 +1,90 @@
+## Context
+
+`SearchMap` and the generic `Map` component use `react-map-gl` and
+`mapbox-gl@1.13.2`. Mapbox GL draws its map and all search markers in a WebGL
+canvas. When a browser makes that context unavailable, the search shell loads
+but the canvas remains blank. The legacy Angular location editors already use
+Leaflet and are unaffected.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep map search and offer-location maps useful when WebGL is unavailable.
+- Preserve the normal Mapbox GL experience when WebGL is supported.
+- Preserve result fetching, persisted viewport, offer and Community Note
+  actions, and clustering in the fallback.
+- Detect the capability without identifying or tracking members.
+
+**Non-Goals:**
+
+- Detecting a browser mode or asking members to change browser settings.
+- Replacing Mapbox GL for supported browsers.
+- Giving the fallback Mapbox style switching, 3D rendering, or hover effects.
+
+## Decisions
+
+### Choose by WebGL capability before mounting Mapbox GL
+
+A shared utility will attempt to obtain a `webgl` (or legacy
+`experimental-webgl`) context and return false for unavailable, blocked, or
+exceptional browser implementations. Components select the renderer from that
+result before Mapbox GL creates a canvas. This fixes the actual compatibility
+constraint without attempting to identify a browser mode.
+
+An error-event-only fallback was rejected because Mapbox GL may fail before a
+usable map instance exists, producing a blank viewport first.
+
+### Use Leaflet and raster OpenStreetMap tiles for the fallback
+
+Leaflet is already a first-class project dependency for location editors and
+uses DOM and image tiles rather than WebGL. Its OpenStreetMap layer works with
+the current CSP and does not need a Mapbox token. A separate renderer keeps the
+WebGL-only Mapbox source/layer API out of the fallback.
+
+Using a newer Mapbox GL release was rejected because Mapbox GL still requires
+WebGL. A static image would not preserve navigation or result selection.
+
+### Cluster fallback points with Supercluster
+
+The fallback will index the existing GeoJSON result collections using
+`supercluster`, then render ordinary Leaflet markers for individual points and
+cluster markers for grouped points. Clicking a cluster uses its expansion zoom;
+clicking an offer or Community Note invokes the existing callbacks. This keeps
+the number of DOM markers bounded and preserves the current interaction model.
+
+`supercluster` is presently transitive through Mapbox GL, so it will be added
+as a direct dependency rather than importing an undeclared dependency.
+
+### Keep the compact offer map covered
+
+The only consumer of the generic Mapbox-based `Map` component is the offer
+location display. It will select an equivalent Leaflet renderer and show the
+offer marker, so all currently shipped Mapbox GL map entry points have a
+fallback.
+
+## Risks / Trade-offs
+
+- [Raster tiles have less visual detail and no style switcher] → show the
+  fallback only where WebGL cannot run; preserve current Mapbox styles
+  elsewhere.
+- [Imperative Leaflet lifecycle can leak maps or event handlers] → initialise
+  once per container and remove the map and handlers during React cleanup.
+- [Fallback tiles are external network requests] → use the existing
+  OpenStreetMap CSP source and deterministic local tile routes in end-to-end
+  tests.
+- [Map data changes while moving] → rebuild the small, bounded marker layer
+  from the current feature collection and viewport on each relevant change.
+
+## Migration Plan
+
+1. Deploy with the capability gate and fallback renderer.
+2. Verify an iPhone browser without WebGL and a normal Safari control case
+   before and after deployment.
+3. If an unexpected regression is found, revert the client-only change; no
+   data or server migration is involved.
+
+## Open Questions
+
+None. The capability gate intentionally treats all missing WebGL support the
+same way.

--- a/openspec/changes/add-webgl-map-fallback/proposal.md
+++ b/openspec/changes/add-webgl-map-fallback/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The map-search page renders entirely with Mapbox GL and therefore requires
+WebGL. When a browser makes WebGL unavailable, members see map controls but an
+empty map, despite map search being a core part of finding offers.
+
+## What Changes
+
+- Select a non-WebGL map renderer when the browser cannot create a WebGL
+  context, before Mapbox GL is mounted.
+- Provide an interactive Leaflet map with OpenStreetMap raster tiles for map
+  search, including offer results, Community Notes, selection, and clustered
+  results.
+- Provide the same non-WebGL fallback for the compact offer-location map.
+- Keep Mapbox GL as the renderer for browsers with WebGL support.
+
+## Capabilities
+
+### New Capabilities
+
+- `map-rendering-compatibility`: Render Trustroots maps and their essential
+  interactions when WebGL is unavailable.
+
+### Modified Capabilities
+
+- `offers-and-search`: Map search remains available in browsers without
+  WebGL.
+
+## Impact
+
+- Affects the core map utility and components, the search map, and the offer
+  location component.
+- Uses the existing Leaflet dependency and adds `supercluster` as a direct
+  dependency for the fallback's client-side clustering.
+- No API, data migration, or production configuration change is required.
+  The fallback uses the existing OpenStreetMap tile CSP allowance.

--- a/openspec/changes/add-webgl-map-fallback/specs/map-rendering-compatibility/spec.md
+++ b/openspec/changes/add-webgl-map-fallback/specs/map-rendering-compatibility/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Maps render without WebGL
+
+The system SHALL render an interactive raster map without mounting Mapbox GL
+when the browser cannot create a WebGL context.
+
+#### Scenario: Browser blocks WebGL
+
+- **WHEN** a member opens a Trustroots page containing a map and WebGL is
+  unavailable
+- **THEN** the page displays a Leaflet raster map instead of a blank Mapbox GL
+  canvas
+
+#### Scenario: Browser supports WebGL
+
+- **WHEN** a member opens a Trustroots page containing a map and WebGL is
+  available
+- **THEN** the page continues to use the Mapbox GL map renderer
+
+### Requirement: Fallback map result interaction
+
+The system SHALL preserve essential search-map interactions in the non-WebGL
+renderer.
+
+#### Scenario: Member selects a fallback-map offer
+
+- **WHEN** a member selects an individual offer marker in the non-WebGL
+  search map
+- **THEN** the system opens that offer in the search results sidebar
+
+#### Scenario: Member expands a fallback-map cluster
+
+- **WHEN** a member selects a cluster in the non-WebGL search map
+- **THEN** the system zooms to the cluster's expansion level
+
+#### Scenario: Member opens a fallback-map Community Note
+
+- **WHEN** a member selects an individual Community Note marker in the
+  non-WebGL search map
+- **THEN** the system opens the Community Note thread in the search sidebar

--- a/openspec/changes/add-webgl-map-fallback/specs/offers-and-search/spec.md
+++ b/openspec/changes/add-webgl-map-fallback/specs/offers-and-search/spec.md
@@ -1,0 +1,23 @@
+## MODIFIED Requirements
+
+### Requirement: Map search
+
+The system SHALL let signed-in members search for offers on a map by location,
+map bounds, and circle membership, including when the browser cannot create a
+WebGL context.
+
+#### Scenario: Member searches within a map area
+
+- **WHEN** a signed-in member searches within a map area
+- **THEN** the system displays matching offers in that area
+
+#### Scenario: Member filters map results by circle
+
+- **WHEN** a signed-in member applies a circle filter
+- **THEN** the system displays offers matching that circle
+
+#### Scenario: Member searches without WebGL
+
+- **WHEN** a signed-in member opens map search in a browser without WebGL
+- **THEN** the system provides an interactive raster map with the matching
+  offers

--- a/openspec/changes/add-webgl-map-fallback/tasks.md
+++ b/openspec/changes/add-webgl-map-fallback/tasks.md
@@ -1,0 +1,26 @@
+## 1. Compatibility foundation
+
+- [x] 1.1 Add and test a shared, exception-safe WebGL capability check
+- [x] 1.2 Add `supercluster` as a direct client dependency and refresh the
+      lockfile
+- [x] 1.3 Add a reusable Leaflet raster-map lifecycle component and styles
+
+## 2. Map fallbacks
+
+- [x] 2.1 Add a Leaflet search-map renderer with persisted viewport and map
+      bounds result fetching
+- [x] 2.2 Render and expand clustered offer results and open selected offers
+      in the fallback
+- [x] 2.3 Render and open Community Notes in the fallback
+- [x] 2.4 Render an offer-location marker with Leaflet when WebGL is
+      unavailable
+
+## 3. Verification
+
+- [x] 3.1 Add client tests for the capability gate and fallback interactions
+- [x] 3.2 Add end-to-end coverage that blocks WebGL and verifies a visible,
+      interactive fallback map
+- [ ] 3.3 Run targeted client and end-to-end tests, then the relevant coverage
+      checks
+- [ ] 3.4 Validate on an iPhone without WebGL and a normal-Safari control
+      case

--- a/package-lock.json
+++ b/package-lock.json
@@ -128,6 +128,7 @@
         "speakingurl": "14.0.1",
         "stopword": "1.0.11",
         "styled-components": "5.3.6",
+        "supercluster": "7.1.5",
         "ui-leaflet": "2.0.0",
         "use-debounce": "3.4.3",
         "use-persisted-state": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -210,6 +210,7 @@
     "speakingurl": "14.0.1",
     "stopword": "1.0.11",
     "styled-components": "5.3.6",
+    "supercluster": "7.1.5",
     "ui-leaflet": "2.0.0",
     "use-debounce": "3.4.3",
     "use-persisted-state": "0.3.3",

--- a/scripts/coverage/check-coverage.js
+++ b/scripts/coverage/check-coverage.js
@@ -13,6 +13,7 @@ const metrics = ['statements', 'branches', 'functions', 'lines'];
 
 const args = process.argv.slice(2);
 const update = args.includes('--update');
+const requireFull = args.includes('--require-full');
 const scopeArg = args.find(arg => arg.startsWith('--scope='));
 const scope = scopeArg ? scopeArg.split('=')[1] : null;
 const suiteNames = scope ? [scope] : Object.keys(suites);
@@ -74,9 +75,7 @@ if (missing.length > 0) {
 }
 
 if (update) {
-  const baseline = fs.existsSync(baselinePath)
-    ? readJson(baselinePath)
-    : {};
+  const baseline = fs.existsSync(baselinePath) ? readJson(baselinePath) : {};
   for (const suite of suiteNames) {
     baseline[suite] = current[suite];
   }
@@ -90,21 +89,25 @@ const failures = [];
 
 for (const suite of suiteNames) {
   for (const metric of metrics) {
-    const expected = baseline[suite][metric];
+    const expected = requireFull ? 100 : baseline[suite][metric];
     const actual = current[suite][metric];
     if (actual < expected) {
       const delta = actual - expected;
+      const expectation = requireFull
+        ? 'required 100.00%'
+        : `baseline ${formatValue(expected)}%`;
       failures.push(
-        `${suite} ${metric}: ${formatValue(actual)}% is below baseline ${formatValue(
-          expected,
-        )}% by ${formatValue(Math.abs(delta))} points`,
+        `${suite} ${metric}: ${formatValue(
+          actual,
+        )}% is below ${expectation} by ${formatValue(Math.abs(delta))} points`,
       );
     }
   }
 }
 
 if (failures.length > 0) {
-  console.error('Coverage ratchet failed:');
+  const check = requireFull ? 'requirement' : 'ratchet';
+  console.error(`Coverage ${check} failed:`);
   for (const failure of failures) {
     console.error(`- ${failure}`);
   }
@@ -115,5 +118,6 @@ for (const suite of suiteNames) {
   const summary = metrics
     .map(metric => `${metric} ${formatValue(current[suite][metric])}%`)
     .join(', ');
-  console.log(`${suite} coverage passed ratchet: ${summary}`);
+  const check = requireFull ? '100% requirement' : 'ratchet';
+  console.log(`${suite} coverage passed ${check}: ${summary}`);
 }

--- a/scripts/devcontainer/phone-url.js
+++ b/scripts/devcontainer/phone-url.js
@@ -1,0 +1,39 @@
+/* eslint-disable no-console, no-process-exit */
+
+const fs = require('fs');
+const os = require('os');
+
+if (fs.existsSync('/.dockerenv')) {
+  console.error(
+    'Run this from the host terminal, not inside the devcontainer.',
+  );
+  process.exit(1);
+}
+
+const port = Number(process.env.TRUSTROOTS_DEV_WEBPACK_HOST_PORT || 13000);
+if (!Number.isInteger(port) || port < 1 || port > 65535) {
+  console.error(
+    'TRUSTROOTS_DEV_WEBPACK_HOST_PORT must be a valid port number.',
+  );
+  process.exit(1);
+}
+
+const ignoredInterface = /^(docker|veth|br-|lo|utun|tun|tap)/i;
+const addresses = Object.entries(os.networkInterfaces())
+  .filter(([name]) => !ignoredInterface.test(name))
+  .flatMap(([, interfaces]) => interfaces || [])
+  .filter(
+    address =>
+      address.family === 'IPv4' &&
+      !address.internal &&
+      !address.address.startsWith('169.254.'),
+  )
+  .map(address => address.address);
+
+if (!addresses.length) {
+  console.error('No local network IPv4 address was found.');
+  process.exit(1);
+}
+
+console.log('Open one of these URLs on a phone connected to the same Wi-Fi:');
+addresses.forEach(address => console.log(`http://${address}:${port}`));

--- a/tests/e2e/features/search-offers-circles/search-map-rendered.spec.js
+++ b/tests/e2e/features/search-offers-circles/search-map-rendered.spec.js
@@ -272,6 +272,59 @@ test.describe('rendered search map feature coverage', () => {
     });
   });
 
+  test('search map uses the raster fallback when WebGL is unavailable', async ({
+    context,
+    page,
+  }, testInfo) => {
+    annotateFeature(testInfo, 'search.map', [
+      'A browser without WebGL receives a visible Leaflet raster map.',
+      'Fallback-map offer markers continue to open the results sidebar.',
+    ]);
+
+    await page.addInitScript(() => {
+      const Canvas = window.HTMLCanvasElement;
+      const getContext = Canvas.prototype.getContext;
+      Canvas.prototype.getContext = function getWebGLContext(type, ...args) {
+        if (type === 'webgl' || type === 'experimental-webgl') {
+          return null;
+        }
+        return getContext.call(this, type, ...args);
+      };
+    });
+    await context.route('**://*.tile.openstreetmap.org/**', route =>
+      route.fulfill({
+        body: Buffer.from(
+          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4z8DwHwAFgAI/ScL0iAAAAABJRU5ErkJggg==',
+          'base64',
+        ),
+        contentType: 'image/png',
+      }),
+    );
+
+    await page.goto('/search');
+
+    await expect(
+      page.locator('[data-testid="leaflet-search-map"]'),
+    ).toBeVisible();
+    await expect(page.locator('.mapboxgl-canvas')).toHaveCount(0);
+    await expect(page.locator('.leaflet-tile').first()).toHaveJSProperty(
+      'naturalWidth',
+      1,
+    );
+    await page.waitForFunction(
+      () => document.querySelectorAll('.leaflet-interactive').length > 0,
+      null,
+      { timeout: 30000 },
+    );
+
+    await page.locator('.leaflet-interactive').last().click();
+    await expect(
+      page
+        .locator('.search-sidebar-results .search-result')
+        .filter({ hasText: /E2E offline map host offer/i }),
+    ).toBeVisible();
+  });
+
   test('clicking a pin cluster zooms the map in to expand it', async ({
     context,
     page,


### PR DESCRIPTION
## Summary

- detect when WebGL maps cannot be created and use a Leaflet raster fallback
- preserve offer and community-note markers, clustering, navigation, and viewport updates
- add unit and end-to-end coverage plus repository worktree guidance

## Testing

- targeted Jest suites: 45 tests passed
- OpenSpec strict validation passed
- staged diff and whitespace checks passed