### PR TITLE
Exclude setup checks from e2e area summaries

### DIFF
--- a/modules/core/tests/server/scripts/e2e-coverage-reporter.unit.tests.js
+++ b/modules/core/tests/server/scripts/e2e-coverage-reporter.unit.tests.js
@@ -18,6 +18,9 @@ const {
   summarizeFeatureCoverage,
   validateFeatureManifest,
 } = require('../../../../../scripts/e2e/feature-coverage-summary');
+const {
+  summarizeReport,
+} = require('../../../../../scripts/e2e/summarize-results');
 
 function reportWithSpecs(specs) {
   return {
@@ -117,6 +120,30 @@ describe('E2E coverage reporter unit tests', () => {
       summary.areaPassCoverage.should.equal(
         Number(((1 / DEFINED_AREAS.length) * 100).toFixed(2)),
       );
+    });
+  });
+
+  describe('summarizeReport', () => {
+    it('counts setup checks without assigning them to a product area', () => {
+      const summary = summarizeReport(
+        reportWithSpecs([
+          spec('tests/e2e/setup/auth.setup.js', 'authentication setup', [
+            testCase('passed'),
+            testCase('passed'),
+            testCase('passed'),
+          ]),
+          spec('tests/e2e/features/messages/messages.spec.js', 'inbox', [
+            testCase('passed'),
+          ]),
+        ]),
+      );
+
+      summary.total.should.equal(4);
+      summary.passed.should.equal(4);
+      summary.byArea.should.deepEqual({
+        Messages: { total: 1, passed: 1, failed: 0, skipped: 0 },
+      });
+      summary.areas.should.deepEqual(['Messages']);
     });
   });
 

--- a/scripts/e2e/summarize-results.js
+++ b/scripts/e2e/summarize-results.js
@@ -53,13 +53,11 @@ function summarizeReport(report) {
   function walkSuites(suiteList) {
     for (const suite of suiteList || []) {
       for (const spec of suite.specs || []) {
-        const fileName = path.basename(spec.file || '');
-        if (fileName === 'auth.setup.js') {
-          continue;
-        }
-
         const area = areaForSpec(spec.file);
-        areas.add(area);
+        const isSetup = area === 'Setup';
+        if (!isSetup) {
+          areas.add(area);
+        }
 
         for (const testCase of spec.tests || []) {
           total += 1;
@@ -81,7 +79,11 @@ function summarizeReport(report) {
             skipped += 1;
           }
 
-          record(area, status);
+          // Setup checks are part of the Playwright run, but are not product
+          // coverage and therefore do not belong in an end-to-end area.
+          if (!isSetup) {
+            record(area, status);
+          }
         }
       }
 
@@ -244,8 +246,14 @@ async function run() {
   }
 }
 
-run().catch(error => {
-  const message = error && error.message ? error.message : String(error);
-  process.stderr.write(`Failed to summarize end-to-end results: ${message}\n`);
-  process.exit(1);
-});
+if (require.main === module) {
+  run().catch(error => {
+    const message = error && error.message ? error.message : String(error);
+    process.stderr.write(
+      `Failed to summarize end-to-end results: ${message}\n`,
+    );
+    process.exitCode = 1;
+  });
+}
+
+module.exports = { summarizeReport };


### PR DESCRIPTION
## Summary

- Count Playwright setup checks in overall e2e totals, but do not assign them to a product area
- Export `summarizeReport` from `scripts/e2e/summarize-results.js` so it can be unit tested
- Add unit coverage for the setup-check behaviour

## Test plan

- [x] Pre-commit lint passed on commit
- [ ] CI server/client tests

Made with [Cursor](https://cursor.com)