### PR TITLE
Dev: cap devcontainer MongoDB cache

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -41,6 +41,9 @@ services:
 
   mongodb:
     image: mongo:4.4
+    # Keep the database within Docker Desktop's available memory when using a
+    # realistic local data dump.
+    command: ['mongod', '--bind_ip_all', '--wiredTigerCacheSizeGB', '0.5']
     container_name: trustroots-devcontainer-db
     volumes:
       - mongodb:/data/db


### PR DESCRIPTION
## Summary

- cap the devcontainer MongoDB WiredTiger cache at 0.5 GB
- keep realistic local MongoDB dump imports within Docker Desktop memory limits

## Why

A production-sized local dump caused the devcontainer MongoDB process to exit with code 137 under memory pressure.

## Validation

- `docker compose -f .devcontainer/docker-compose.yml config`
- `npx prettier --check .devcontainer/docker-compose.yml`
- restored a production-sized local dump and verified the database remained responsive