### PR TITLE
fix for community notes

### DIFF
--- a/modules/admin/client/components/AdminAcquisitionStories.component.js
+++ b/modules/admin/client/components/AdminAcquisitionStories.component.js
@@ -1,5 +1,6 @@
 // External dependencies
-import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import React, { useMemo, useState, useEffect } from 'react';
 
 // Internal dependencies
 import { getAcquisitionStories } from '../api/acquisition-stories.api';
@@ -21,9 +22,51 @@ function formatDate(value) {
   return date.toISOString().slice(0, 10);
 }
 
+const storySortValues = {
+  acquisitionStory: story => String(story.acquisitionStory).toLowerCase(),
+  circleCount: story => Number(story.circleCount) || 0,
+  created: story => {
+    const timestamp = new Date(story.created).getTime();
+    return Number.isNaN(timestamp) ? 0 : timestamp;
+  },
+  member: story => String(story.username).toLowerCase(),
+};
+
+function SortableHeader({ column, label, onSort, sort }) {
+  const isActive = sort.column === column;
+  const direction = isActive ? sort.direction : 'none';
+
+  return (
+    <th aria-sort={direction}>
+      <button
+        className="btn btn-link admin-acquisition-stories-sort"
+        onClick={() => onSort(column)}
+        type="button"
+      >
+        {label}
+        {isActive && (sort.direction === 'ascending' ? ' ▲' : ' ▼')}
+      </button>
+    </th>
+  );
+}
+
+SortableHeader.propTypes = {
+  column: PropTypes.oneOf(Object.keys(storySortValues)).isRequired,
+  label: PropTypes.string.isRequired,
+  onSort: PropTypes.func.isRequired,
+  sort: PropTypes.shape({
+    column: PropTypes.string.isRequired,
+    direction: PropTypes.oneOf(['ascending', 'descending']).isRequired,
+  }).isRequired,
+};
+
 export default function AdminAcquisitionStories() {
   const [stories, setStories] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [sort, setSort] = useState({
+    column: 'created',
+    direction: 'descending',
+  });
 
   useEffect(() => {
     async function loadAcquisitionStories() {
@@ -34,6 +77,31 @@ export default function AdminAcquisitionStories() {
 
     loadAcquisitionStories();
   }, []);
+
+  const sortedStories = useMemo(() => {
+    const direction = sort.direction === 'ascending' ? 1 : -1;
+    const valueFor = storySortValues[sort.column];
+
+    return stories.slice().sort((left, right) => {
+      const leftValue = valueFor(left);
+      const rightValue = valueFor(right);
+      const comparison =
+        typeof leftValue === 'number'
+          ? leftValue - rightValue
+          : leftValue.localeCompare(rightValue);
+      return comparison * direction;
+    });
+  }, [sort, stories]);
+
+  function sortBy(column) {
+    setSort(currentSort => ({
+      column,
+      direction:
+        currentSort.column === column && currentSort.direction === 'ascending'
+          ? 'descending'
+          : 'ascending',
+    }));
+  }
 
   return (
     <>
@@ -50,13 +118,34 @@ export default function AdminAcquisitionStories() {
           <table className="table table-condensed table-striped admin-acquisition-stories-table">
             <thead>
               <tr>
-                <th>Date</th>
-                <th>Username</th>
-                <th>Story</th>
+                <SortableHeader
+                  column="created"
+                  label="Date"
+                  onSort={sortBy}
+                  sort={sort}
+                />
+                <SortableHeader
+                  column="member"
+                  label="Member"
+                  onSort={sortBy}
+                  sort={sort}
+                />
+                <SortableHeader
+                  column="circleCount"
+                  label="Circles"
+                  onSort={sortBy}
+                  sort={sort}
+                />
+                <SortableHeader
+                  column="acquisitionStory"
+                  label="Story"
+                  onSort={sortBy}
+                  sort={sort}
+                />
               </tr>
             </thead>
             <tbody>
-              {stories.map((story, index) => (
+              {sortedStories.map((story, index) => (
                 <tr key={story._id} id={`acquisition-story-${index + 1}`}>
                   <td>
                     <a href={`#acquisition-story-${index + 1}`}>
@@ -66,14 +155,31 @@ export default function AdminAcquisitionStories() {
                     </a>
                   </td>
                   <td>
-                    <UserLink
-                      user={{
-                        _id: story._id,
-                        displayName: story.displayName,
-                        username: story.username,
-                      }}
-                    />
+                    <div className="admin-acquisition-stories-member">
+                      <a
+                        aria-label={`Open public profile for ${
+                          story.displayName || story.username
+                        }`}
+                        href={`/profile/${story.username}`}
+                      >
+                        <img
+                          alt=""
+                          aria-hidden="true"
+                          className="avatar avatar-32"
+                          loading="lazy"
+                          src={`/api/users/${story._id}/avatar?size=32`}
+                        />
+                      </a>
+                      <UserLink
+                        user={{
+                          _id: story._id,
+                          displayName: story.displayName,
+                          username: story.username,
+                        }}
+                      />
+                    </div>
                   </td>
+                  <td>{story.circleCount || 0}</td>
                   <td>{story.acquisitionStory}</td>
                 </tr>
               ))}

--- a/modules/admin/client/components/AdminMessages.component.js
+++ b/modules/admin/client/components/AdminMessages.component.js
@@ -1,5 +1,5 @@
 // External dependencies
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 // Internal dependencies
 import { getMessages } from '../api/messages.api';
@@ -28,13 +28,12 @@ export default function AdminMessages() {
   const [member1, setMember1] = useState(initialMember1);
   const [member2, setMember2] = useState(initialMember2);
 
-  async function onSubmit(event) {
-    event.preventDefault();
-    if (member1 && member2) {
-      const userId1 = await resolveExactMemberId(member1, searchUsers, [
+  const runQuery = useCallback(async (member1Value, member2Value) => {
+    if (member1Value && member2Value) {
+      const userId1 = await resolveExactMemberId(member1Value, searchUsers, [
         'username',
       ]);
-      const userId2 = await resolveExactMemberId(member2, searchUsers, [
+      const userId2 = await resolveExactMemberId(member2Value, searchUsers, [
         'username',
       ]);
       if (!userId1 || !userId2) {
@@ -51,6 +50,17 @@ export default function AdminMessages() {
       );
       setQueried(true);
     }
+  }, []);
+
+  useEffect(() => {
+    if (initialMember1 && initialMember2) {
+      void runQuery(initialMember1, initialMember2);
+    }
+  }, [initialMember1, initialMember2, runQuery]);
+
+  function onSubmit(event) {
+    event.preventDefault();
+    void runQuery(member1, member2);
   }
 
   return (

--- a/modules/admin/client/components/AdminThreads.component.js
+++ b/modules/admin/client/components/AdminThreads.component.js
@@ -1,6 +1,6 @@
 // External dependencies
 import classnames from 'classnames';
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 // Internal dependencies
 import { getThreads } from '../api/threads.api';
@@ -24,17 +24,27 @@ export default function AdminThreads() {
   const [query, setQuery] = useState(initialQuery);
   const [threads, setThreads] = useState([]);
 
-  async function onSubmit(event) {
-    event.preventDefault();
-    const trimmedQuery = normalizeAdminQuery(query);
+  const runQuery = useCallback(async queryValue => {
+    const trimmedQuery = normalizeAdminQuery(queryValue);
     const userId = isMongoObjectId(trimmedQuery) ? trimmedQuery : '';
     const username = userId ? '' : trimmedQuery;
 
-    const threads = await getThreads({ userId, username });
+    const result = await getThreads({ userId, username });
     setQueried(true);
-    if (threads) {
-      setThreads(threads);
+    if (result) {
+      setThreads(result);
     }
+  }, []);
+
+  useEffect(() => {
+    if (initialQuery) {
+      void runQuery(initialQuery);
+    }
+  }, [initialQuery, runQuery]);
+
+  function onSubmit(event) {
+    event.preventDefault();
+    void runQuery(query);
   }
 
   function renderResults() {

--- a/modules/admin/client/less/admin.less
+++ b/modules/admin/client/less/admin.less
@@ -129,13 +129,30 @@
 }
 
 .admin-acquisition-stories-table {
+  th:first-child,
   th:nth-child(2),
   th:nth-child(3),
+  td:first-child,
   td:nth-child(2),
   td:nth-child(3) {
     width: 1%;
     white-space: nowrap;
   }
+}
+
+.admin-acquisition-stories-member {
+  display: flex;
+  align-items: center;
+
+  .avatar {
+    margin-right: 8px;
+  }
+}
+
+.admin-acquisition-stories-sort {
+  padding: 0;
+  color: inherit;
+  font-weight: inherit;
 }
 
 .admin-action,

--- a/modules/admin/server/controllers/admin.acquisition-stories.server.controller.js
+++ b/modules/admin/server/controllers/admin.acquisition-stories.server.controller.js
@@ -301,16 +301,27 @@ function getStories() {
     {
       acquisitionStory: { $exists: true, $ne: '' },
     },
-    '_id acquisitionStory created displayName username',
+    '_id acquisitionStory created displayName member username',
   )
     .sort('-created')
     .limit(3000)
     .exec();
 }
 
+function storyForList(story) {
+  return {
+    _id: story._id,
+    acquisitionStory: story.acquisitionStory,
+    circleCount: story.member.length,
+    created: story.created,
+    displayName: story.displayName,
+    username: story.username,
+  };
+}
+
 exports.list = async (req, res) => {
   const stories = await getStories();
-  res.send(stories || []);
+  res.send(stories ? stories.map(storyForList) : []);
 };
 
 exports.getAnalysis = async (req, res) => {

--- a/modules/admin/tests/client/components/AdminAcquisitionStories.component.tests.js
+++ b/modules/admin/tests/client/components/AdminAcquisitionStories.component.tests.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
 import AdminAcquisitionStories from '@/modules/admin/client/components/AdminAcquisitionStories.component';
@@ -24,6 +24,7 @@ describe('<AdminAcquisitionStories />', () => {
       {
         _id: '111111111111111111111111',
         acquisitionStory: 'I met people at a hitchhiking festival.',
+        circleCount: 3,
         created: '2026-04-05T06:07:08.000Z',
         displayName: 'Alice Example',
         username: 'alice',
@@ -39,6 +40,22 @@ describe('<AdminAcquisitionStories />', () => {
     expect(
       screen.getByRole('link', { name: 'alice (Alice Example)' }),
     ).toHaveAttribute('href', '/admin/user?id=111111111111111111111111');
+    expect(
+      screen.getByRole('link', {
+        name: 'Open public profile for Alice Example',
+      }),
+    ).toHaveAttribute('href', '/profile/alice');
+    const profileImage = screen
+      .getByRole('link', {
+        name: 'Open public profile for Alice Example',
+      })
+      .querySelector('img');
+    expect(profileImage).toHaveAttribute('loading', 'lazy');
+    expect(profileImage).toHaveAttribute(
+      'src',
+      '/api/users/111111111111111111111111/avatar?size=32',
+    );
+    expect(screen.getByText('3')).toBeInTheDocument();
     expect(
       screen.getByRole('link', { name: 'Stories' }).closest('li'),
     ).toHaveClass('active');
@@ -77,5 +94,56 @@ describe('<AdminAcquisitionStories />', () => {
     expect(await screen.findByText('No date story.')).toBeInTheDocument();
     expect(screen.getByText('Invalid date story.')).toBeInTheDocument();
     expect(screen.getAllByText('', { selector: 'time' })).toHaveLength(2);
+  });
+
+  it('sorts stories by every table column', async () => {
+    acquisitionStoriesApi.getAcquisitionStories.mockResolvedValueOnce([
+      {
+        _id: '111111111111111111111111',
+        acquisitionStory: 'Zebra recommendation',
+        circleCount: 2,
+        created: '2026-01-01T00:00:00.000Z',
+        displayName: 'Alice Example',
+        username: 'alice',
+      },
+      {
+        _id: '222222222222222222222222',
+        acquisitionStory: 'A friend recommended it',
+        circleCount: 0,
+        created: '2026-02-01T00:00:00.000Z',
+        displayName: 'Bob Example',
+        username: 'bob',
+      },
+    ]);
+
+    render(<AdminAcquisitionStories />);
+    await screen.findByText('Zebra recommendation');
+
+    const storyOrder = () =>
+      Array.from(document.querySelectorAll('tbody tr')).map(row =>
+        row.textContent.includes('Zebra recommendation') ? 'alice' : 'bob',
+      );
+
+    expect(storyOrder()).toEqual(['bob', 'alice']);
+    expect(screen.getByText('Date ▼').closest('th')).toHaveAttribute(
+      'aria-sort',
+      'descending',
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Date ▼' }));
+    expect(storyOrder()).toEqual(['alice', 'bob']);
+    fireEvent.click(screen.getByRole('button', { name: 'Date ▲' }));
+    expect(storyOrder()).toEqual(['bob', 'alice']);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Member' }));
+    expect(storyOrder()).toEqual(['alice', 'bob']);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Circles' }));
+    expect(storyOrder()).toEqual(['bob', 'alice']);
+    fireEvent.click(screen.getByRole('button', { name: 'Circles ▲' }));
+    expect(storyOrder()).toEqual(['alice', 'bob']);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Story' }));
+    expect(storyOrder()).toEqual(['bob', 'alice']);
   });
 });

--- a/modules/admin/tests/client/components/AdminMessages.component.tests.js
+++ b/modules/admin/tests/client/components/AdminMessages.component.tests.js
@@ -227,9 +227,9 @@ describe('<AdminMessages />', () => {
 
     render(<AdminMessages />);
 
-    expect(screen.getByText('Press "Read"')).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: 'Read' }));
-
+    await waitFor(() =>
+      expect(messagesApi.getMessages).toHaveBeenCalledWith(user1, user2),
+    );
     expect(await screen.findByText('Nothing found…')).toBeInTheDocument();
   });
 

--- a/modules/admin/tests/client/components/AdminThreads.component.tests.js
+++ b/modules/admin/tests/client/components/AdminThreads.component.tests.js
@@ -35,22 +35,34 @@ const makeUser = overrides => ({
 });
 
 describe('<AdminThreads />', () => {
-  it('uses a valid member id from the URL as the initial query', () => {
+  it('queries automatically using a valid member id from the URL', async () => {
     window.history.pushState({}, '', `/admin/threads?userId=${userId}`);
+    threadsApi.getThreads.mockResolvedValueOnce([]);
 
     render(<AdminThreads />);
 
     expect(screen.getByLabelText('Member username or ID')).toHaveValue(userId);
-    expect(screen.queryByText('Press "Query"')).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(threadsApi.getThreads).toHaveBeenCalledWith({
+        userId,
+        username: '',
+      }),
+    );
   });
 
-  it('uses a username from the URL as the initial query', () => {
+  it('queries automatically using a username from the URL', async () => {
     window.history.pushState({}, '', '/admin/threads?username=alice');
+    threadsApi.getThreads.mockResolvedValueOnce([]);
 
     render(<AdminThreads />);
 
     expect(screen.getByLabelText('Member username or ID')).toHaveValue('alice');
-    expect(screen.queryByText('Press "Query"')).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(threadsApi.getThreads).toHaveBeenCalledWith({
+        userId: '',
+        username: 'alice',
+      }),
+    );
   });
 
   it('queries by username and renders thread state and links', async () => {

--- a/modules/admin/tests/server/admin.acquisition-stories.server.controller.unit.tests.js
+++ b/modules/admin/tests/server/admin.acquisition-stories.server.controller.unit.tests.js
@@ -33,6 +33,7 @@ describe('Admin acquisition stories controller unit tests', () => {
     it('returns acquisition stories for users who have one', async () => {
       const users = utils.generateUsers(2);
       users[0].acquisitionStory = 'Found via couch surfing';
+      users[0].member = [{ tribe: new mongoose.Types.ObjectId() }];
       users[1].acquisitionStory = '';
 
       await utils.saveUsers(users);
@@ -42,6 +43,8 @@ describe('Admin acquisition stories controller unit tests', () => {
 
       res.body.length.should.equal(1);
       res.body[0].acquisitionStory.should.equal('Found via couch surfing');
+      res.body[0].circleCount.should.equal(1);
+      should(res.body[0].member).be.undefined();
     });
 
     it('returns an empty array when no stories exist', async () => {

--- a/modules/core/server/routes/core.server.routes.js
+++ b/modules/core/server/routes/core.server.routes.js
@@ -49,6 +49,63 @@ module.exports = function (app) {
 
   app.route('/api/languages').get(core.getLanguages);
 
+  app.route('/api/nostr/author-visibility').get(function (req, res) {
+    const mongoose = require('mongoose');
+    const User = mongoose.model('User');
+    const rawPubkeys = req.query.pubkey;
+    const pubkeys = Array.isArray(rawPubkeys) ? rawPubkeys : [rawPubkeys];
+
+    if (
+      pubkeys.length > 100 ||
+      pubkeys.some(
+        pubkey => typeof pubkey !== 'string' || !/^[0-9a-f]{64}$/i.test(pubkey),
+      )
+    ) {
+      return res
+        .status(400)
+        .send({ error: 'One to 100 valid public keys required.' });
+    }
+
+    const normalizedPubkeys = [
+      ...new Set(pubkeys.map(pubkey => pubkey.toLowerCase())),
+    ];
+    const npubs = normalizedPubkeys.map(pubkey => nip19.npubEncode(pubkey));
+
+    User.find(
+      {
+        nostrNpub: { $in: npubs },
+      },
+      function (err, users) {
+        if (err) {
+          return res.status(500).send({ error: 'Internal server error' });
+        }
+
+        const linkedNpubs = new Set(users.map(user => user.nostrNpub));
+        const visibleNpubs = new Set(
+          users
+            .filter(
+              user =>
+                user.public &&
+                user.email &&
+                !user.roles.some(role =>
+                  ['suspended', 'shadowban'].includes(role),
+                ),
+            )
+            .map(user => user.nostrNpub),
+        );
+
+        return res.json({
+          linkedPubkeys: normalizedPubkeys.filter(pubkey =>
+            linkedNpubs.has(nip19.npubEncode(pubkey)),
+          ),
+          pubkeys: normalizedPubkeys.filter(pubkey =>
+            visibleNpubs.has(nip19.npubEncode(pubkey)),
+          ),
+        });
+      },
+    );
+  });
+
   // Return a 404 for all undefined api, module or lib routes
   app.route('/:url(api|modules|lib|developers)/*').get(core.renderNotFound);
 

--- a/modules/core/tests/server/core.server.routes.tests.js
+++ b/modules/core/tests/server/core.server.routes.tests.js
@@ -534,4 +534,167 @@ describe('Core CRUD tests', function () {
       });
     });
   });
+
+  describe('Nostr author visibility API', function () {
+    const validNpub =
+      'npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqujme';
+    const validNpubHex =
+      '0000000000000000000000000000000000000000000000000000000000000000';
+
+    afterEach(utils.clearDatabase);
+
+    function createNostrUser(overrides, done) {
+      const user = new User(
+        Object.assign(
+          {
+            public: true,
+            firstName: 'Nostr',
+            lastName: 'User',
+            email: 'nostruser@example.com',
+            username: 'nostruser',
+            password: 'M3@n.jsI$Aw3$0m3',
+            provider: 'local',
+            roles: ['user'],
+            nostrNpub: validNpub,
+          },
+          overrides,
+        ),
+      );
+
+      user.save(done);
+    }
+
+    it('returns only eligible public author keys from a batch', function (done) {
+      createNostrUser({}, function (saveErr) {
+        if (saveErr) return done(saveErr);
+
+        agent
+          .get(
+            '/api/nostr/author-visibility?pubkey=' +
+              validNpubHex +
+              '&pubkey=' +
+              '11'.repeat(32),
+          )
+          .expect(200)
+          .end(function (err, res) {
+            if (err) return done(err);
+            res.body.should.deepEqual({
+              linkedPubkeys: [validNpubHex],
+              pubkeys: [validNpubHex],
+            });
+            return done();
+          });
+      });
+    });
+
+    it('excludes shadowbanned author keys', function (done) {
+      createNostrUser({ roles: ['user', 'shadowban'] }, function (saveErr) {
+        if (saveErr) return done(saveErr);
+
+        agent
+          .get('/api/nostr/author-visibility?pubkey=' + validNpubHex)
+          .expect(200)
+          .end(function (err, res) {
+            if (err) return done(err);
+            res.body.should.deepEqual({
+              linkedPubkeys: [validNpubHex],
+              pubkeys: [],
+            });
+            return done();
+          });
+      });
+    });
+
+    it('identifies private author keys without making them visible', function (done) {
+      createNostrUser({ public: false }, function (saveErr) {
+        if (saveErr) return done(saveErr);
+
+        agent
+          .get('/api/nostr/author-visibility?pubkey=' + validNpubHex)
+          .expect(200)
+          .end(function (err, res) {
+            if (err) return done(err);
+            res.body.should.deepEqual({
+              linkedPubkeys: [validNpubHex],
+              pubkeys: [],
+            });
+            return done();
+          });
+      });
+    });
+
+    it('identifies unconfirmed author keys without making them visible', function (done) {
+      createNostrUser({}, function (saveErr, user) {
+        if (saveErr) return done(saveErr);
+
+        User.updateOne(
+          { _id: user._id },
+          { $set: { email: '' } },
+          function (updateErr) {
+            if (updateErr) return done(updateErr);
+
+            agent
+              .get('/api/nostr/author-visibility?pubkey=' + validNpubHex)
+              .expect(200)
+              .end(function (err, res) {
+                if (err) return done(err);
+                res.body.should.deepEqual({
+                  linkedPubkeys: [validNpubHex],
+                  pubkeys: [],
+                });
+                return done();
+              });
+          },
+        );
+      });
+    });
+
+    it('rejects invalid author key batches', function (done) {
+      agent
+        .get('/api/nostr/author-visibility?pubkey=invalid')
+        .expect(400)
+        .end(function (err, res) {
+          if (err) return done(err);
+          res.body.error.should.equal('One to 100 valid public keys required.');
+          return done();
+        });
+    });
+
+    it('rejects non-string and oversized author key batches', function (done) {
+      const oversizedBatch = Array(101).fill(validNpubHex).join('&pubkey=');
+
+      agent
+        .get('/api/nostr/author-visibility?pubkey[$ne]=x')
+        .expect(400)
+        .end(function (objectErr) {
+          if (objectErr) return done(objectErr);
+
+          agent
+            .get('/api/nostr/author-visibility?pubkey=' + oversizedBatch)
+            .expect(400)
+            .end(function (batchErr, res) {
+              if (batchErr) return done(batchErr);
+              res.body.error.should.equal(
+                'One to 100 valid public keys required.',
+              );
+              return done();
+            });
+        });
+    });
+
+    it('returns an error when the author lookup fails', function (done) {
+      const sinon = require('sinon');
+      sinon.stub(User, 'find').yields(new Error('db unavailable'));
+
+      agent
+        .get('/api/nostr/author-visibility?pubkey=' + validNpubHex)
+        .expect(500)
+        .end(function (err, res) {
+          sinon.restore();
+          if (err) return done(err);
+          res.body.error.should.equal('Internal server error');
+          return done();
+        });
+    });
+  });
 });

--- a/modules/search/client/components/CommunityNotesSidebar.component.js
+++ b/modules/search/client/components/CommunityNotesSidebar.component.js
@@ -61,7 +61,7 @@ export default function CommunityNotesSidebar({ notes, plusCode }) {
 
   if (!notes || notes.length === 0) return null;
 
-  const sorted = [...notes].sort((a, b) => b.created_at - a.created_at);
+  const sorted = [...notes].sort((a, b) => a.created_at - b.created_at);
 
   return (
     <div className="community-notes-sidebar">

--- a/modules/search/client/components/LeafletSearchMap.js
+++ b/modules/search/client/components/LeafletSearchMap.js
@@ -281,7 +281,7 @@ export default function LeafletSearchMap({
       index: communityNoteIndex,
       map,
       onPointClick: point => callbacksRef.current.onCommunityNoteClick(point),
-      pointColour: point => (point.properties.verified ? '#1565C0' : '#1976D2'),
+      pointColour: () => '#1565C0',
       viewport,
     });
   }, [communityNotes, offers, viewport]);

--- a/modules/search/client/components/SearchMap.component.js
+++ b/modules/search/client/components/SearchMap.component.js
@@ -463,6 +463,64 @@ export default function SearchMap({
     }
   }
 
+  const zoomToCommunityNotesCluster = cluster => {
+    if (!cluster?.geometry?.coordinates) {
+      return;
+    }
+
+    setViewport({
+      ...viewport,
+      latitude: cluster.geometry.coordinates[1],
+      longitude: cluster.geometry.coordinates[0],
+      zoom: Math.min((viewport.zoom || 2) + 3, CLUSTER_MAX_ZOOM),
+      transitionDuration: 'auto',
+      transitionInterpolator: new FlyToInterpolator({ speed: 3.0 }),
+    });
+  };
+
+  const openCommunityNotesCluster = cluster => {
+    const clusterId = cluster?.properties?.cluster_id;
+    if (clusterId === undefined) {
+      zoomToCommunityNotesCluster(cluster);
+      return;
+    }
+
+    const source = getMapRef()?.getSource(SOURCE_COMMUNITY_NOTES);
+    if (!source) {
+      zoomToCommunityNotesCluster(cluster);
+      return;
+    }
+
+    source.getClusterLeaves(
+      clusterId,
+      cluster.properties.point_count,
+      0,
+      (error, leaves) => {
+        if (error) {
+          zoomToCommunityNotesCluster(cluster);
+          return;
+        }
+
+        const plusCode = getPlusCodeFromEvent(leaves[0].properties);
+        const sharesPlusCode = leaves.every(
+          leaf => getPlusCodeFromEvent(leaf.properties) === plusCode,
+        );
+
+        if (!sharesPlusCode) {
+          zoomToCommunityNotesCluster(cluster);
+          return;
+        }
+
+        if (onCommunityNoteOpen) {
+          onCommunityNoteOpen({
+            notes: leaves.map(leaf => reconstructEvent(leaf.properties)),
+            plusCode,
+          });
+        }
+      },
+    );
+  };
+
   const onClickMap = event => {
     const { features } = event;
     clearPreviouslySelectedState();
@@ -484,17 +542,7 @@ export default function SearchMap({
 
     // Community notes cluster click — zoom in
     if (layerId === communityNotesClusterLayer.id) {
-      const feature = features[0];
-      if (feature?.geometry?.coordinates) {
-        setViewport({
-          ...viewport,
-          latitude: feature.geometry.coordinates[1],
-          longitude: feature.geometry.coordinates[0],
-          zoom: Math.min((viewport.zoom || 2) + 3, CLUSTER_MAX_ZOOM),
-          transitionDuration: 'auto',
-          transitionInterpolator: new FlyToInterpolator({ speed: 3.0 }),
-        });
-      }
+      openCommunityNotesCluster(features[0]);
       return;
     }
 

--- a/modules/search/client/components/SearchMap.component.js
+++ b/modules/search/client/components/SearchMap.component.js
@@ -44,13 +44,31 @@ import {
   communityNotesLayer,
   communityNotesClusterLayer,
   communityNotesClusterCountLayer,
+  communityNotesClusterCountLayerOSM,
 } from './community-notes-layers';
 import { OpenLocationCode } from 'open-location-code';
 import 'mapbox-gl/dist/mapbox-gl.css';
 
 const COMMUNITY_NOTES_RECONNECT_DELAY_MS = 1000;
+const MISSING_MAP_LAYER_ERROR =
+  /^The layer '.*' does not exist in the map's style and cannot be queried for features\.$/;
 
 const olc = new OpenLocationCode();
+
+function handleMapError(event) {
+  const error = event?.error;
+
+  // A pointer event can race with style teardown after React has removed the
+  // interactive layers. Mapbox already returns no features for this query, so
+  // do not report the expected lifecycle race as an application error.
+  if (MISSING_MAP_LAYER_ERROR.test(error?.message)) {
+    return;
+  }
+
+  // Keep Mapbox's default behaviour for every other map error.
+  // eslint-disable-next-line no-console
+  console.error(error || event);
+}
 
 function getPlusCodeFromRawEvent(event) {
   const tag = event.tags.find(
@@ -181,6 +199,7 @@ export default function SearchMap({
     typeof mapStyle === 'string' && mapStyle.startsWith('mapbox://');
   const effectiveMapStyle =
     !MAPBOX_TOKEN && isMapboxStyle ? MAP_STYLE_OSM : mapStyle;
+  const isOsmStyle = effectiveMapStyle?.name === MAP_STYLE_OSM.name;
   // If no mapbox token, and we're in production, don't show the style switcher
   const showMapStyles =
     webGLSupported && (!!MAPBOX_TOKEN || process.env.NODE_ENV !== 'production');
@@ -693,6 +712,7 @@ export default function SearchMap({
         mapboxApiAccessToken={MAPBOX_TOKEN}
         mapStyle={effectiveMapStyle}
         onClick={onClickMap}
+        onError={handleMapError}
         onHover={onHover}
         onInteractionStateChange={debouncedUpdateOffers}
         onMouseLeave={clearPreviouslyHoveredState}
@@ -727,7 +747,7 @@ export default function SearchMap({
         >
           <Layer {...clusterLayer} />
           {/* OSM and Mapbox use different fonts for cluster numbers */}
-          {effectiveMapStyle === MAP_STYLE_OSM ? (
+          {isOsmStyle ? (
             <Layer {...clusterCountLayerOSM} />
           ) : (
             <Layer {...clusterCountLayerMapbox} />
@@ -745,7 +765,11 @@ export default function SearchMap({
             promoteId="id"
           >
             <Layer {...communityNotesClusterLayer} />
-            <Layer {...communityNotesClusterCountLayer} />
+            {isOsmStyle ? (
+              <Layer {...communityNotesClusterCountLayerOSM} />
+            ) : (
+              <Layer {...communityNotesClusterCountLayer} />
+            )}
             <Layer {...communityNotesLayer} />
           </Source>
         )}

--- a/modules/search/client/components/SearchMap.component.js
+++ b/modules/search/client/components/SearchMap.component.js
@@ -48,6 +48,8 @@ import {
 import { OpenLocationCode } from 'open-location-code';
 import 'mapbox-gl/dist/mapbox-gl.css';
 
+const COMMUNITY_NOTES_RECONNECT_DELAY_MS = 1000;
+
 const olc = new OpenLocationCode();
 
 function getPlusCodeFromRawEvent(event) {
@@ -112,7 +114,6 @@ function nostrEventsToGeoJSON(events) {
           pubkey: event.pubkey,
           authorPubkey: getNostrEventAuthorPubkey(event),
           created_at: event.created_at,
-          verified: event.kind === 30398,
           kind: event.kind,
           tags: JSON.stringify(event.tags),
         },
@@ -564,24 +565,73 @@ export default function SearchMap({
     }
 
     communityNotesEventsRef.current = [];
-    nostrService
-      .subscribeMapNotes(event => {
-        communityNotesEventsRef.current.push({
-          ...event,
-          authorPubkey: getNostrEventAuthorPubkey(event),
+    let cancelled = false;
+    let reconnectTimer = null;
+
+    const updateCommunityNotes = async () => {
+      const events = [...communityNotesEventsRef.current];
+      const visibleNotes =
+        await nostrService.filterCommunityNotesByAuthorVisibility(events);
+
+      if (
+        cancelled ||
+        events.length !== communityNotesEventsRef.current.length
+      ) {
+        return;
+      }
+      setCommunityNotes(nostrEventsToGeoJSON(visibleNotes));
+    };
+
+    const receiveCommunityNote = event => {
+      const note = {
+        ...event,
+        authorPubkey: getNostrEventAuthorPubkey(event),
+      };
+      const existingIndex = communityNotesEventsRef.current.findIndex(
+        existing => existing.id === event.id,
+      );
+      if (existingIndex === -1) {
+        communityNotesEventsRef.current.push(note);
+      } else {
+        communityNotesEventsRef.current[existingIndex] = note;
+      }
+      clearTimeout(communityNotesTimerRef.current);
+      communityNotesTimerRef.current = setTimeout(() => {
+        void updateCommunityNotes();
+      }, 200);
+    };
+
+    const handleEose = () => {
+      clearTimeout(communityNotesTimerRef.current);
+      void updateCommunityNotes();
+    };
+
+    const scheduleReconnect = () => {
+      if (cancelled || reconnectTimer) return;
+      reconnectTimer = setTimeout(() => {
+        reconnectTimer = null;
+        // Defined below before any reconnect timer can run.
+        // eslint-disable-next-line no-use-before-define
+        void subscribeToCommunityNotes();
+      }, COMMUNITY_NOTES_RECONNECT_DELAY_MS);
+    };
+
+    const subscribeToCommunityNotes = async () => {
+      try {
+        await nostrService.subscribeMapNotes(receiveCommunityNote, undefined, {
+          onClose: scheduleReconnect,
+          onEose: handleEose,
         });
-        clearTimeout(communityNotesTimerRef.current);
-        communityNotesTimerRef.current = setTimeout(() => {
-          setCommunityNotes(
-            nostrEventsToGeoJSON([...communityNotesEventsRef.current]),
-          );
-        }, 200);
-      })
-      .catch(() => {
-        setCommunityNotes({ type: 'FeatureCollection', features: [] });
-      });
+      } catch {
+        scheduleReconnect();
+      }
+    };
+
+    void subscribeToCommunityNotes();
 
     return () => {
+      cancelled = true;
+      clearTimeout(reconnectTimer);
       nostrService.unsubscribeMapNotes();
       clearTimeout(communityNotesTimerRef.current);
     };

--- a/modules/search/client/components/community-notes-layers.js
+++ b/modules/search/client/components/community-notes-layers.js
@@ -39,12 +39,7 @@ export const communityNotesLayer = {
   filter: ['!', ['has', 'point_count']],
   minzoom: MIN_ZOOM,
   paint: {
-    'circle-color': [
-      'case',
-      ['==', ['get', 'verified'], true],
-      '#1565C0', // Verified (kind 30398)
-      '#1976D2', // Unverified (kind 30397)
-    ],
+    'circle-color': '#1565C0',
     // Make circles larger as the user zooms from z2 to z22
     'circle-radius': {
       base: 1.75,

--- a/modules/search/client/components/community-notes-layers.js
+++ b/modules/search/client/components/community-notes-layers.js
@@ -32,6 +32,14 @@ export const communityNotesClusterCountLayer = {
   },
 };
 
+export const communityNotesClusterCountLayerOSM = {
+  ...communityNotesClusterCountLayer,
+  layout: {
+    ...communityNotesClusterCountLayer.layout,
+    'text-font': ['Open Sans Semibold'],
+  },
+};
+
 export const communityNotesLayer = {
   id: 'community-notes-points',
   type: 'circle',

--- a/modules/search/client/services/nostr.client.service.js
+++ b/modules/search/client/services/nostr.client.service.js
@@ -6,27 +6,11 @@ import { Relay } from 'nostr-tools/lib/cjs/relay.js';
 
 export const NOSTR_RELAY_URL = 'wss://relay.trustroots.org';
 export const MAP_NOTES_LIMIT = 500;
-
-// Nostroots validation server pubkey — only kind 30398 events signed by this
-// key are considered verified map notes.
-export const NOSTROOTS_VALIDATION_PUBKEY =
-  'f5bc71692fc08ea52c0d1c8bcfb87579584106b5feb4ea542b1b8a95612f257b';
+export const NOSTR_AUTHOR_VISIBILITY_ENDPOINT = '/api/nostr/author-visibility';
+export const AUTHOR_VISIBILITY_CACHE_TTL_MS = 5 * 60 * 1000;
 
 export function getNostrEventAuthorPubkey(event) {
-  if (event?.kind === 30398) {
-    const originalAuthorTag = event.tags?.find(tag => tag[0] === 'p' && tag[1]);
-    if (originalAuthorTag) {
-      return originalAuthorTag[1];
-    }
-  }
-
   return event?.pubkey;
-}
-
-function getReferencedEventIds(event) {
-  return (event.tags ?? [])
-    .filter(tag => tag[0] === 'e' && tag[1])
-    .map(tag => tag[1]);
 }
 
 /**
@@ -37,12 +21,12 @@ export default class NostrService {
   /**
    * @param {string} relayUrl — WebSocket URL of the Nostr relay
    */
-  constructor(relayUrl, validationPubkey = NOSTROOTS_VALIDATION_PUBKEY) {
+  constructor(relayUrl) {
     this.relayUrl = relayUrl;
-    this.validationPubkey = validationPubkey;
     this.relay = null;
     this.subscriptions = new Map();
     this.usernameCache = new Map();
+    this.communityNoteAuthorVisibilityCache = new Map();
   }
 
   /**
@@ -93,15 +77,20 @@ export default class NostrService {
   }
 
   /**
-   * Subscribe to recent verified map notes (kind 30398) from the Nostroots
-   * validation server.
+   * Subscribe to recent original map notes (kind 30397). Author visibility is
+   * evaluated separately against current Trustroots account state.
    * Closes any existing 'mapNotes' subscription before creating a new one.
    *
    * @param {Function} onEvent — callback invoked for each matching event
    * @param {number} [limit=MAP_NOTES_LIMIT] — maximum historical events
+   * @param {object} [callbacks] — subscription lifecycle callbacks
    * @returns {Promise<object>} the subscription handle
    */
-  async subscribeMapNotes(onEvent, limit = MAP_NOTES_LIMIT) {
+  async subscribeMapNotes(
+    onEvent,
+    limit = MAP_NOTES_LIMIT,
+    { onClose, onEose } = {},
+  ) {
     const relay = await this.connect();
 
     this.unsubscribeMapNotes();
@@ -109,14 +98,14 @@ export default class NostrService {
     const sub = relay.subscribe(
       [
         {
-          kinds: [30398],
-          authors: [this.validationPubkey],
+          kinds: [30397],
           limit,
         },
       ],
       {
         onevent: onEvent,
-        oneose() {},
+        oneose: onEose || (() => {}),
+        onclose: onClose,
       },
     );
 
@@ -145,26 +134,8 @@ export default class NostrService {
           return;
         }
         resolved = true;
-        const validatedOriginalEventIds = new Set();
-        events.forEach(event => {
-          if (event.kind === 30398) {
-            getReferencedEventIds(event).forEach(eventId => {
-              validatedOriginalEventIds.add(eventId);
-            });
-          }
-        });
         const dedupedEvents = [
-          ...new Map(
-            events
-              .filter(
-                event =>
-                  !(
-                    event.kind === 30397 &&
-                    validatedOriginalEventIds.has(event.id)
-                  ),
-              )
-              .map(event => [event.id, event]),
-          ).values(),
+          ...new Map(events.map(event => [event.id, event])).values(),
         ]
           .sort((a, b) => b.created_at - a.created_at)
           .slice(0, limit);
@@ -173,15 +144,7 @@ export default class NostrService {
       };
 
       subscriptionRef.current = relay.subscribe(
-        [
-          { kinds: [30397], authors: [pubkeyHex], limit },
-          {
-            kinds: [30398],
-            authors: [this.validationPubkey],
-            '#p': [pubkeyHex],
-            limit,
-          },
-        ],
+        [{ kinds: [30397], authors: [pubkeyHex], limit }],
         {
           onevent(event) {
             events.push(event);
@@ -248,23 +211,73 @@ export default class NostrService {
       );
     });
   }
-}
 
-function runtimeValidationPubkey() {
-  /* istanbul ignore next -- exercised by the browser E2E bundle only */
-  if (
-    typeof window !== 'undefined' &&
-    (window.location.hostname === 'localhost' ||
-      window.location.hostname === '127.0.0.1') &&
-    window.__TRUSTROOTS_E2E_NOSTROOTS_VALIDATION_PUBKEY__
-  ) {
-    return window.__TRUSTROOTS_E2E_NOSTROOTS_VALIDATION_PUBKEY__;
+  async filterCommunityNotesByAuthorVisibility(notes) {
+    const now = Date.now();
+    const authorPubkeys = [
+      ...new Set(
+        notes
+          .map(note => (note.authorPubkey || note.pubkey || '').toLowerCase())
+          .filter(pubkey => /^[0-9a-f]{64}$/.test(pubkey)),
+      ),
+    ];
+    const unresolvedPubkeys = authorPubkeys.filter(pubkey => {
+      const cached = this.communityNoteAuthorVisibilityCache.get(pubkey);
+      return !cached || cached.expiresAt <= now;
+    });
+
+    try {
+      for (let index = 0; index < unresolvedPubkeys.length; index += 100) {
+        const query = new URLSearchParams();
+        const batch = unresolvedPubkeys.slice(index, index + 100);
+        batch.forEach(pubkey => query.append('pubkey', pubkey));
+
+        const response = await fetch(
+          `${NOSTR_AUTHOR_VISIBILITY_ENDPOINT}?${query.toString()}`,
+        );
+        if (!response.ok) throw new Error('Author visibility lookup failed');
+
+        const payload = await response.json();
+        if (
+          !angular.isArray(payload?.pubkeys) ||
+          !angular.isArray(payload?.linkedPubkeys)
+        ) {
+          throw new Error('Invalid author visibility response');
+        }
+
+        const linkedPubkeys = new Set(
+          payload.linkedPubkeys
+            .filter(pubkey => angular.isString(pubkey))
+            .map(pubkey => pubkey.toLowerCase()),
+        );
+        const visiblePubkeys = new Set(
+          payload.pubkeys
+            .filter(pubkey => angular.isString(pubkey))
+            .map(pubkey => pubkey.toLowerCase()),
+        );
+        const expiresAt = Date.now() + AUTHOR_VISIBILITY_CACHE_TTL_MS;
+        batch.forEach(pubkey => {
+          this.communityNoteAuthorVisibilityCache.set(pubkey, {
+            visible: !linkedPubkeys.has(pubkey) || visiblePubkeys.has(pubkey),
+            expiresAt,
+          });
+        });
+      }
+    } catch {
+      // Visibility failures are not cached. The next map update can retry.
+    }
+
+    return notes.filter(note => {
+      const authorPubkey = (
+        note.authorPubkey ||
+        note.pubkey ||
+        ''
+      ).toLowerCase();
+      if (!/^[0-9a-f]{64}$/.test(authorPubkey)) return false;
+      const cached = this.communityNoteAuthorVisibilityCache.get(authorPubkey);
+      return cached ? cached.visible : true;
+    });
   }
-
-  return NOSTROOTS_VALIDATION_PUBKEY;
 }
 
-export const nostrService = new NostrService(
-  NOSTR_RELAY_URL,
-  runtimeValidationPubkey(),
-);
+export const nostrService = new NostrService(NOSTR_RELAY_URL);

--- a/modules/search/tests/client/components/CommunityNotesSidebar.tests.js
+++ b/modules/search/tests/client/components/CommunityNotesSidebar.tests.js
@@ -90,12 +90,12 @@ describe('CommunityNotesSidebar', () => {
     expect(screen.getByText('9F2X+3Q')).toBeInTheDocument();
   });
 
-  it('renders notes sorted newest first', () => {
+  it('renders notes with the newest message lowest', () => {
     render(<CommunityNotesSidebar notes={NOTES} plusCode="9F2X+3Q" />);
 
     const contents = screen.getAllByText(/note at this spot/);
-    expect(contents[0]).toHaveTextContent('Newer note at this spot');
-    expect(contents[1]).toHaveTextContent('Older note at this spot');
+    expect(contents[0]).toHaveTextContent('Older note at this spot');
+    expect(contents[1]).toHaveTextContent('Newer note at this spot');
   });
 
   it('resolves author usernames and links to profiles', async () => {

--- a/modules/search/tests/client/components/LeafletSearchMap.component.tests.js
+++ b/modules/search/tests/client/components/LeafletSearchMap.component.tests.js
@@ -312,7 +312,7 @@ describe('<LeafletSearchMap />', () => {
     expect(mockLayerGroups[1].clearLayers).toHaveBeenCalledTimes(1);
   });
 
-  it('uses fallback colours for unknown offers and unverified notes', () => {
+  it('uses fallback colours for unknown offers and Community Notes', () => {
     mockClusterResults.push(
       [point('offer-1', { offer: 'unknown' })],
       [point('note-1', { verified: false })],
@@ -324,7 +324,7 @@ describe('<LeafletSearchMap />', () => {
     });
 
     expect(mockCircleMarkers[0].options.fillColor).toBe('#ccc');
-    expect(mockCircleMarkers[1].options.fillColor).toBe('#1976D2');
+    expect(mockCircleMarkers[1].options.fillColor).toBe('#1565C0');
     expect(() => mockCircleMarkers[0].handlers.click({})).not.toThrow();
   });
 });

--- a/modules/search/tests/client/components/SearchMap.component.tests.js
+++ b/modules/search/tests/client/components/SearchMap.component.tests.js
@@ -107,6 +107,7 @@ let mockSourcePropsById;
 let mockLayerPropsById;
 const mockSource = {
   getClusterExpansionZoom: jest.fn(),
+  getClusterLeaves: jest.fn(),
 };
 let mockSourceInstance = mockSource;
 jest.mock('react-map-gl', () => {
@@ -214,6 +215,7 @@ beforeEach(() => {
   mockSource.getClusterExpansionZoom.mockImplementation((clusterId, done) =>
     done(null, 18),
   );
+  mockSource.getClusterLeaves.mockReset();
   mockSourceInstance = mockSource;
   mockMap.getSource.mockImplementation(() => mockSourceInstance);
   mockGetOffer.mockResolvedValue({ _id: 'offer-1' });
@@ -1244,6 +1246,168 @@ describe('Search', () => {
     expect(mockMapProps.latitude).toBe(52);
     expect(mockMapProps.longitude).toBe(13);
     expect(mockMapProps.zoom).toBe(5);
+  });
+
+  it('opens overlapping Community Notes instead of repeatedly zooming', () => {
+    const onCommunityNoteOpen = jest.fn();
+    const makeLeaf = (id, content, createdAt) => ({
+      properties: {
+        id,
+        content,
+        pubkey: `${id}-author`,
+        authorPubkey: `${id}-author`,
+        created_at: createdAt,
+        kind: 30397,
+        tags: JSON.stringify([['l', '9F350000+', 'open-location-code']]),
+      },
+    });
+    mockSource.getClusterLeaves.mockImplementation(
+      (clusterId, limit, offset, done) => {
+        done(null, [
+          makeLeaf('note-older', 'Older note', 1700000000),
+          makeLeaf('note-newer', 'Newer note', 1700000100),
+        ]);
+      },
+    );
+
+    renderSearchMap({
+      filters: '{"communityNotes":true}',
+      onCommunityNoteOpen,
+    });
+
+    act(() => {
+      mockMapProps.onClick({
+        features: [
+          {
+            geometry: { coordinates: [3.5, 51.5] },
+            layer: { id: 'community-notes-clusters' },
+            properties: { cluster_id: 7, point_count: 2 },
+          },
+        ],
+      });
+    });
+
+    expect(mockSource.getClusterLeaves).toHaveBeenCalledWith(
+      7,
+      2,
+      0,
+      expect.any(Function),
+    );
+    expect(onCommunityNoteOpen).toHaveBeenCalledWith({
+      notes: [
+        expect.objectContaining({ id: 'note-older', content: 'Older note' }),
+        expect.objectContaining({ id: 'note-newer', content: 'Newer note' }),
+      ],
+      plusCode: '9F350000+',
+    });
+    expect(mockMapProps.zoom).toBe(2);
+  });
+
+  it('zooms Community Note clusters whose leaves have different locations', () => {
+    mockSource.getClusterLeaves.mockImplementation(
+      (clusterId, limit, offset, done) => {
+        done(null, [
+          {
+            properties: {
+              tags: JSON.stringify([['l', '9F350000+', 'open-location-code']]),
+            },
+          },
+          {
+            properties: {
+              tags: JSON.stringify([
+                ['l', '8FVC9G8F+5W', 'open-location-code'],
+              ]),
+            },
+          },
+        ]);
+      },
+    );
+
+    renderSearchMap({ filters: '{"communityNotes":true}' });
+
+    act(() => {
+      mockMapProps.onClick({
+        features: [
+          {
+            geometry: { coordinates: [3.5, 51.5] },
+            layer: { id: 'community-notes-clusters' },
+            properties: { cluster_id: 8, point_count: 2 },
+          },
+        ],
+      });
+    });
+
+    expect(mockMapProps.zoom).toBe(5);
+  });
+
+  it('falls back to zooming when cluster leaves cannot be read', () => {
+    mockSource.getClusterLeaves.mockImplementation(
+      (clusterId, limit, offset, done) => done(new Error('source unavailable')),
+    );
+
+    renderSearchMap({ filters: '{"communityNotes":true}' });
+
+    act(() => {
+      mockMapProps.onClick({
+        features: [
+          {
+            geometry: { coordinates: [3.5, 51.5] },
+            layer: { id: 'community-notes-clusters' },
+            properties: { cluster_id: 9, point_count: 2 },
+          },
+        ],
+      });
+    });
+
+    expect(mockMapProps.zoom).toBe(5);
+  });
+
+  it('falls back to zooming when the Community Notes source is unavailable', () => {
+    mockSourceInstance = null;
+    renderSearchMap({ filters: '{"communityNotes":true}' });
+
+    act(() => {
+      mockMapProps.onClick({
+        features: [
+          {
+            geometry: { coordinates: [3.5, 51.5] },
+            layer: { id: 'community-notes-clusters' },
+            properties: { cluster_id: 10, point_count: 2 },
+          },
+        ],
+      });
+    });
+
+    expect(mockMapProps.zoom).toBe(5);
+  });
+
+  it('does not require a note handler for overlapping Community Notes', () => {
+    mockSource.getClusterLeaves.mockImplementation(
+      (clusterId, limit, offset, done) => {
+        done(null, [
+          {
+            properties: {
+              tags: JSON.stringify([['l', '9F350000+', 'open-location-code']]),
+            },
+          },
+        ]);
+      },
+    );
+    renderSearchMap({ filters: '{"communityNotes":true}' });
+
+    expect(() => {
+      act(() => {
+        mockMapProps.onClick({
+          features: [
+            {
+              geometry: { coordinates: [3.5, 51.5] },
+              layer: { id: 'community-notes-clusters' },
+              properties: { cluster_id: 11, point_count: 1 },
+            },
+          ],
+        });
+      });
+    }).not.toThrow();
   });
 
   it('uses the default community-note cluster zoom step when viewport zoom is missing', () => {

--- a/modules/search/tests/client/components/SearchMap.component.tests.js
+++ b/modules/search/tests/client/components/SearchMap.component.tests.js
@@ -18,11 +18,16 @@ const mockGetNostrEventAuthorPubkey = jest.fn(
 );
 const mockSubscribeMapNotes = jest.fn();
 const mockUnsubscribeMapNotes = jest.fn();
+const mockFilterCommunityNotesByAuthorVisibility = jest.fn(notes =>
+  Promise.resolve(notes),
+);
 jest.mock('@/modules/search/client/services/nostr.client.service', () => ({
   getNostrEventAuthorPubkey: event => mockGetNostrEventAuthorPubkey(event),
   nostrService: {
     subscribeMapNotes: (...args) => mockSubscribeMapNotes(...args),
     unsubscribeMapNotes: (...args) => mockUnsubscribeMapNotes(...args),
+    filterCommunityNotesByAuthorVisibility: (...args) =>
+      mockFilterCommunityNotesByAuthorVisibility(...args),
   },
 }));
 
@@ -217,6 +222,9 @@ beforeEach(() => {
     event => event.authorPubkey || event.pubkey,
   );
   mockSubscribeMapNotes.mockResolvedValue({ close: jest.fn() });
+  mockFilterCommunityNotesByAuthorVisibility.mockImplementation(notes =>
+    Promise.resolve(notes),
+  );
   jest.clearAllMocks();
 });
 
@@ -782,10 +790,10 @@ describe('Search', () => {
       onEvent({
         id: 'note-valid',
         content: 'A valid map note',
-        pubkey: 'validation-pubkey',
+        pubkey: 'author-pubkey',
         authorPubkey: 'author-pubkey',
         created_at: 1700000000,
-        kind: 30398,
+        kind: 30397,
         tags: [['l', '8FVC9G8F+5W', 'open-location-code']],
       });
       onEvent({
@@ -803,7 +811,14 @@ describe('Search', () => {
       filters: '{"communityNotes":true}',
     });
 
-    expect(mockSubscribeMapNotes).toHaveBeenCalledWith(expect.any(Function));
+    expect(mockSubscribeMapNotes).toHaveBeenCalledWith(
+      expect.any(Function),
+      undefined,
+      expect.objectContaining({
+        onClose: expect.any(Function),
+        onEose: expect.any(Function),
+      }),
+    );
 
     act(() => {
       jest.advanceTimersByTime(200);
@@ -820,11 +835,190 @@ describe('Search', () => {
         properties: expect.objectContaining({
           authorPubkey: 'author-pubkey',
           content: 'A valid map note',
-          verified: true,
+          kind: 30397,
         }),
       }),
     );
 
+    jest.useRealTimers();
+  });
+
+  it('hides community notes blocked by the Nostr visibility check', async () => {
+    jest.useFakeTimers();
+    mockSubscribeMapNotes.mockImplementationOnce(onEvent => {
+      onEvent({
+        id: 'note-visible',
+        content: 'Visible note',
+        authorPubkey: 'author-visible',
+        tags: [['l', '8FVC9G8F+5W', 'open-location-code']],
+      });
+      onEvent({
+        id: 'note-hidden',
+        content: 'Hidden note',
+        authorPubkey: 'author-hidden',
+        tags: [['l', '8FVC9G8F+5W', 'open-location-code']],
+      });
+      return Promise.resolve();
+    });
+    mockFilterCommunityNotesByAuthorVisibility.mockImplementationOnce(
+      async notes => [notes[0]],
+    );
+
+    renderSearchMap({
+      filters: '{"communityNotes":true}',
+    });
+
+    expect(mockSubscribeMapNotes).toHaveBeenCalledWith(
+      expect.any(Function),
+      undefined,
+      expect.objectContaining({
+        onClose: expect.any(Function),
+        onEose: expect.any(Function),
+      }),
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    await waitFor(() =>
+      expect(mockSourcePropsById['community-notes'].data.features).toHaveLength(
+        1,
+      ),
+    );
+    expect(
+      mockSourcePropsById['community-notes'].data.features[0].properties
+        .content,
+    ).toBe('Visible note');
+    expect(mockSourcePropsById['community-notes'].data.features[0].id).toBe(
+      'note-visible',
+    );
+    expect(mockFilterCommunityNotesByAuthorVisibility).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'note-visible' }),
+        expect.objectContaining({ id: 'note-hidden' }),
+      ]),
+    );
+
+    jest.useRealTimers();
+  });
+
+  it('reconnects after an interrupted relay load and deduplicates replayed notes', async () => {
+    jest.useFakeTimers();
+    let firstCallbacks;
+    let secondCallbacks;
+    mockSubscribeMapNotes
+      .mockImplementationOnce((onEvent, limit, callbacks) => {
+        firstCallbacks = callbacks;
+        onEvent({
+          id: 'note-first',
+          authorPubkey: 'author-first',
+          tags: [['l', '8FVC9G8F+5W', 'open-location-code']],
+        });
+        return Promise.resolve();
+      })
+      .mockImplementationOnce((onEvent, limit, callbacks) => {
+        secondCallbacks = callbacks;
+        onEvent({
+          id: 'note-first',
+          authorPubkey: 'author-first',
+          tags: [['l', '8FVC9G8F+5W', 'open-location-code']],
+        });
+        onEvent({
+          id: 'note-second',
+          authorPubkey: 'author-second',
+          tags: [['l', '7FG49Q00+', 'open-location-code']],
+        });
+        return Promise.resolve();
+      });
+
+    const { unmount } = renderSearchMap({
+      filters: '{"communityNotes":true}',
+    });
+    await waitFor(() => expect(firstCallbacks).toBeDefined());
+
+    act(() => {
+      firstCallbacks.onClose();
+      firstCallbacks.onClose();
+      jest.advanceTimersByTime(1000);
+    });
+    await waitFor(() => expect(secondCallbacks).toBeDefined());
+
+    act(() => {
+      secondCallbacks.onEose();
+    });
+    await waitFor(() =>
+      expect(mockSourcePropsById['community-notes'].data.features).toHaveLength(
+        2,
+      ),
+    );
+
+    unmount();
+    act(() => {
+      secondCallbacks.onClose();
+      jest.advanceTimersByTime(1000);
+    });
+    expect(mockSubscribeMapNotes).toHaveBeenCalledTimes(2);
+    jest.useRealTimers();
+  });
+
+  it('does not replace newer community notes with a stale visibility result', async () => {
+    jest.useFakeTimers();
+    let onEvent;
+    let resolveFirstVisibilityCheck;
+    const firstVisibilityCheck = new Promise(resolve => {
+      resolveFirstVisibilityCheck = resolve;
+    });
+    mockSubscribeMapNotes.mockImplementationOnce(callback => {
+      onEvent = callback;
+      onEvent({
+        id: 'note-first',
+        content: 'First note',
+        authorPubkey: 'author-first',
+        tags: [['l', '8FVC9G8F+5W', 'open-location-code']],
+      });
+      return Promise.resolve();
+    });
+    mockFilterCommunityNotesByAuthorVisibility
+      .mockImplementationOnce(() => firstVisibilityCheck)
+      .mockImplementationOnce(notes => Promise.resolve(notes));
+
+    renderSearchMap({ filters: '{"communityNotes":true}' });
+
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    onEvent({
+      id: 'note-second',
+      content: 'Second note',
+      authorPubkey: 'author-second',
+      tags: [['l', '8FVC9G8F+5W', 'open-location-code']],
+    });
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    await waitFor(() =>
+      expect(mockSourcePropsById['community-notes'].data.features).toHaveLength(
+        2,
+      ),
+    );
+
+    await act(async () => {
+      resolveFirstVisibilityCheck([
+        {
+          id: 'note-first',
+          content: 'First note',
+          authorPubkey: 'author-first',
+          tags: [['l', '8FVC9G8F+5W', 'open-location-code']],
+        },
+      ]);
+    });
+
+    expect(mockSourcePropsById['community-notes'].data.features).toHaveLength(
+      2,
+    );
     jest.useRealTimers();
   });
 
@@ -1070,23 +1264,25 @@ describe('Search', () => {
     expect(mockMapProps.zoom).toBe(2);
   });
 
-  it('clears community notes when the subscription fails and unsubscribes on unmount', async () => {
+  it('retries failed subscriptions and unsubscribes on unmount', async () => {
+    jest.useFakeTimers();
     mockSubscribeMapNotes.mockRejectedValueOnce(new Error('relay unavailable'));
 
     const { unmount } = renderSearchMap({
       filters: '{"communityNotes":true}',
     });
 
-    await waitFor(() =>
-      expect(mockSourcePropsById['community-notes'].data).toEqual({
-        features: [],
-        type: 'FeatureCollection',
-      }),
-    );
+    await waitFor(() => expect(mockSubscribeMapNotes).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    await waitFor(() => expect(mockSubscribeMapNotes).toHaveBeenCalledTimes(2));
 
     unmount();
 
     expect(mockUnsubscribeMapNotes).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
   });
 
   it('logs offer query failures in development without replacing current offers', async () => {

--- a/modules/search/tests/client/components/SearchMap.component.tests.js
+++ b/modules/search/tests/client/components/SearchMap.component.tests.js
@@ -104,6 +104,7 @@ let mockMapInstance = mockMap;
 let mockMapProps;
 let mockSourceProps;
 let mockSourcePropsById;
+let mockLayerPropsById;
 const mockSource = {
   getClusterExpansionZoom: jest.fn(),
 };
@@ -150,6 +151,7 @@ jest.mock('react-map-gl', () => {
   };
 
   function Layer(props) {
+    mockLayerPropsById[props.id] = props;
     return React.createElement('div', {
       'data-testid': `map-layer-${props.id}`,
     });
@@ -190,6 +192,7 @@ beforeEach(() => {
   mockIsWebGLSupported.mockReturnValue(true);
   mockLeafletSearchMap.mockClear();
   mockSourcePropsById = {};
+  mockLayerPropsById = {};
   mockPersistentMapLocation = {
     latitude: 48.6908333333,
     longitude: 9.14055555556,
@@ -349,6 +352,27 @@ describe('Search', () => {
       'clusters',
       'unclustered-point',
     ]);
+  });
+
+  it('ignores missing-layer errors caused by map style teardown', () => {
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    renderSearchMap();
+
+    mockMapProps.onError({
+      error: new Error(
+        "The layer 'clusters' does not exist in the map's style and cannot be queried for features.",
+      ),
+    });
+    expect(consoleError).not.toHaveBeenCalled();
+
+    const otherError = new Error('Map source failed');
+    mockMapProps.onError({ error: otherError });
+    expect(consoleError).toHaveBeenCalledWith(otherError);
+    mockMapProps.onError({});
+    expect(consoleError).toHaveBeenCalledWith({});
+    consoleError.mockRestore();
   });
 
   it('falls back to OSM when a mapbox style is persisted without a token', () => {
@@ -1312,10 +1336,16 @@ describe('Search', () => {
   });
 
   it('uses the OSM cluster count layer when the persisted map style is OSM', () => {
-    mockMapStyle = MAP_STYLE_OSM;
+    mockMapStyle = JSON.parse(JSON.stringify(MAP_STYLE_OSM));
 
-    renderSearchMap();
+    renderSearchMap({ filters: '{"communityNotes":true}' });
 
-    expect(mockMapProps.mapStyle).toBe(MAP_STYLE_OSM);
+    expect(mockMapProps.mapStyle).toEqual(MAP_STYLE_OSM);
+    expect(mockLayerPropsById['cluster-count'].layout['text-font']).toEqual([
+      'Open Sans Bold',
+    ]);
+    expect(
+      mockLayerPropsById['community-notes-cluster-count'].layout['text-font'],
+    ).toEqual(['Open Sans Semibold']);
   });
 });

--- a/modules/search/tests/client/services/nostr.client.service.tests.js
+++ b/modules/search/tests/client/services/nostr.client.service.tests.js
@@ -30,17 +30,7 @@ describe('NostrService', () => {
   });
 
   describe('getNostrEventAuthorPubkey()', () => {
-    it('returns the original author from kind 30398 reposts', () => {
-      expect(
-        getNostrEventAuthorPubkey({
-          kind: 30398,
-          pubkey: 'validation-server-pubkey',
-          tags: [['p', 'original-author-pubkey']],
-        }),
-      ).toBe('original-author-pubkey');
-    });
-
-    it('falls back to event pubkey for direct events', () => {
+    it('returns the event author', () => {
       expect(
         getNostrEventAuthorPubkey({
           kind: 30397,
@@ -48,16 +38,6 @@ describe('NostrService', () => {
           tags: [],
         }),
       ).toBe('direct-author-pubkey');
-    });
-
-    it('falls back to event pubkey for validated events without author tags', () => {
-      expect(
-        getNostrEventAuthorPubkey({
-          kind: 30398,
-          pubkey: 'validation-server-pubkey',
-          tags: [['p']],
-        }),
-      ).toBe('validation-server-pubkey');
     });
 
     it('returns undefined when event data is missing', () => {
@@ -82,12 +62,6 @@ describe('NostrService', () => {
     it('initializes empty username cache', () => {
       expect(service.usernameCache).toBeInstanceOf(Map);
       expect(service.usernameCache.size).toBe(0);
-    });
-
-    it('accepts an explicit validation pubkey', () => {
-      const configured = new NostrService(RELAY_URL, 'fixture-validator');
-
-      expect(configured.validationPubkey).toBe('fixture-validator');
     });
   });
 
@@ -191,27 +165,7 @@ describe('NostrService', () => {
   });
 
   describe('subscribeMapNotes()', () => {
-    it('uses an explicitly configured validation pubkey', async () => {
-      service = new NostrService(RELAY_URL, 'fixture-validator');
-      const mockSub = { close: jest.fn() };
-      await service.connect();
-      Relay._lastInstance.subscribe.mockReturnValue(mockSub);
-
-      await service.subscribeMapNotes(jest.fn());
-
-      expect(Relay._lastInstance.subscribe).toHaveBeenCalledWith(
-        [
-          {
-            kinds: [30398],
-            authors: ['fixture-validator'],
-            limit: 500,
-          },
-        ],
-        expect.any(Object),
-      );
-    });
-
-    it('subscribes with correct filters for verified notes', async () => {
+    it('subscribes with correct filters for original notes', async () => {
       const mockSub = { close: jest.fn() };
       await service.connect();
       Relay._lastInstance.subscribe.mockReturnValue(mockSub);
@@ -223,10 +177,7 @@ describe('NostrService', () => {
       expect(Relay._lastInstance.subscribe).toHaveBeenCalledWith(
         [
           {
-            kinds: [30398],
-            authors: [
-              'f5bc71692fc08ea52c0d1c8bcfb87579584106b5feb4ea542b1b8a95612f257b',
-            ],
+            kinds: [30397],
             limit: 500,
           },
         ],
@@ -250,6 +201,23 @@ describe('NostrService', () => {
       await expect(service.subscribeMapNotes(jest.fn())).resolves.toBe(mockSub);
     });
 
+    it('forwards map subscription lifecycle callbacks', async () => {
+      const mockSub = { close: jest.fn() };
+      const onClose = jest.fn();
+      const onEose = jest.fn();
+      await service.connect();
+      Relay._lastInstance.subscribe.mockImplementation((filters, callbacks) => {
+        callbacks.oneose();
+        callbacks.onclose('relay connection closed');
+        return mockSub;
+      });
+
+      await service.subscribeMapNotes(jest.fn(), 25, { onClose, onEose });
+
+      expect(onEose).toHaveBeenCalledTimes(1);
+      expect(onClose).toHaveBeenCalledWith('relay connection closed');
+    });
+
     it('allows callers to override the historical map note limit', async () => {
       const mockSub = { close: jest.fn() };
       await service.connect();
@@ -260,10 +228,7 @@ describe('NostrService', () => {
       expect(Relay._lastInstance.subscribe).toHaveBeenCalledWith(
         [
           {
-            kinds: [30398],
-            authors: [
-              'f5bc71692fc08ea52c0d1c8bcfb87579584106b5feb4ea542b1b8a95612f257b',
-            ],
+            kinds: [30397],
             limit: 25,
           },
         ],
@@ -307,54 +272,6 @@ describe('NostrService', () => {
   });
 
   describe('fetchUserNotes()', () => {
-    it('handles validated events without tags', async () => {
-      await service.connect();
-      const relay = Relay._lastInstance;
-      const validatedNote = {
-        id: 'validated-note',
-        kind: 30398,
-        created_at: 101,
-      };
-
-      relay.subscribe.mockImplementation((filters, callbacks) => {
-        callbacks.onevent(validatedNote);
-        callbacks.oneose();
-        return { close: jest.fn() };
-      });
-
-      await expect(service.fetchUserNotes('aabbcc')).resolves.toEqual([
-        validatedNote,
-      ]);
-    });
-
-    it('keeps the validated copy when it references an original note', async () => {
-      await service.connect();
-      const relay = Relay._lastInstance;
-      const originalNote = {
-        id: 'original-note',
-        kind: 30397,
-        created_at: 100,
-        tags: [],
-      };
-      const validatedNote = {
-        id: 'validated-note',
-        kind: 30398,
-        created_at: 101,
-        tags: [['e', originalNote.id]],
-      };
-
-      relay.subscribe.mockImplementation((filters, callbacks) => {
-        callbacks.onevent(originalNote);
-        callbacks.onevent(validatedNote);
-        callbacks.oneose();
-        return { close: jest.fn() };
-      });
-
-      await expect(service.fetchUserNotes('aabbcc')).resolves.toEqual([
-        validatedNote,
-      ]);
-    });
-
     it('resolves with events sorted by created_at desc', async () => {
       await service.connect();
       const relay = Relay._lastInstance;
@@ -379,17 +296,7 @@ describe('NostrService', () => {
       expect(sub.close).toHaveBeenCalled();
 
       expect(relay.subscribe).toHaveBeenCalledWith(
-        [
-          { kinds: [30397], authors: ['aabbcc'], limit: 3 },
-          {
-            kinds: [30398],
-            authors: [
-              'f5bc71692fc08ea52c0d1c8bcfb87579584106b5feb4ea542b1b8a95612f257b',
-            ],
-            '#p': ['aabbcc'],
-            limit: 3,
-          },
-        ],
+        [{ kinds: [30397], authors: ['aabbcc'], limit: 3 }],
         expect.objectContaining({
           onevent: expect.any(Function),
           oneose: expect.any(Function),
@@ -415,17 +322,7 @@ describe('NostrService', () => {
       await service.fetchUserNotes('aabbcc');
 
       expect(relay.subscribe).toHaveBeenCalledWith(
-        [
-          { kinds: [30397], authors: ['aabbcc'], limit: 3 },
-          {
-            kinds: [30398],
-            authors: [
-              'f5bc71692fc08ea52c0d1c8bcfb87579584106b5feb4ea542b1b8a95612f257b',
-            ],
-            '#p': ['aabbcc'],
-            limit: 3,
-          },
-        ],
+        [{ kinds: [30397], authors: ['aabbcc'], limit: 3 }],
         expect.any(Object),
       );
     });
@@ -594,6 +491,115 @@ describe('NostrService', () => {
       await Promise.resolve();
 
       expect(sub.close).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('filterCommunityNotesByAuthorVisibility()', () => {
+    const originalFetch = global.fetch;
+
+    beforeEach(() => {
+      global.fetch = jest.fn();
+    });
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it('keeps eligible and unlinked authors but hides known ineligible authors', async () => {
+      const visiblePubkey = 'aa'.repeat(32);
+      const hiddenPubkey = 'bb'.repeat(32);
+      const unlinkedPubkey = 'cc'.repeat(32);
+      global.fetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            linkedPubkeys: [visiblePubkey, hiddenPubkey],
+            pubkeys: [visiblePubkey],
+          }),
+      });
+
+      await expect(
+        service.filterCommunityNotesByAuthorVisibility([
+          { id: 'visible', authorPubkey: visiblePubkey },
+          { id: 'visible-by-pubkey', pubkey: visiblePubkey },
+          { id: 'hidden', authorPubkey: hiddenPubkey },
+          { id: 'unlinked', authorPubkey: unlinkedPubkey },
+          { id: 'missing-author' },
+        ]),
+      ).resolves.toEqual([
+        { id: 'visible', authorPubkey: visiblePubkey },
+        { id: 'visible-by-pubkey', pubkey: visiblePubkey },
+        { id: 'unlinked', authorPubkey: unlinkedPubkey },
+      ]);
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/nostr/author-visibility?pubkey=' +
+          visiblePubkey +
+          '&pubkey=' +
+          hiddenPubkey +
+          '&pubkey=' +
+          unlinkedPubkey,
+      );
+    });
+
+    it('retries visibility checks after a transient API failure', async () => {
+      const pubkey = 'aa'.repeat(32);
+      const notes = [{ id: 'note', authorPubkey: pubkey }];
+      global.fetch.mockRejectedValueOnce(new Error('service unavailable'));
+      await expect(
+        service.filterCommunityNotesByAuthorVisibility(notes),
+      ).resolves.toEqual(notes);
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ linkedPubkeys: [pubkey], pubkeys: [] }),
+      });
+
+      await expect(
+        service.filterCommunityNotesByAuthorVisibility(notes),
+      ).resolves.toEqual([]);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('batches uncached authors and reuses fresh visibility results', async () => {
+      const notes = Array.from({ length: 101 }, (_, index) => ({
+        id: `note-${index}`,
+        authorPubkey: index.toString(16).padStart(64, '0'),
+      }));
+      global.fetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            linkedPubkeys: notes.map(note => note.authorPubkey),
+            pubkeys: [],
+          }),
+      });
+
+      await expect(
+        service.filterCommunityNotesByAuthorVisibility(notes),
+      ).resolves.toEqual([]);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+
+      await expect(
+        service.filterCommunityNotesByAuthorVisibility([notes[0]]),
+      ).resolves.toEqual([]);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('keeps notes visible when the API response is unsuccessful or invalid', async () => {
+      const pubkey = 'cc'.repeat(32);
+      const notes = [{ id: 'note', authorPubkey: pubkey }];
+      global.fetch.mockResolvedValueOnce({ ok: false });
+
+      await expect(
+        service.filterCommunityNotesByAuthorVisibility(notes),
+      ).resolves.toEqual(notes);
+
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ linkedPubkeys: [], pubkeys: null }),
+      });
+      await expect(
+        service.filterCommunityNotesByAuthorVisibility(notes),
+      ).resolves.toEqual(notes);
     });
   });
 });

--- a/modules/users/client/controllers/profile-edit-photo.client.controller.js
+++ b/modules/users/client/controllers/profile-edit-photo.client.controller.js
@@ -81,19 +81,22 @@ function ProfileEditPhotoController(
           updateUserProfile();
         })
         .error(function (data, status) {
+          const responseStatus = Number.isInteger(status)
+            ? status
+            : Number(data && data.status);
           // Default error
           let saveAvatarErr = 'Oops! Something went wrong. Try again later.';
 
-          if (status === 422) {
+          if (responseStatus === 422) {
             // Could not process file
             saveAvatarErr = 'Sorry, we could not process this file.';
-          } else if (status === 413) {
+          } else if (responseStatus === 413) {
             // File too large
             saveAvatarErr =
               'Whoops, your file is too big. Please keep it up to ' +
               bytesToSize(appSettings.maxUploadSize) +
               '.';
-          } else if (status === 415) {
+          } else if (responseStatus === 415) {
             // Unsupported media type
             saveAvatarErr = 'Sorry, we do not support this type of file.';
           }

--- a/modules/users/tests/client/profile-edit-photo.client.controller.tests.js
+++ b/modules/users/tests/client/profile-edit-photo.client.controller.tests.js
@@ -288,6 +288,32 @@ describe('ProfileEditPhotoController', function () {
     );
   });
 
+  it('uses the payload status when the upload error callback omits the HTTP status', function () {
+    selectValidImage();
+
+    uploadErrorCallback({ status: 415 }, null);
+
+    expect(ProfileEditPhotoController.avatarUploading).toBe(false);
+    expect(ProfileEditPhotoController.avatarPreview).toBe(false);
+    expect(messageCenterService.add).toHaveBeenCalledWith(
+      'danger',
+      'Sorry, we do not support this type of file.',
+    );
+  });
+
+  it('falls back to a generic error when neither callback arg has a numeric status', function () {
+    selectValidImage();
+
+    uploadErrorCallback(null, 'invalid');
+
+    expect(ProfileEditPhotoController.avatarUploading).toBe(false);
+    expect(ProfileEditPhotoController.avatarPreview).toBe(false);
+    expect(messageCenterService.add).toHaveBeenCalledWith(
+      'danger',
+      'Oops! Something went wrong. Try again later.',
+    );
+  });
+
   it('shows the generic avatar upload error for unknown upload failures', function () {
     selectValidImage();
 

--- a/modules/users/tests/server/services/historical-spam-cleanup.server.service.tests.js
+++ b/modules/users/tests/server/services/historical-spam-cleanup.server.service.tests.js
@@ -1,5 +1,6 @@
 const mongoose = require('mongoose');
 const should = require('should');
+const sinon = require('sinon');
 
 const cleanup = require('../../../server/services/historical-spam-cleanup.server.service');
 
@@ -66,7 +67,60 @@ describe('Service: historical spam cleanup', () => {
     sequence = 0;
   });
 
-  afterEach(removeCreatedData);
+  afterEach(async () => {
+    sinon.restore();
+    await removeCreatedData();
+  });
+
+  it('uses safe defaults when there are no campaign accounts', async () => {
+    const result = await cleanup.run();
+
+    result.should.deepEqual({
+      candidates: 0,
+      eligible: 0,
+      protected: 0,
+      deleted: 0,
+    });
+  });
+
+  it('retains an account protected immediately before deletion', async () => {
+    const candidate = await createCandidate();
+    const query = result => ({
+      select() {
+        return this;
+      },
+      lean() {
+        return Promise.resolve(result);
+      },
+    });
+    const find = sinon.stub(AdminNote, 'find');
+    find.onFirstCall().returns(query([]));
+    find.onSecondCall().returns(query([{ user: candidate._id }]));
+
+    const result = await cleanup.run({ deleteAccounts: true });
+
+    result.should.deepEqual({
+      candidates: 1,
+      eligible: 0,
+      protected: 1,
+      deleted: 0,
+    });
+    should.exist(await User.findById(candidate._id));
+  });
+
+  it('supports legacy and empty deletion results', async () => {
+    await createCandidate();
+    const deleteMany = sinon.stub(User, 'deleteMany');
+    deleteMany.onFirstCall().resolves({ n: 1 });
+    deleteMany.onSecondCall().resolves({});
+
+    const legacyResult = await cleanup.run({ deleteAccounts: true });
+    const emptyResult = await cleanup.run({ deleteAccounts: true });
+    deleteMany.restore();
+
+    legacyResult.deleted.should.equal(1);
+    emptyResult.deleted.should.equal(0);
+  });
 
   it('dry-runs eligible campaign accounts and retains protected accounts', async () => {
     const eligible = await createCandidate();

--- a/openspec/changes/archive/2026-07-17-add-nostr-author-visibility-api/proposal.md
+++ b/openspec/changes/archive/2026-07-17-add-nostr-author-visibility-api/proposal.md
@@ -1,0 +1,32 @@
+# Add Nostr author visibility API
+
+## Why
+
+Community-note clients need to exclude notes from shadowbanned authors without
+performing one relay and NIP-05 lookup per author. The existing NIP-05 lookup
+only works in the username-to-public-key direction and cannot efficiently
+check a set of note authors.
+
+## What Changes
+
+- Add a public batch API that accepts one or more Nostr public-key hex values.
+- Return only keys associated with eligible public Trustroots members.
+- Use the API when filtering community-note authors on the search map.
+
+## Capabilities
+
+### New Capabilities
+
+- `nostr-author-visibility`: Determine which Nostr public keys may have their
+  community notes displayed publicly.
+
+### Modified Capabilities
+
+- `nostr-integration`: Community-note discovery excludes notes from
+  shadowbanned and otherwise non-public authors.
+
+## Impact
+
+- Adds a public read-only API route in the core module.
+- Changes the Nostr client service and search-map note filtering.
+- Adds server and client regression coverage.

--- a/openspec/changes/archive/2026-07-17-add-nostr-author-visibility-api/specs/nostr-author-visibility/spec.md
+++ b/openspec/changes/archive/2026-07-17-add-nostr-author-visibility-api/specs/nostr-author-visibility/spec.md
@@ -1,0 +1,32 @@
+# Nostr Author Visibility Specification
+
+## Purpose
+
+Allow community-note clients to determine whether a set of Nostr authors is
+eligible for public display without revealing moderation state.
+
+## ADDED Requirements
+
+### Requirement: Batch author visibility lookup
+
+The system SHALL provide a public read-only endpoint that accepts one or more
+valid Nostr public-key hex values and returns only the keys associated with
+eligible public Trustroots members.
+
+#### Scenario: Lookup includes eligible and ineligible authors
+
+- **WHEN** a client requests visibility for public, shadowbanned, and unknown
+  Nostr public keys
+- **THEN** the response includes the public member's key
+- **AND** excludes the shadowbanned and unknown keys
+
+#### Scenario: Lookup contains multiple valid keys
+
+- **WHEN** a client submits multiple valid Nostr public keys within the batch
+  limit
+- **THEN** the response evaluates all submitted keys in one request
+
+#### Scenario: Lookup contains no valid keys
+
+- **WHEN** a client submits an invalid key or exceeds the batch limit
+- **THEN** the endpoint rejects the request with a validation error

--- a/openspec/changes/archive/2026-07-17-add-nostr-author-visibility-api/specs/nostr-integration/spec.md
+++ b/openspec/changes/archive/2026-07-17-add-nostr-author-visibility-api/specs/nostr-integration/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: Community-note discovery
+
+The system SHALL let signed-in members enable a persistent Community Notes
+filter on the search map and read the associated Nostroots thread for a
+selected location. The map SHALL exclude notes authored by members who are not
+eligible for public display.
+
+#### Scenario: Member enables Community Notes
+
+- **WHEN** a signed-in member enables the Community Notes search filter
+- **THEN** the map displays available community-note locations from eligible
+  authors
+- **AND** excludes notes from shadowbanned, suspended, private, and unknown
+  authors
+- **AND** the filter remains enabled after the member reloads the page
+
+#### Scenario: Member selects a community-note location
+
+- **WHEN** a member selects a community-note location
+- **THEN** the system displays the location's note thread and available author
+  information
+- **AND** a reply action opens the Nostroots action options

--- a/openspec/changes/archive/2026-07-17-add-nostr-author-visibility-api/tasks.md
+++ b/openspec/changes/archive/2026-07-17-add-nostr-author-visibility-api/tasks.md
@@ -1,0 +1,16 @@
+## 1. Public visibility API
+
+- [x] 1.1 Add and validate a bounded batch public-key query route
+- [x] 1.2 Return only keys belonging to eligible public members
+- [x] 1.3 Add route coverage for visible, shadowbanned, invalid, and multiple keys
+
+## 2. Community-note filtering
+
+- [x] 2.1 Replace per-author relay and NIP-05 lookups with the batch API
+- [x] 2.2 Preserve retryable behaviour for transient API failures
+- [x] 2.3 Add client regression coverage for batch filtering and stale updates
+
+## 3. Verification
+
+- [ ] 3.1 Run targeted server and client tests
+- [ ] 3.2 Validate the OpenSpec change

--- a/openspec/changes/archive/2026-07-18-improve-admin-acquisition-stories/proposal.md
+++ b/openspec/changes/archive/2026-07-18-improve-admin-acquisition-stories/proposal.md
@@ -1,0 +1,20 @@
+# Improve admin acquisition stories
+
+## Why
+
+The acquisition-stories table provides the submitted text and basic member
+identity, but administrators cannot quickly recognise the member, open their
+public profile, compare circle participation, or reorder the rows while
+reviewing the data.
+
+## What Changes
+
+- Show each member's profile picture linked to their public profile.
+- Keep the existing administration report link for the member name.
+- Include the number of circles each member has joined.
+- Let administrators sort the table by date, member, circle count, or story.
+
+## Affected Modules
+
+- `modules/admin` (acquisition-story response, table, styles, and tests)
+- `tests/e2e` (administration acquisition-story flow)

--- a/openspec/changes/archive/2026-07-18-improve-admin-acquisition-stories/specs/admin-moderation/spec.md
+++ b/openspec/changes/archive/2026-07-18-improve-admin-acquisition-stories/specs/admin-moderation/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: Administration operational views
+
+The system SHALL provide authorised administrators with administration views
+for audit history, newsletter subscribers, acquisition stories, and acquisition
+analysis. The acquisition-stories view SHALL identify members with profile
+pictures and public-profile links, show their circle participation, and allow
+the available columns to be sorted.
+
+#### Scenario: Administrator opens acquisition stories
+
+- **WHEN** an authorised administrator opens the acquisition-stories view
+- **THEN** each story identifies its member with a profile picture and public-profile link
+- **AND** shows the number of circles that member has joined
+- **AND** the administrator can sort the rows by date, member, circle count, or story
+
+#### Scenario: Administrator opens an available operational view
+
+- **WHEN** an authorised administrator opens an available operational view
+- **THEN** the requested view displays its available data
+
+#### Scenario: Administrator requests unavailable newsletter subscriber data
+
+- **WHEN** an authorised administrator requests newsletter subscriber data while the subscriber API is unavailable
+- **THEN** the system fails safely without exposing subscriber data

--- a/openspec/changes/archive/2026-07-18-improve-admin-acquisition-stories/tasks.md
+++ b/openspec/changes/archive/2026-07-18-improve-admin-acquisition-stories/tasks.md
@@ -1,0 +1,16 @@
+## 1. Acquisition-story data
+
+- [x] 1.1 Include each member's circle count in the administration response
+- [x] 1.2 Keep the response limited to fields needed by the table and analysis
+
+## 2. Acquisition-story table
+
+- [x] 2.1 Show profile pictures linked to public member profiles
+- [x] 2.2 Display the number of circles joined
+- [x] 2.3 Add accessible sorting for every data column
+
+## 3. Verification
+
+- [x] 3.1 Add server and client regression coverage
+- [x] 3.2 Extend end-to-end coverage for the richer table
+- [x] 3.3 Validate and archive the OpenSpec change

--- a/openspec/changes/archive/2026-07-18-preserve-unlinked-community-notes/proposal.md
+++ b/openspec/changes/archive/2026-07-18-preserve-unlinked-community-notes/proposal.md
@@ -1,0 +1,27 @@
+# Preserve unlinked Community Notes
+
+## Why
+
+Trustroots currently consumes validation-server copies of Community Notes.
+Those copies record a decision made at one point in time, so a later suspension
+or shadowban makes the validation decision stale and would otherwise require
+the validation server to retract or replace an event. The author-visibility
+filter also treats every Nostr key that is not
+linked to an eligible public Trustroots account as hidden, which removes valid
+Nostroots content from unlinked authors.
+
+## What Changes
+
+- Consume original kind `30397` Community Notes everywhere instead of kind
+  `30398` validation-server copies, including map and profile queries.
+- Distinguish author keys linked to Trustroots accounts from unknown keys.
+- Continue hiding notes from known shadowbanned, suspended, or private members.
+- Preserve notes from valid but unlinked Nostr authors.
+- Continue rejecting malformed author keys and fail open on transient API
+  failures for valid keys.
+
+## Affected Modules
+
+- `modules/core` (author-visibility response)
+- `modules/search` (Community Note filtering and tests)
+- `tests/e2e` (original-event map fixture)

--- a/openspec/changes/archive/2026-07-18-preserve-unlinked-community-notes/specs/nostr-author-visibility/spec.md
+++ b/openspec/changes/archive/2026-07-18-preserve-unlinked-community-notes/specs/nostr-author-visibility/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: Batch author visibility lookup
+
+The system SHALL provide a public read-only endpoint that accepts one or more
+valid Nostr public-key hex values and identifies which keys are linked to
+Trustroots members and which linked keys are eligible for public display. The
+response SHALL NOT disclose why a linked key is ineligible.
+
+#### Scenario: Lookup includes eligible and ineligible authors
+
+- **WHEN** a client requests visibility for public, shadowbanned, and unknown Nostr public keys
+- **THEN** the response identifies the public and shadowbanned keys as linked
+- **AND** includes only the public member's key as eligible
+- **AND** does not disclose why the shadowbanned key is ineligible
+
+#### Scenario: Lookup contains multiple valid keys
+
+- **WHEN** a client submits multiple valid Nostr public keys within the batch limit
+- **THEN** the response evaluates all submitted keys in one request
+
+#### Scenario: Lookup contains no valid keys
+
+- **WHEN** a client submits an invalid key or exceeds the batch limit
+- **THEN** the endpoint rejects the request with a validation error

--- a/openspec/changes/archive/2026-07-18-preserve-unlinked-community-notes/specs/nostr-integration/spec.md
+++ b/openspec/changes/archive/2026-07-18-preserve-unlinked-community-notes/specs/nostr-integration/spec.md
@@ -1,0 +1,40 @@
+## MODIFIED Requirements
+
+### Requirement: Community-note discovery
+
+The system SHALL let signed-in members enable a persistent Community Notes
+filter on the search map and read the associated Nostroots thread for a
+selected location. The map SHALL fetch only original kind `30397` events and
+SHALL NOT fetch kind `30398` validation-server events, so that current
+Trustroots account visibility can be applied without depending on a stale
+validation decision. It SHALL exclude notes authored by known Trustroots
+members who are not eligible for public display while preserving notes from
+valid Nostr authors who are not linked to a Trustroots account.
+
+#### Scenario: Member enables Community Notes
+
+- **WHEN** a signed-in member enables the Community Notes search filter
+- **THEN** the map displays available original community-note locations from eligible and unlinked authors
+- **AND** excludes notes from known shadowbanned, suspended, or private authors
+- **AND** excludes notes with malformed author keys
+- **AND** does not require validation-server copies of the original notes
+- **AND** the filter remains enabled after the member reloads the page
+
+#### Scenario: Member selects a community-note location
+
+- **WHEN** a member selects a community-note location
+- **THEN** the system displays the location's note thread and available author information
+- **AND** a reply action opens the Nostroots action options
+
+### Requirement: Profile community notes
+
+The system SHALL show a Nostroots badge and recent original community notes on
+a member profile when notes are available for that member's Nostr identity. It
+SHALL fetch only kind `30397` events and SHALL NOT fetch kind `30398`
+validation-server events.
+
+#### Scenario: Member with community notes has their profile viewed
+
+- **WHEN** a visitor views community notes associated with a member profile
+- **THEN** the system fetches and displays only original kind `30397` events
+- **AND** does not fetch kind `30398` validation-server copies

--- a/openspec/changes/archive/2026-07-18-preserve-unlinked-community-notes/tasks.md
+++ b/openspec/changes/archive/2026-07-18-preserve-unlinked-community-notes/tasks.md
@@ -1,0 +1,17 @@
+## 1. Author visibility
+
+- [x] 1.1 Return which requested keys are linked to Trustroots accounts
+- [x] 1.2 Keep eligibility reasons private
+
+## 2. Community Notes
+
+- [x] 2.1 Subscribe the map to original kind `30397` notes
+- [x] 2.2 Fetch only original kind `30397` notes for profiles
+- [x] 2.3 Preserve notes from valid unlinked authors
+- [x] 2.4 Continue hiding notes from known ineligible authors
+- [x] 2.5 Reject malformed author keys and retain transient-failure behaviour
+
+## 3. Verification
+
+- [x] 3.1 Add server and client regression coverage
+- [x] 3.2 Validate and archive the OpenSpec change

--- a/openspec/specs/admin-moderation/spec.md
+++ b/openspec/specs/admin-moderation/spec.md
@@ -137,7 +137,16 @@ between related members and activity.
 
 The system SHALL provide authorised administrators with administration views
 for audit history, newsletter subscribers, acquisition stories, and acquisition
-analysis.
+analysis. The acquisition-stories view SHALL identify members with profile
+pictures and public-profile links, show their circle participation, and allow
+the available columns to be sorted.
+
+#### Scenario: Administrator opens acquisition stories
+
+- **WHEN** an authorised administrator opens the acquisition-stories view
+- **THEN** each story identifies its member with a profile picture and public-profile link
+- **AND** shows the number of circles that member has joined
+- **AND** the administrator can sort the rows by date, member, circle count, or story
 
 #### Scenario: Administrator opens an available operational view
 

--- a/openspec/specs/nostr-author-visibility/spec.md
+++ b/openspec/specs/nostr-author-visibility/spec.md
@@ -1,0 +1,31 @@
+# nostr-author-visibility Specification
+
+## Purpose
+
+TBD - created by archiving change add-nostr-author-visibility-api. Update Purpose after archive.
+
+## Requirements
+
+### Requirement: Batch author visibility lookup
+
+The system SHALL provide a public read-only endpoint that accepts one or more
+valid Nostr public-key hex values and identifies which keys are linked to
+Trustroots members and which linked keys are eligible for public display. The
+response SHALL NOT disclose why a linked key is ineligible.
+
+#### Scenario: Lookup includes eligible and ineligible authors
+
+- **WHEN** a client requests visibility for public, shadowbanned, and unknown Nostr public keys
+- **THEN** the response identifies the public and shadowbanned keys as linked
+- **AND** includes only the public member's key as eligible
+- **AND** does not disclose why the shadowbanned key is ineligible
+
+#### Scenario: Lookup contains multiple valid keys
+
+- **WHEN** a client submits multiple valid Nostr public keys within the batch limit
+- **THEN** the response evaluates all submitted keys in one request
+
+#### Scenario: Lookup contains no valid keys
+
+- **WHEN** a client submits an invalid key or exceeds the batch limit
+- **THEN** the endpoint rejects the request with a validation error

--- a/openspec/specs/nostr-integration/spec.md
+++ b/openspec/specs/nostr-integration/spec.md
@@ -65,26 +65,53 @@ Nostr connections in public connection statistics.
 
 The system SHALL let signed-in members enable a persistent Community Notes
 filter on the search map and read the associated Nostroots thread for a
-selected location.
+selected location. The map SHALL fetch only original kind `30397` events and
+SHALL NOT fetch kind `30398` validation-server events, so that current
+Trustroots account visibility can be applied without depending on a stale
+validation decision. It SHALL exclude notes authored by known Trustroots
+members who are not eligible for public display while preserving notes from
+valid Nostr authors who are not linked to a Trustroots account.
 
 #### Scenario: Member enables Community Notes
 
 - **WHEN** a signed-in member enables the Community Notes search filter
-- **THEN** the map displays available community-note locations
+- **THEN** the map displays available original community-note locations from eligible and unlinked authors
+- **AND** excludes notes from known shadowbanned, suspended, or private authors
+- **AND** excludes notes with malformed author keys
+- **AND** does not require validation-server copies of the original notes
 - **AND** the filter remains enabled after the member reloads the page
 
 #### Scenario: Member selects a community-note location
 
-- **WHEN** a signed-in member selects a community-note location on the search map
-- **THEN** the system displays the location's note thread and available author information
+- **WHEN** a member selects a community-note location
+- **THEN** the system displays the location's note thread and available author
+  information
 - **AND** a reply action opens the Nostroots action options
+
+### Requirement: Batch Nostr author visibility lookup
+
+The system SHALL provide a public read-only endpoint that accepts one or more
+valid Nostr public-key hex values and identifies which keys are linked to
+Trustroots members and which linked keys are eligible for public display. The
+response SHALL NOT disclose why a linked key is ineligible.
+
+#### Scenario: Lookup includes eligible and ineligible authors
+
+- **WHEN** a client requests visibility for public, shadowbanned, and unknown
+  Nostr public keys
+- **THEN** the response identifies the public and shadowbanned keys as linked
+- **AND** includes only the public member's key as eligible
+- **AND** does not disclose why the shadowbanned key is ineligible
 
 ### Requirement: Profile community notes
 
-The system SHALL show a Nostroots badge and recent community notes on a
-member profile when notes are available for that member's Nostr identity.
+The system SHALL show a Nostroots badge and recent original community notes on
+a member profile when notes are available for that member's Nostr identity. It
+SHALL fetch only kind `30397` events and SHALL NOT fetch kind `30398`
+validation-server events.
 
 #### Scenario: Member with community notes has their profile viewed
 
-- **WHEN** a profile with available community notes is viewed
-- **THEN** the profile displays the Nostroots badge and recent notes
+- **WHEN** a visitor views community notes associated with a member profile
+- **THEN** the system fetches and displays only original kind `30397` events
+- **AND** does not fetch kind `30398` validation-server copies

--- a/tests/e2e/features/admin-moderation/admin-acquisition.spec.js
+++ b/tests/e2e/features/admin-moderation/admin-acquisition.spec.js
@@ -13,6 +13,9 @@ test.describe('admin acquisition feature coverage', () => {
     annotateFeature(testInfo, 'admin.acquisition-stories', [
       'Acquisition stories page loads.',
       'Acquisition stories query returns deterministic rows.',
+      'Story rows link profile pictures to public member profiles.',
+      'Story rows show circle participation.',
+      'Story columns can be sorted.',
     ]);
     annotateFeature(testInfo, 'admin.acquisition-analysis', [
       'Acquisition story analysis page loads.',
@@ -21,14 +24,27 @@ test.describe('admin acquisition feature coverage', () => {
 
     await page.goto('/admin/acquisition-stories');
     await expect(page).toHaveURL(/\/admin\/acquisition-stories/);
+    await expect(
+      page.getByRole('link', {
+        name: 'Open public profile for Alice Contact',
+      }),
+    ).toHaveAttribute('href', '/profile/e2e-seeded-alice');
+    await expect(
+      page.getByRole('button', { name: /^circles$/i }),
+    ).toBeVisible();
+    await expect(page.locator('img[loading="lazy"]').first()).toHaveAttribute(
+      'src',
+      /\/api\/users\/.+\/avatar\?size=32/,
+    );
 
     const stories = await page.request.post('/api/admin/acquisition-stories');
     expect(stories.ok()).toBeTruthy();
-    expect(
-      (await stories.json()).some(item =>
-        /hitchhiking friends/i.test(item.acquisitionStory),
-      ),
-    ).toBe(true);
+    const storyRows = await stories.json();
+    const aliceStory = storyRows.find(item =>
+      /hitchhiking friends/i.test(item.acquisitionStory),
+    );
+    expect(aliceStory).toBeTruthy();
+    expect(aliceStory.circleCount).toBe(1);
 
     await page.goto('/admin/acquisition-stories/analysis');
     await expect(page).toHaveURL(/\/admin\/acquisition-stories\/analysis/);

--- a/tests/e2e/features/admin-moderation/admin-inspection.spec.js
+++ b/tests/e2e/features/admin-moderation/admin-inspection.spec.js
@@ -34,16 +34,13 @@ test.describe('admin moderation inspection flows', () => {
     const berlin = await findUserByUsername('e2e-seeded-berlin');
     const berlinId = String(berlin._id);
 
-    await page.goto(`/admin/messages?userId1=${shadowId}&userId2=${berlinId}`);
     const messagesResponse = page.waitForResponse(
       response =>
         response.url().includes('/api/admin/messages') &&
         response.request().method() === 'POST' &&
         response.ok(),
     );
-    await page.locator('input[name="member1"]').fill(shadowId);
-    await page.locator('input[name="member2"]').fill(berlinId);
-    await page.getByRole('button', { name: /^read$/i }).click();
+    await page.goto(`/admin/messages?userId1=${shadowId}&userId2=${berlinId}`);
     await messagesResponse;
 
     await expect(page.getByText(SEEDED_SHADOW_MESSAGE).first()).toBeVisible();

--- a/tests/e2e/features/search-offers-circles/search-map-rendered.spec.js
+++ b/tests/e2e/features/search-offers-circles/search-map-rendered.spec.js
@@ -613,23 +613,19 @@ test.describe('rendered search map feature coverage', () => {
       {
         content: communityNoteText,
         created_at: 1700000000,
-        kind: 30398,
-        tags: [
-          ['l', '9F4MGCC4+22', 'open-location-code'],
-          [
-            'p',
-            '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
-          ],
-        ],
+        kind: 30397,
+        tags: [['l', '9F4MGCC4+22', 'open-location-code']],
       },
       new Uint8Array(32).fill(1),
     );
-
-    // Local E2E pages accept an explicit fixture validator override. The
-    // deployed site always retains the configured Nostroots validation key.
-    await page.addInitScript(fixturePubkey => {
-      window.__TRUSTROOTS_E2E_NOSTROOTS_VALIDATION_PUBKEY__ = fixturePubkey;
-    }, signedNote.pubkey);
+    await context.route('**/api/nostr/author-visibility?*', route =>
+      route.fulfill({
+        json: {
+          linkedPubkeys: [signedNote.pubkey],
+          pubkeys: [signedNote.pubkey],
+        },
+      }),
+    );
     await installNostrRelayStub(page, [signedNote]);
 
     await page.goto('/search');


### PR DESCRIPTION
## Summary

Includes several fixes and administration improvements that should reach main soon:

### Community Note author visibility

- fetch original kind 30397 events only for both map discovery and profile notes
- stop fetching kind 30398 validation-server copies because their past decision becomes stale after a later suspension or shadowban
- evaluate linked Trustroots authors against current account visibility in batches of up to 100 keys
- hide currently shadowbanned, suspended, or private linked members without disclosing the reason
- preserve valid notes from Nostr authors who are not linked to Trustroots
- reject malformed author keys, cache successful checks briefly, and retry transient failures
- reconnect and refetch automatically when the relay WebSocket is interrupted, deduplicating replayed notes

### Avatar upload errors

- use the HTTP status from the response payload when the upload callback omits its status argument
- retain specific messages for files that are too large, unsupported, or cannot be processed
- fall back to the generic upload error when neither source provides a valid status

### Admin message inspection

- automatically query member threads when opening /admin/threads with a userId or username
- automatically load a conversation when opening /admin/messages with both member IDs
- keep the existing Query and Read actions available for manual searches

### Admin acquisition stories

- show lazily loaded member profile pictures linked to public profiles
- retain member-name links to administration reports
- show how many circles each member has joined
- sort rows by date, member, circle count, or story

### Coverage maintenance

- cover the remaining historical spam cleanup branches introduced on main
- restore server branch coverage from 99.69% to 100%

## Root causes

The map previously kept only the events received before an interrupted relay WebSocket and never reconnected, which could leave just two markers visible. It now reconnects after one second and refetches the original-event history.

Validation-server events preserve a historical approval decision. If the original author is suspended or shadowbanned later, consuming that copy would require a separate unvalidation event. Trustroots now consumes the original event and applies current account visibility when displaying it.

The previous author filter also treated unlinked Nostr authors as ineligible Trustroots members, which removed legitimate bridge content. The API now distinguishes linked keys from unknown keys without revealing the reason a linked account is hidden.

Avatar uploads could receive the status only in the response payload, causing known upload failures to display the generic error instead of the relevant guidance.

Admin message-inspection links populated their query fields from the URL but still required an unnecessary second click before showing results.

The acquisition-stories table did not provide enough member context or allow administrators to reorder the data while reviewing it.

## Validation

- OpenSpec change validated, archived, and living Nostr specifications updated
- lint checks passed
- client: 249 suites and 1,378 tests passed; statements, branches, functions, and lines at 100%
- server: 1,515 tests passed; statements, branches, functions, and lines at 100%
- focused Community Note browser scenario passed using an original kind 30397 event
