### PR TITLE
Add native iOS member search

### DIFF
--- a/apps/ios/Trustroots.xcodeproj/project.pbxproj
+++ b/apps/ios/Trustroots.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0E831D2402FCD69878BB4CEF /* NostrIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D160385B89B56C5385E8E9 /* NostrIdentity.swift */; };
 		0EE9C2C716DAC81E1D756A95 /* CircleDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81AC8FF10AA3FC5D79B111BA /* CircleDetailView.swift */; };
 		15790C63AF0422B5D50AB4EA /* LocationPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5627FC9D7597842E4C1125E1 /* LocationPreviewView.swift */; };
+		1F1A4B84AF934DE09A9EB2D1 /* MemberSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F2A4B84AF934DE09A9EB2D1 /* MemberSearchView.swift */; };
 		29DF2AC39A79037D7C0457CA /* MapFilterSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9474F8363D8A2E281F012D /* MapFilterSheet.swift */; };
 		2B14C92119A7AC3B5F83B6B3 /* TrustrootsApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803C2E0AE7321926A1ABB7F0 /* TrustrootsApp.swift */; };
 		39E542290B8429EB621D1D5A /* SignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EC27FA444EF5257316FDB35 /* SignInView.swift */; };
@@ -54,6 +55,7 @@
 
 /* Begin PBXFileReference section */
 		16B6D2A9ABB3F6C095F1D7A4 /* TrustrootsBrowserView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TrustrootsBrowserView.swift; sourceTree = "<group>"; };
+		1F2A4B84AF934DE09A9EB2D1 /* MemberSearchView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MemberSearchView.swift; sourceTree = "<group>"; };
 		2D39D0CB9F25268806927E57 /* CommunityNotesStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CommunityNotesStore.swift; sourceTree = "<group>"; };
 		3BEBBFF3D5A19B724A3AD0AA /* Trustroots.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Trustroots.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4B3A8DF28B2E964E6E81F6FC /* ContactSupportView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactSupportView.swift; sourceTree = "<group>"; };
@@ -125,6 +127,7 @@
 				FF9474F8363D8A2E281F012D /* MapFilterSheet.swift */,
 				7040954AE5BE42F61ACC6E79 /* MemberAvatarView.swift */,
 				4C99E5EF486955BCD9BC9DC7 /* MemberProfileView.swift */,
+				1F2A4B84AF934DE09A9EB2D1 /* MemberSearchView.swift */,
 				E7E2961EE91180D18EAD37B7 /* MemberSessionStore.swift */,
 				AFDE64017484020751FDBD35 /* MessageInboxView.swift */,
 				63684517FEA4D117EEDA1429 /* NIP07Bridge.swift */,
@@ -302,6 +305,7 @@
 				29DF2AC39A79037D7C0457CA /* MapFilterSheet.swift in Sources */,
 				41DFAB865863E84445853B11 /* MemberAvatarView.swift in Sources */,
 				C5E9F66FE8D73DD80460CD32 /* MemberProfileView.swift in Sources */,
+				1F1A4B84AF934DE09A9EB2D1 /* MemberSearchView.swift in Sources */,
 				F91CF77FA8AC58CC93A0633C /* MemberSessionStore.swift in Sources */,
 				5BF5363FD85409C9BDD0E7C3 /* MessageInboxView.swift in Sources */,
 				3F7B4302D3CCCC2F0AEF29F0 /* NIP07Bridge.swift in Sources */,

--- a/apps/ios/TrustrootsApp/Info.plist
+++ b/apps/ios/TrustrootsApp/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>2026.7.29</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/apps/ios/TrustrootsApp/MemberSearchView.swift
+++ b/apps/ios/TrustrootsApp/MemberSearchView.swift
@@ -1,0 +1,185 @@
+import SwiftUI
+
+struct MemberSearchView: View {
+    @ObservedObject var session: MemberSessionStore
+    @State private var query = ""
+    @State private var results: [MemberSearchResult] = []
+    @State private var isSearching = false
+    @State private var hasSearched = false
+    @State private var errorMessage: String?
+    @FocusState private var isSearchFocused: Bool
+
+    private let api = TrustrootsAPI()
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if isSearching {
+                    ProgressView("Finding members…")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if let errorMessage {
+                    ContentUnavailableView(
+                        "Member search unavailable",
+                        systemImage: "person.crop.circle.badge.exclamationmark",
+                        description: Text(errorMessage)
+                    )
+                } else if hasSearched && results.isEmpty {
+                    ContentUnavailableView(
+                        "No members found",
+                        systemImage: "person.2.slash",
+                        description: Text("Try another name or username.")
+                    )
+                } else if results.isEmpty {
+                    ContentUnavailableView(
+                        "Find members",
+                        systemImage: "person.crop.circle.badge.magnifyingglass",
+                        description: Text("Search by name or username.")
+                    )
+                } else {
+                    List(results) { member in
+                        NavigationLink {
+                            MemberProfileView(session: session, username: member.username)
+                        } label: {
+                            memberRow(member)
+                        }
+                    }
+                    .listStyle(.plain)
+                    .scrollDismissesKeyboard(.interactively)
+                }
+            }
+            .navigationTitle("Find members")
+            .navigationBarTitleDisplayMode(.inline)
+            .safeAreaInset(edge: .bottom, spacing: 0) {
+                searchForm
+            }
+        }
+    }
+
+    private var searchForm: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 9) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                TextField("Name or username", text: $query)
+                    .focused($isSearchFocused)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .submitLabel(.search)
+                    .onSubmit {
+                        guard canSearch else { return }
+                        isSearchFocused = false
+                        Task { await search() }
+                    }
+                    .onChange(of: query) {
+                        hasSearched = false
+                        errorMessage = nil
+                    }
+                if !query.isEmpty {
+                    Button {
+                        query = ""
+                        results = []
+                        hasSearched = false
+                        errorMessage = nil
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .accessibilityLabel("Clear member search")
+                }
+                Button {
+                    isSearchFocused = false
+                    Task { await search() }
+                } label: {
+                    Image(systemName: "arrow.right.circle.fill")
+                        .font(.title2)
+                }
+                .disabled(!canSearch || isSearching)
+                .accessibilityLabel("Search members")
+            }
+            .padding(.horizontal, 13)
+            .frame(height: 46)
+            .background(Color(.secondarySystemBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+
+            if !trimmedQuery.isEmpty && !canSearch {
+                Text("Enter at least 3 characters.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 4)
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(.regularMaterial)
+        .overlay(alignment: .top) {
+            Divider()
+        }
+        .toolbar {
+            ToolbarItemGroup(placement: .keyboard) {
+                Button("Search") {
+                    isSearchFocused = false
+                    Task { await search() }
+                }
+                .disabled(!canSearch || isSearching)
+                Spacer()
+                Button("Done") {
+                    isSearchFocused = false
+                }
+                .fontWeight(.semibold)
+            }
+        }
+    }
+
+    private func memberRow(_ member: MemberSearchResult) -> some View {
+        HStack(spacing: 14) {
+            MemberAvatarView(
+                memberID: member.id,
+                displayName: member.displayName,
+                serverURLString: session.serverURLString,
+                size: 64
+            )
+            VStack(alignment: .leading, spacing: 3) {
+                Text(member.displayName)
+                    .font(.headline)
+                Text("@\(member.username)")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                if let location = member.locationSummary {
+                    Label(location, systemImage: "mappin.and.ellipse")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            Spacer()
+        }
+        .padding(.vertical, 5)
+    }
+
+    private var trimmedQuery: String {
+        query.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var canSearch: Bool {
+        trimmedQuery.count >= 3
+    }
+
+    @MainActor
+    private func search() async {
+        guard canSearch, !isSearching else { return }
+        isSearching = true
+        hasSearched = true
+        errorMessage = nil
+        defer { isSearching = false }
+
+        do {
+            results = try await api.searchMembers(
+                serverURLString: session.serverURLString,
+                query: trimmedQuery
+            )
+        } catch {
+            results = []
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/apps/ios/TrustrootsApp/TrustrootsAPI.swift
+++ b/apps/ios/TrustrootsApp/TrustrootsAPI.swift
@@ -194,6 +194,45 @@ struct MiniMember: Decodable {
     }
 }
 
+struct MemberSearchResult: Decodable, Identifiable {
+    let id: String?
+    let username: String
+    let displayName: String
+    let locationLiving: String?
+    let locationFrom: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case mongoID = "_id"
+        case username
+        case displayName
+        case locationLiving
+        case locationFrom
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeIfPresent(String.self, forKey: .mongoID)
+            ?? container.decodeIfPresent(String.self, forKey: .id)
+        username = try container.decode(String.self, forKey: .username)
+        displayName = try container.decodeIfPresent(String.self, forKey: .displayName) ?? username
+        locationLiving = try container.decodeIfPresent(String.self, forKey: .locationLiving)
+        locationFrom = try container.decodeIfPresent(String.self, forKey: .locationFrom)
+    }
+
+    var locationSummary: String? {
+        let living = locationLiving?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let living, !living.isEmpty {
+            return living
+        }
+        let from = locationFrom?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let from, !from.isEmpty {
+            return "From \(from)"
+        }
+        return nil
+    }
+}
+
 struct MemberProfile: Decodable {
     let id: String?
     let displayName: String
@@ -795,6 +834,21 @@ final class TrustrootsAPI {
         try await get(
             serverURLString: serverURLString,
             path: "api/users/\(username)"
+        )
+    }
+
+    func searchMembers(
+        serverURLString: String,
+        query: String,
+        limit: Int = 50
+    ) async throws -> [MemberSearchResult] {
+        try await get(
+            serverURLString: serverURLString,
+            path: "api/users",
+            queryItems: [
+                URLQueryItem(name: "search", value: query),
+                URLQueryItem(name: "limit", value: String(limit)),
+            ]
         )
     }
 

--- a/apps/ios/TrustrootsApp/TrustrootsRootView.swift
+++ b/apps/ios/TrustrootsApp/TrustrootsRootView.swift
@@ -57,6 +57,8 @@ struct TrustrootsRootView: View {
                             )
                         case .contacts:
                             ContactsView(session: session)
+                        case .memberSearch:
+                            MemberSearchView(session: session)
                         case .support:
                             ContactSupportView(session: session) {
                                 browserRoute = .website(path: "/faq", title: "Frequently asked questions")
@@ -312,6 +314,7 @@ private enum TrustrootsDestination: CaseIterable {
     case profile
     case editProfile
     case contacts
+    case memberSearch
     case support
     case account
     case search
@@ -324,6 +327,7 @@ private enum TrustrootsDestination: CaseIterable {
         case .profile: return "Profile"
         case .editProfile: return "Edit profile"
         case .contacts: return "Contacts"
+        case .memberSearch: return "Find members"
         case .support: return "Contact and support"
         case .account: return "Account"
         case .search: return "Search"
@@ -338,6 +342,7 @@ private enum TrustrootsDestination: CaseIterable {
         case .profile: return "person.2.fill"
         case .editProfile: return "pencil"
         case .contacts: return "person.2.fill"
+        case .memberSearch: return "person.crop.circle.badge.magnifyingglass"
         case .support: return "questionmark.circle"
         case .account: return "person.crop.circle"
         case .search: return "magnifyingglass"
@@ -352,6 +357,7 @@ private enum TrustrootsDestination: CaseIterable {
         case .profile: return "/ios/profile"
         case .editProfile: return "/ios/profile/edit"
         case .contacts: return "/ios/contacts"
+        case .memberSearch: return "/ios/search/members"
         case .support: return "/ios/support"
         case .account: return "/ios/account"
         case .search: return "/ios/search"
@@ -477,7 +483,7 @@ private struct MoreView: View {
                     selectDestination(.contacts)
                 }
                 Button {
-                    openBrowser(.website(path: "/search/members", title: "Find members"))
+                    selectDestination(.memberSearch)
                 } label: {
                     Label("Find members", systemImage: "person.crop.circle.badge.magnifyingglass")
                 }

--- a/apps/ios/TrustrootsTests/TrustrootsTests.swift
+++ b/apps/ios/TrustrootsTests/TrustrootsTests.swift
@@ -281,6 +281,53 @@ final class TrustrootsTests: XCTestCase {
         XCTAssertNil(recordedRequest?.value(forHTTPHeaderField: "Authorization"))
     }
 
+    func testMemberSearchUsesExistingProtectedRouteAndDecodesNativeResults() async throws {
+        let credentialStore = InMemorySessionCredentialStore()
+        XCTAssertTrue(credentialStore.save(
+            SessionCredentials(cookieHeader: "connect.sid=signed-session", username: "traveller")
+        ))
+
+        var recordedRequest: URLRequest?
+        APIURLProtocol.handler = { request in
+            recordedRequest = request
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil
+            )!
+            return (
+                response,
+                Data(
+                    #"[{"_id":"member-1","username":"alex","displayName":"Alex Traveller","locationLiving":"Lisbon"}]"#.utf8
+                )
+            )
+        }
+        defer { APIURLProtocol.handler = nil }
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [APIURLProtocol.self]
+        let api = TrustrootsAPI(
+            session: URLSession(configuration: configuration),
+            credentialStore: credentialStore
+        )
+
+        let members = try await api.searchMembers(
+            serverURLString: "https://api.example.test",
+            query: "alex"
+        )
+
+        XCTAssertEqual(recordedRequest?.url?.path, "/api/users")
+        XCTAssertEqual(
+            URLComponents(url: try XCTUnwrap(recordedRequest?.url), resolvingAgainstBaseURL: false)?
+                .queryItems?
+                .first(where: { $0.name == "search" })?
+                .value,
+            "alex"
+        )
+        XCTAssertEqual(recordedRequest?.value(forHTTPHeaderField: "Cookie"), "connect.sid=signed-session")
+        XCTAssertEqual(members.first?.username, "alex")
+        XCTAssertEqual(members.first?.displayName, "Alex Traveller")
+        XCTAssertEqual(members.first?.locationSummary, "Lisbon")
+    }
+
     func testAccommodationUsesExistingOfferByUserRoute() async throws {
         let credentialStore = InMemorySessionCredentialStore()
         XCTAssertTrue(credentialStore.save(

--- a/openspec/changes/add-native-ios-member-mvp/proposal.md
+++ b/openspec/changes/add-native-ios-member-mvp/proposal.md
@@ -14,8 +14,8 @@ authorisation and visibility behaviour.
 - Authenticate through the existing `/api/auth/signin` website-session flow,
   keep the signed session cookie in the iOS Keychain and call the established
   `/api/*` resources.
-- Deliver native profile, circle, offer-search, contacts, experiences,
-  messaging, account and support interfaces.
+- Deliver native profile, member-search, circle, offer-search, contacts,
+  experiences, messaging, account and support interfaces.
 - Keep confirmation and password recovery in an allowlisted `WKWebView`
   because those are existing website flows.
 - Add a permissioned NIP-07 bridge for approved Trustroots and Hitchwiki HTTPS

--- a/openspec/changes/add-native-ios-member-mvp/specs/native-ios-member-app/spec.md
+++ b/openspec/changes/add-native-ios-member-mvp/specs/native-ios-member-app/spec.md
@@ -32,8 +32,8 @@ implemented MVP areas and SHALL NOT provide administration or moderation tools.
 
 #### Scenario: Member uses a supported MVP area
 
-- **WHEN** an eligible member opens a supported account, profile, circle,
-  offer-search, offer-management, or messaging area in the iOS app
+- **WHEN** an eligible member opens a supported account, profile, member-search,
+  circle, offer-search, offer-management, or messaging area in the iOS app
 - **THEN** the app presents a native iOS interface for that area
 
 #### Scenario: Administrator needs administration tools
@@ -79,8 +79,41 @@ developer API availability controls.
 - **WHEN** the member opens the native menu
 - **THEN** the menu does not show API origin, build or availability diagnostics
 - **AND** does not show an API availability check or refresh control
-- **AND** provides a Find members action that opens the existing member-search
-  page in the built-in browser
+- **AND** provides a Find members action that opens native member search
+
+### Requirement: Native member search
+
+The native app SHALL let signed-in members find other available members through
+the existing protected member-search route without opening the built-in
+browser. The native results SHALL preserve the website route's visibility,
+blocking and role restrictions.
+
+#### Scenario: Member searches for another member
+
+- **WHEN** a signed-in member submits at least three characters in native
+  member search
+- **THEN** the app requests matching members from the existing
+  `/api/users?search=` route
+- **AND** displays the returned members in a native list
+- **AND** selecting a result opens that member's native profile
+
+#### Scenario: Native member search has no matches
+
+- **WHEN** the protected member-search route returns no members
+- **THEN** the native screen explains that no members matched
+- **AND** remains ready for another search
+
+#### Scenario: Native member search input is incomplete
+
+- **WHEN** the member enters fewer than three characters
+- **THEN** the app does not submit a request
+- **AND** explains the minimum search length
+
+#### Scenario: Member uses the on-screen keyboard
+
+- **WHEN** the member enters a native member search
+- **THEN** the app provides visible Search and Done keyboard actions
+- **AND** does not move the primary navigation above the keyboard
 
 #### Scenario: Member filters a native list
 

--- a/openspec/changes/add-native-ios-member-mvp/tasks.md
+++ b/openspec/changes/add-native-ios-member-mvp/tasks.md
@@ -43,6 +43,9 @@
       operations and origin-permission decisions with iOS tests.
 - [x] 2.9 Add an account/server-scoped protected cache for authenticated GET
       responses and a persistent warning whenever cached data is being shown.
+- [x] 2.10 Implement native member search through the existing protected
+      `/api/users?search=` route, including native results, empty and error
+      states, keyboard dismissal, and navigation to native profiles.
 
 ## 3. TestFlight readiness
 


### PR DESCRIPTION
## What changed

- replace the Find members browser shortcut with a native SwiftUI search screen
- use the existing protected `GET /api/users?search=` route without API changes
- show member avatars, names, usernames and available location context
- open results in native member profiles
- provide native loading, empty, error and minimum-query states with keyboard dismissal
- advance the iOS build number to `2026.7.29 (2)` for the next Xcode Cloud/TestFlight build
- update and validate the native iOS OpenSpec

## Why

Find members was presented as a native app action but opened the website in the
embedded browser. This keeps the whole member-discovery journey native while
retaining the website route's established visibility, blocking and role rules.

## Validation

- `openspec validate add-native-ios-member-mvp --strict`
- signed generic iOS device build with Xcode
- staged diff validation

The new API-client contract test was added but not run locally.
