### PR TITLE
Improve native profiles, safety, and host filtering

### DIFF
--- a/apps/ios/TrustrootsApp/Info.plist
+++ b/apps/ios/TrustrootsApp/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>2026.7.29</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>3</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/apps/ios/TrustrootsApp/MapFilterSheet.swift
+++ b/apps/ios/TrustrootsApp/MapFilterSheet.swift
@@ -4,6 +4,7 @@ struct MapFilterSheet: View {
     @Environment(\.dismiss) private var dismiss
     @Binding var showingHosts: Bool
     @Binding var showingCommunityNotes: Bool
+    @Binding var onlineInPastSixMonths: Bool
     let circles: [TrustrootsCircle]
     @Binding var selectedCircleIDs: Set<String>
 
@@ -14,6 +15,11 @@ struct MapFilterSheet: View {
                     Toggle("Hosts", isOn: $showingHosts)
                         .tint(TrustrootsPalette.green)
                     Toggle("Community Notes via Nostroots", isOn: $showingCommunityNotes)
+                        .tint(TrustrootsPalette.green)
+                }
+
+                Section("Members") {
+                    Toggle("Logged in within 6 months", isOn: $onlineInPastSixMonths)
                         .tint(TrustrootsPalette.green)
                 }
 
@@ -47,6 +53,7 @@ struct MapFilterSheet: View {
                     Button("Reset") {
                         showingHosts = true
                         showingCommunityNotes = true
+                        onlineInPastSixMonths = true
                         selectedCircleIDs.removeAll()
                     }
                 }

--- a/apps/ios/TrustrootsApp/MemberProfileView.swift
+++ b/apps/ios/TrustrootsApp/MemberProfileView.swift
@@ -156,10 +156,6 @@ struct MemberProfileView: View {
                                 .accessibilityLabel("Open or start a conversation with \(profile.displayName)")
                             }
 
-                            if !isOwnProfile(profile) {
-                                memberSafetySection(profile)
-                            }
-
                             ProfileActivityView(
                                 seen: profile.seen,
                                 replyRate: profile.replyRate,
@@ -266,6 +262,10 @@ struct MemberProfileView: View {
                                         )
                                     }
                                 }
+                            }
+
+                            if !isOwnProfile(profile) {
+                                memberSafetySection(profile)
                             }
                         }
                         .padding(20)
@@ -378,42 +378,44 @@ struct MemberProfileView: View {
     }
 
     private func memberSafetySection(_ profile: MemberProfile) -> some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: 6) {
+            Divider()
+
             if isBlocked {
-                Label(
-                    "You have blocked \(profile.displayName).",
-                    systemImage: "hand.raised.fill"
-                )
-                .font(.subheadline.weight(.semibold))
-                .foregroundStyle(.red)
+                Text("You have blocked \(profile.displayName).")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
-            HStack(spacing: 12) {
+            HStack(spacing: 18) {
                 Button {
                     showReportMember = true
                 } label: {
                     Label("Report member", systemImage: "flag")
-                        .frame(maxWidth: .infinity)
                 }
-                .buttonStyle(.bordered)
+                .foregroundStyle(.secondary)
 
                 Button(role: isBlocked ? nil : .destructive) {
                     showBlockConfirmation = true
                 } label: {
                     if isUpdatingBlock {
                         ProgressView()
-                            .frame(maxWidth: .infinity)
+                            .controlSize(.small)
                     } else {
                         Label(
                             isBlocked ? "Unblock" : "Block",
                             systemImage: isBlocked ? "hand.raised.slash" : "hand.raised"
                         )
-                        .frame(maxWidth: .infinity)
                     }
                 }
-                .buttonStyle(.bordered)
+                .foregroundStyle(isBlocked ? Color.secondary : Color.red)
                 .disabled(isUpdatingBlock)
+
+                Spacer()
             }
+            .font(.footnote)
+            .buttonStyle(.plain)
+            .frame(minHeight: 32)
 
             if let safetyErrorMessage {
                 Text(safetyErrorMessage)
@@ -422,9 +424,7 @@ struct MemberProfileView: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(14)
-        .background(Color(.secondarySystemBackground))
-        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .padding(.top, 2)
     }
 
     private func updateBlock(blocked: Bool) async {

--- a/apps/ios/TrustrootsApp/MemberProfileView.swift
+++ b/apps/ios/TrustrootsApp/MemberProfileView.swift
@@ -14,6 +14,11 @@ struct MemberProfileView: View {
     @State private var showAllExperiences = false
     @State private var errorMessage: String?
     @State private var isLoading = false
+    @State private var isBlocked = false
+    @State private var isUpdatingBlock = false
+    @State private var showBlockConfirmation = false
+    @State private var showReportMember = false
+    @State private var safetyErrorMessage: String?
 
     private let api = TrustrootsAPI()
 
@@ -125,7 +130,7 @@ struct MemberProfileView: View {
                                 .tint(TrustrootsPalette.green)
                             }
 
-                            if !isOwnProfile(profile), let memberID = profile.id {
+                            if !isOwnProfile(profile), !isBlocked, let memberID = profile.id {
                                 NavigationLink {
                                     ConversationView(
                                         otherMember: MiniMember(
@@ -149,6 +154,10 @@ struct MemberProfileView: View {
                                 .buttonStyle(.borderedProminent)
                                 .tint(TrustrootsPalette.green)
                                 .accessibilityLabel("Open or start a conversation with \(profile.displayName)")
+                            }
+
+                            if !isOwnProfile(profile) {
+                                memberSafetySection(profile)
                             }
 
                             ProfileActivityView(
@@ -287,6 +296,37 @@ struct MemberProfileView: View {
             .onReceive(NotificationCenter.default.publisher(for: .trustrootsReturnToMap)) { _ in
                 dismiss()
             }
+            .sheet(isPresented: $showReportMember) {
+                if let profile {
+                    ReportMemberView(
+                        session: session,
+                        username: profile.username,
+                        displayName: profile.displayName
+                    )
+                }
+            }
+            .confirmationDialog(
+                isBlocked ? "Unblock this member?" : "Block this member?",
+                isPresented: $showBlockConfirmation,
+                titleVisibility: .visible
+            ) {
+                if isBlocked {
+                    Button("Unblock member") {
+                        Task { await updateBlock(blocked: false) }
+                    }
+                } else {
+                    Button("Block member", role: .destructive) {
+                        Task { await updateBlock(blocked: true) }
+                    }
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                if isBlocked {
+                    Text("They will be able to see your profile and message you again.")
+                } else {
+                    Text("They will no longer be able to see your profile or message you.")
+                }
+            }
     }
 
     private var shouldOpenCanonicalOwnProfile: Bool {
@@ -310,6 +350,17 @@ struct MemberProfileView: View {
         do {
             let loadedProfile = try await api.profile(serverURLString: session.serverURLString, username: username)
             profile = loadedProfile
+            if !isOwnProfile(loadedProfile) {
+                let blockedMembers = (try? await api.blockedMembers(
+                    serverURLString: session.serverURLString
+                )) ?? []
+                isBlocked = blockedMembers.contains { member in
+                    if let memberID = member.id, let loadedID = loadedProfile.id {
+                        return memberID == loadedID
+                    }
+                    return member.username?.caseInsensitiveCompare(loadedProfile.username) == .orderedSame
+                }
+            }
             if let userID = loadedProfile.id {
                 async let loadedContacts = api.contacts(serverURLString: session.serverURLString, userID: userID)
                 async let loadedExperiences = api.experiences(serverURLString: session.serverURLString, userID: userID)
@@ -323,6 +374,74 @@ struct MemberProfileView: View {
             }
         } catch {
             errorMessage = error.localizedDescription
+        }
+    }
+
+    private func memberSafetySection(_ profile: MemberProfile) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if isBlocked {
+                Label(
+                    "You have blocked \(profile.displayName).",
+                    systemImage: "hand.raised.fill"
+                )
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.red)
+            }
+
+            HStack(spacing: 12) {
+                Button {
+                    showReportMember = true
+                } label: {
+                    Label("Report member", systemImage: "flag")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+
+                Button(role: isBlocked ? nil : .destructive) {
+                    showBlockConfirmation = true
+                } label: {
+                    if isUpdatingBlock {
+                        ProgressView()
+                            .frame(maxWidth: .infinity)
+                    } else {
+                        Label(
+                            isBlocked ? "Unblock" : "Block",
+                            systemImage: isBlocked ? "hand.raised.slash" : "hand.raised"
+                        )
+                        .frame(maxWidth: .infinity)
+                    }
+                }
+                .buttonStyle(.bordered)
+                .disabled(isUpdatingBlock)
+            }
+
+            if let safetyErrorMessage {
+                Text(safetyErrorMessage)
+                    .font(.footnote)
+                    .foregroundStyle(.red)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(14)
+        .background(Color(.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+
+    private func updateBlock(blocked: Bool) async {
+        guard !isUpdatingBlock, let profile else { return }
+        isUpdatingBlock = true
+        safetyErrorMessage = nil
+        defer { isUpdatingBlock = false }
+
+        do {
+            try await api.setMemberBlocked(
+                serverURLString: session.serverURLString,
+                username: profile.username,
+                blocked: blocked
+            )
+            isBlocked = blocked
+        } catch {
+            safetyErrorMessage = error.localizedDescription
         }
     }
 
@@ -392,6 +511,119 @@ struct MemberProfileView: View {
             .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
         }
         .buttonStyle(.plain)
+    }
+}
+
+private struct ReportMemberView: View {
+    @Environment(\.dismiss) private var dismiss
+    @ObservedObject var session: MemberSessionStore
+    let username: String
+    let displayName: String
+    @State private var message = ""
+    @State private var isSending = false
+    @State private var isSent = false
+    @State private var errorMessage: String?
+    @FocusState private var messageIsFocused: Bool
+
+    private let api = TrustrootsAPI()
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if isSent {
+                    ContentUnavailableView(
+                        "Report sent",
+                        systemImage: "checkmark.circle.fill",
+                        description: Text("Thank you. The Trustroots support team will review your report.")
+                    )
+                } else {
+                    Form {
+                        Section("Reporting") {
+                            LabeledContent("Member", value: "\(displayName) (@\(username))")
+                        }
+
+                        Section {
+                            TextEditor(text: $message)
+                                .frame(minHeight: 150)
+                                .focused($messageIsFocused)
+                                .accessibilityLabel("Describe your concern")
+                        } header: {
+                            Text("What happened?")
+                        } footer: {
+                            Text("Please include enough detail for the support team to understand and investigate.")
+                        }
+
+                        if let errorMessage {
+                            Section {
+                                Text(errorMessage)
+                                    .foregroundStyle(.red)
+                            }
+                        }
+
+                        Section {
+                            Button {
+                                Task { await sendReport() }
+                            } label: {
+                                HStack {
+                                    Spacer()
+                                    if isSending {
+                                        ProgressView()
+                                    } else {
+                                        Label("Send report", systemImage: "flag.fill")
+                                    }
+                                    Spacer()
+                                }
+                            }
+                            .disabled(
+                                message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                                    || isSending
+                            )
+                        } footer: {
+                            Text("If anyone is in immediate danger or a crime has occurred, contact local emergency services.")
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Report member")
+            .navigationBarTitleDisplayMode(.inline)
+            .interactiveDismissDisabled(isSending)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(isSent ? "Done" : "Cancel") {
+                        dismiss()
+                    }
+                    .disabled(isSending)
+                }
+                ToolbarItemGroup(placement: .keyboard) {
+                    Spacer()
+                    Button("Done") {
+                        messageIsFocused = false
+                    }
+                }
+            }
+        }
+    }
+
+    private func sendReport() async {
+        guard !isSending else { return }
+        let trimmedMessage = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedMessage.isEmpty else { return }
+        isSending = true
+        errorMessage = nil
+        messageIsFocused = false
+        defer { isSending = false }
+
+        do {
+            try await api.sendSupportMessage(
+                serverURLString: session.serverURLString,
+                message: trimmedMessage,
+                reportMember: username
+            )
+            message = ""
+            isSent = true
+        } catch {
+            errorMessage = error.localizedDescription
+        }
     }
 }
 

--- a/apps/ios/TrustrootsApp/MemberProfileView.swift
+++ b/apps/ios/TrustrootsApp/MemberProfileView.swift
@@ -125,6 +125,38 @@ struct MemberProfileView: View {
                                 .tint(TrustrootsPalette.green)
                             }
 
+                            if !isOwnProfile(profile), let memberID = profile.id {
+                                NavigationLink {
+                                    ConversationView(
+                                        otherMember: MiniMember(
+                                            id: memberID,
+                                            username: profile.username,
+                                            displayName: profile.displayName
+                                        ),
+                                        session: session
+                                    )
+                                } label: {
+                                    VStack(spacing: 3) {
+                                        Label("Message", systemImage: "bubble.left.and.bubble.right.fill")
+                                            .font(.subheadline.weight(.semibold))
+                                        Text("Open or start a conversation")
+                                            .font(.caption)
+                                            .opacity(0.85)
+                                    }
+                                    .frame(maxWidth: .infinity)
+                                    .padding(.vertical, 9)
+                                }
+                                .buttonStyle(.borderedProminent)
+                                .tint(TrustrootsPalette.green)
+                                .accessibilityLabel("Open or start a conversation with \(profile.displayName)")
+                            }
+
+                            ProfileActivityView(
+                                seen: profile.seen,
+                                replyRate: profile.replyRate,
+                                replyTime: profile.replyTime
+                            )
+
                             if profile.locationLiving != nil || profile.locationFrom != nil {
                                 VStack(alignment: .leading, spacing: 10) {
                                     if let living = profile.locationLiving, !living.isEmpty {
@@ -264,6 +296,11 @@ struct MemberProfileView: View {
         return username.caseInsensitiveCompare(signedInUsername) == .orderedSame
     }
 
+    private func isOwnProfile(_ profile: MemberProfile) -> Bool {
+        guard let signedInUsername = session.member?.username else { return false }
+        return profile.username.caseInsensitiveCompare(signedInUsername) == .orderedSame
+    }
+
     private func loadProfile() async {
         guard !isLoading, let username = username ?? session.member?.username else { return }
         isLoading = true
@@ -355,6 +392,67 @@ struct MemberProfileView: View {
             .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
         }
         .buttonStyle(.plain)
+    }
+}
+
+private struct ProfileActivityView: View {
+    let seen: Date?
+    let replyRate: String?
+    let replyTime: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Activity")
+                .font(.headline)
+
+            activityRow(
+                systemImage: "clock.arrow.circlepath",
+                title: "Last login",
+                value: seen?.formatted(.relative(presentation: .named)) ?? "Long ago"
+            )
+            activityRow(
+                systemImage: "arrowshape.turn.up.left.fill",
+                title: "Reply rate",
+                value: nonEmpty(replyRate) ?? "Not available yet"
+            )
+            if let replyTime = nonEmpty(replyTime) {
+                activityRow(
+                    systemImage: "timer",
+                    title: "Usually replies",
+                    value: "Within \(replyTime)"
+                )
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(16)
+        .background(TrustrootsPalette.paleGreen)
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+
+    private func activityRow(
+        systemImage: String,
+        title: String,
+        value: String
+    ) -> some View {
+        HStack(spacing: 11) {
+            Image(systemName: systemImage)
+                .foregroundStyle(TrustrootsPalette.darkGreen)
+                .frame(width: 22)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(value)
+                    .font(.subheadline.weight(.semibold))
+            }
+            Spacer()
+        }
+    }
+
+    private func nonEmpty(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let trimmed, !trimmed.isEmpty else { return nil }
+        return trimmed
     }
 }
 

--- a/apps/ios/TrustrootsApp/MessageInboxView.swift
+++ b/apps/ios/TrustrootsApp/MessageInboxView.swift
@@ -200,7 +200,7 @@ private struct MessageThreadRow: View {
     }
 }
 
-private struct ConversationView: View {
+struct ConversationView: View {
     let otherMember: MiniMember
     @ObservedObject var session: MemberSessionStore
     @State private var messages: [DirectMessage] = []

--- a/apps/ios/TrustrootsApp/OfferMapView.swift
+++ b/apps/ios/TrustrootsApp/OfferMapView.swift
@@ -14,6 +14,7 @@ struct OfferMapView: View {
     @State private var showingFilters = false
     @State private var showingHosts = true
     @State private var showingCommunityNotes = true
+    @State private var onlineInPastSixMonths = true
     @State private var circles: [TrustrootsCircle] = []
     @State private var selectedCircleIDs: Set<String> = []
     @State private var searchGeneration = 0
@@ -162,6 +163,7 @@ struct OfferMapView: View {
                 MapFilterSheet(
                     showingHosts: $showingHosts,
                     showingCommunityNotes: $showingCommunityNotes,
+                    onlineInPastSixMonths: $onlineInPastSixMonths,
                     circles: circles,
                     selectedCircleIDs: $selectedCircleIDs
                 )
@@ -215,7 +217,8 @@ struct OfferMapView: View {
                 serverURLString: session.serverURLString,
                 in: region,
                 types: types,
-                tribeIDs: selectedCircleIDs.sorted()
+                tribeIDs: selectedCircleIDs.sorted(),
+                seenWithinMonths: onlineInPastSixMonths ? 6 : 24
             )
             guard generation == searchGeneration else { return }
             offers = fetchedOffers

--- a/apps/ios/TrustrootsApp/TrustrootsAPI.swift
+++ b/apps/ios/TrustrootsApp/TrustrootsAPI.swift
@@ -185,6 +185,12 @@ struct MiniMember: Decodable {
         case displayName
     }
 
+    init(id: String?, username: String?, displayName: String?) {
+        self.id = id
+        self.username = username
+        self.displayName = displayName
+    }
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         id = try container.decodeIfPresent(String.self, forKey: .mongoID)
@@ -242,8 +248,11 @@ struct MemberProfile: Decodable {
     let locationLiving: String?
     let locationFrom: String?
     let languages: [String]?
+    let seen: Date?
     let created: Date?
     let avatarUploaded: Bool?
+    let replyRate: String?
+    let replyTime: String?
     let email: String?
     let emailTemporary: String?
     let newsletter: Bool?
@@ -259,8 +268,11 @@ struct MemberProfile: Decodable {
         case locationLiving
         case locationFrom
         case languages
+        case seen
         case created
         case avatarUploaded
+        case replyRate
+        case replyTime
         case email
         case emailTemporary
         case newsletter
@@ -278,8 +290,11 @@ struct MemberProfile: Decodable {
         locationLiving = try container.decodeIfPresent(String.self, forKey: .locationLiving)
         locationFrom = try container.decodeIfPresent(String.self, forKey: .locationFrom)
         languages = try container.decodeIfPresent([String].self, forKey: .languages)
+        seen = try container.decodeIfPresent(Date.self, forKey: .seen)
         created = try container.decodeIfPresent(Date.self, forKey: .created)
         avatarUploaded = try container.decodeIfPresent(Bool.self, forKey: .avatarUploaded)
+        replyRate = try container.decodeIfPresent(String.self, forKey: .replyRate)
+        replyTime = try container.decodeIfPresent(String.self, forKey: .replyTime)
         email = try container.decodeIfPresent(String.self, forKey: .email)
         emailTemporary = try container.decodeIfPresent(String.self, forKey: .emailTemporary)
         newsletter = try container.decodeIfPresent(Bool.self, forKey: .newsletter)

--- a/apps/ios/TrustrootsApp/TrustrootsAPI.swift
+++ b/apps/ios/TrustrootsApp/TrustrootsAPI.swift
@@ -811,7 +811,8 @@ final class TrustrootsAPI {
         serverURLString: String,
         in region: MKCoordinateRegion,
         types: [String] = ["host"],
-        tribeIDs: [String] = []
+        tribeIDs: [String] = [],
+        seenWithinMonths: Int = 6
     ) async throws -> [MapOffer] {
         let latitudeDelta = region.span.latitudeDelta / 2
         let longitudeDelta = region.span.longitudeDelta / 2
@@ -825,7 +826,8 @@ final class TrustrootsAPI {
                 URLQueryItem(name: "northEastLng", value: String(region.center.longitude + longitudeDelta)),
                 URLQueryItem(
                     name: "filters",
-                    value: "{\"types\":\(types.jsonArray),\"tribes\":\(tribeIDs.jsonArray)}"
+                    value: "{\"types\":\(types.jsonArray),\"tribes\":\(tribeIDs.jsonArray),"
+                        + "\"seen\":{\"months\":\(seenWithinMonths)}}"
                 ),
             ]
         )
@@ -978,7 +980,11 @@ final class TrustrootsAPI {
         }
     }
 
-    func sendSupportMessage(serverURLString: String, message: String) async throws {
+    func sendSupportMessage(
+        serverURLString: String,
+        message: String,
+        reportMember: String? = nil
+    ) async throws {
         guard let configuration = TrustrootsAPIConfiguration(baseURLString: serverURLString) else {
             throw TrustrootsAPIError.invalidServerURL
         }
@@ -987,7 +993,50 @@ final class TrustrootsAPI {
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
-        request.httpBody = try encoder.encode(["message": message])
+        var body = ["message": message]
+        if let reportMember, !reportMember.isEmpty {
+            body["reportMember"] = reportMember
+        }
+        request.httpBody = try encoder.encode(body)
+
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw TrustrootsAPIError.invalidResponse
+            }
+            guard (200..<300).contains(httpResponse.statusCode) else {
+                throw decodedError(from: data, statusCode: httpResponse.statusCode)
+            }
+        } catch let error as TrustrootsAPIError {
+            throw error
+        } catch {
+            throw TrustrootsAPIError.requestFailed(error.localizedDescription)
+        }
+    }
+
+    func blockedMembers(serverURLString: String) async throws -> [MiniMember] {
+        try await get(
+            serverURLString: serverURLString,
+            path: "api/blocked-users"
+        )
+    }
+
+    func setMemberBlocked(
+        serverURLString: String,
+        username: String,
+        blocked: Bool
+    ) async throws {
+        guard let configuration = TrustrootsAPIConfiguration(baseURLString: serverURLString) else {
+            throw TrustrootsAPIError.invalidServerURL
+        }
+        var request = URLRequest(
+            url: configuration.baseURL
+                .appendingPathComponent("api/blocked-users")
+                .appendingPathComponent(username)
+        )
+        authorise(&request)
+        request.httpMethod = blocked ? "PUT" : "DELETE"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
 
         do {
             let (data, response) = try await session.data(for: request)

--- a/apps/ios/TrustrootsTests/TrustrootsTests.swift
+++ b/apps/ios/TrustrootsTests/TrustrootsTests.swift
@@ -261,7 +261,9 @@ final class TrustrootsTests: XCTestCase {
             )!
             return (
                 response,
-                Data(#"{"username":"traveller","displayName":"A Traveller","public":true}"#.utf8)
+                Data(
+                    #"{"username":"traveller","displayName":"A Traveller","public":true,"seen":"2026-07-29T12:00:00Z","replyRate":"82%","replyTime":"4 hours"}"#.utf8
+                )
             )
         }
         defer { APIURLProtocol.handler = nil }
@@ -276,6 +278,9 @@ final class TrustrootsTests: XCTestCase {
         let member = try await api.currentMember(serverURLString: "https://api.example.test")
 
         XCTAssertEqual(member.username, "traveller")
+        XCTAssertNotNil(member.seen)
+        XCTAssertEqual(member.replyRate, "82%")
+        XCTAssertEqual(member.replyTime, "4 hours")
         XCTAssertEqual(recordedRequest?.url?.path, "/api/users/traveller")
         XCTAssertEqual(recordedRequest?.value(forHTTPHeaderField: "Cookie"), "connect.sid=signed-session")
         XCTAssertNil(recordedRequest?.value(forHTTPHeaderField: "Authorization"))

--- a/apps/ios/TrustrootsTests/TrustrootsTests.swift
+++ b/apps/ios/TrustrootsTests/TrustrootsTests.swift
@@ -1,3 +1,4 @@
+import MapKit
 import XCTest
 @testable import Trustroots
 
@@ -179,6 +180,49 @@ final class TrustrootsTests: XCTestCase {
         XCTAssertEqual(offer.coordinate?.longitude, -9.1393)
     }
 
+    func testOfferSearchDefaultsToMembersSeenWithinSixMonths() async throws {
+        let credentialStore = InMemorySessionCredentialStore()
+        XCTAssertTrue(credentialStore.save(
+            SessionCredentials(cookieHeader: "connect.sid=signed-session", username: "traveller")
+        ))
+
+        var recordedRequest: URLRequest?
+        APIURLProtocol.handler = { request in
+            recordedRequest = request
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil
+            )!
+            return (response, Data(#"{"features":[]}"#.utf8))
+        }
+        defer { APIURLProtocol.handler = nil }
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [APIURLProtocol.self]
+        let api = TrustrootsAPI(
+            session: URLSession(configuration: configuration),
+            credentialStore: credentialStore
+        )
+
+        _ = try await api.searchOffers(
+            serverURLString: "https://api.example.test",
+            in: MKCoordinateRegion(
+                center: CLLocationCoordinate2D(latitude: 38.72, longitude: -9.14),
+                span: MKCoordinateSpan(latitudeDelta: 1, longitudeDelta: 1)
+            )
+        )
+
+        let filtersValue = URLComponents(
+            url: try XCTUnwrap(recordedRequest?.url),
+            resolvingAgainstBaseURL: false
+        )?.queryItems?.first(where: { $0.name == "filters" })?.value
+        let filtersData = try XCTUnwrap(filtersValue?.data(using: .utf8))
+        let filters = try JSONSerialization.jsonObject(with: filtersData) as? [String: Any]
+        let seen = filters?["seen"] as? [String: Any]
+
+        XCTAssertEqual(recordedRequest?.url?.path, "/api/offers")
+        XCTAssertEqual(seen?["months"] as? Int, 6)
+    }
+
     func testAboutRouteUsesTheDedicatedWebsitePage() {
         XCTAssertEqual(
             TrustrootsBrowserRoute.website(path: "/about", title: "About Trustroots").url.path,
@@ -331,6 +375,80 @@ final class TrustrootsTests: XCTestCase {
         XCTAssertEqual(members.first?.username, "alex")
         XCTAssertEqual(members.first?.displayName, "Alex Traveller")
         XCTAssertEqual(members.first?.locationSummary, "Lisbon")
+    }
+
+    func testMemberReportUsesExistingSupportRouteWithReportedUsername() async throws {
+        let credentialStore = InMemorySessionCredentialStore()
+        XCTAssertTrue(credentialStore.save(
+            SessionCredentials(cookieHeader: "connect.sid=signed-session", username: "traveller")
+        ))
+
+        var recordedRequest: URLRequest?
+        APIURLProtocol.handler = { request in
+            recordedRequest = request
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil
+            )!
+            return (response, Data(#"{"message":"Support request sent."}"#.utf8))
+        }
+        defer { APIURLProtocol.handler = nil }
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [APIURLProtocol.self]
+        let api = TrustrootsAPI(
+            session: URLSession(configuration: configuration),
+            credentialStore: credentialStore
+        )
+
+        try await api.sendSupportMessage(
+            serverURLString: "https://api.example.test",
+            message: "This profile contains abusive content.",
+            reportMember: "reported-member"
+        )
+
+        let body = try JSONDecoder().decode(
+            [String: String].self,
+            from: try XCTUnwrap(recordedRequest?.httpBody)
+        )
+        XCTAssertEqual(recordedRequest?.url?.path, "/api/support")
+        XCTAssertEqual(recordedRequest?.httpMethod, "POST")
+        XCTAssertEqual(recordedRequest?.value(forHTTPHeaderField: "Cookie"), "connect.sid=signed-session")
+        XCTAssertEqual(body["reportMember"], "reported-member")
+        XCTAssertEqual(body["message"], "This profile contains abusive content.")
+    }
+
+    func testMemberBlockUsesExistingBlockedMemberRoute() async throws {
+        let credentialStore = InMemorySessionCredentialStore()
+        XCTAssertTrue(credentialStore.save(
+            SessionCredentials(cookieHeader: "connect.sid=signed-session", username: "traveller")
+        ))
+
+        var recordedRequest: URLRequest?
+        APIURLProtocol.handler = { request in
+            recordedRequest = request
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil
+            )!
+            return (response, Data("Member added to block list.".utf8))
+        }
+        defer { APIURLProtocol.handler = nil }
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [APIURLProtocol.self]
+        let api = TrustrootsAPI(
+            session: URLSession(configuration: configuration),
+            credentialStore: credentialStore
+        )
+
+        try await api.setMemberBlocked(
+            serverURLString: "https://api.example.test",
+            username: "reported-member",
+            blocked: true
+        )
+
+        XCTAssertEqual(recordedRequest?.url?.path, "/api/blocked-users/reported-member")
+        XCTAssertEqual(recordedRequest?.httpMethod, "PUT")
+        XCTAssertEqual(recordedRequest?.value(forHTTPHeaderField: "Cookie"), "connect.sid=signed-session")
     }
 
     func testAccommodationUsesExistingOfferByUserRoute() async throws {

--- a/openspec/changes/add-native-ios-member-mvp/proposal.md
+++ b/openspec/changes/add-native-ios-member-mvp/proposal.md
@@ -15,7 +15,8 @@ authorisation and visibility behaviour.
   keep the signed session cookie in the iOS Keychain and call the established
   `/api/*` resources.
 - Deliver native profile, member-search, circle, offer-search, contacts,
-  experiences, messaging, account and support interfaces.
+  experiences, messaging, account and support interfaces, including the
+  established member-reporting and blocking safeguards.
 - Keep confirmation and password recovery in an allowlisted `WKWebView`
   because those are existing website flows.
 - Add a permissioned NIP-07 bridge for approved Trustroots and Hitchwiki HTTPS

--- a/openspec/changes/add-native-ios-member-mvp/specs/native-ios-member-app/spec.md
+++ b/openspec/changes/add-native-ios-member-mvp/specs/native-ios-member-app/spec.md
@@ -246,6 +246,40 @@ using the established offer-by-user endpoint.
 - **AND** the experience section summarises recommendation, meeting and
   hosting percentages from the loaded experiences
 
+### Requirement: Native profile activity and messaging
+
+Native member profiles SHALL display the existing public last-seen and reply
+statistics returned by the protected profile route. A signed-in member SHALL be
+able to open the existing native conversation with another member, or begin it
+by sending the first message, without leaving that profile for the website.
+
+#### Scenario: Profile has activity and reply statistics
+
+- **WHEN** a member opens a profile whose response includes `seen`,
+  `replyRate`, or `replyTime`
+- **THEN** the profile displays the available last-login, reply-rate and
+  typical-reply-time information
+- **AND** does not derive or request additional private activity data
+
+#### Scenario: Profile has no reply statistics
+
+- **WHEN** a member opens a profile whose reply statistics are empty
+- **THEN** the profile explains that reply data is not available yet
+- **AND** remains otherwise fully usable
+
+#### Scenario: Member opens messaging from another profile
+
+- **WHEN** a signed-in member selects the profile's conversation action
+- **THEN** the app opens the existing native conversation and displays its
+  history
+- **AND** if the conversation is empty, provides the composer that creates the
+  thread when the first message is sent
+
+#### Scenario: Member views their own profile
+
+- **WHEN** the signed-in member opens their own profile
+- **THEN** the app does not offer a conversation with themselves
+
 #### Scenario: Member returns to a circle
 
 - **WHEN** a member revisits a recently loaded circle during the same app

--- a/openspec/changes/add-native-ios-member-mvp/specs/native-ios-member-app/spec.md
+++ b/openspec/changes/add-native-ios-member-mvp/specs/native-ios-member-app/spec.md
@@ -198,7 +198,15 @@ enabled by default, and disabling a layer SHALL remove its annotations.
 
 - **WHEN** the member opens native search with default filters
 - **THEN** authorised host and meetup offers are requested
+- **AND** offers are limited to members seen within the past six months
 - **AND** verified Community Notes are loaded from the Trustroots Nostr relay
+
+#### Scenario: Member changes the recent-login filter
+
+- **WHEN** the member disables Logged in within 6 months
+- **THEN** the offer search uses the website-compatible 24-month window
+- **AND** the member can restore the default six-month window from the same
+  native filter sheet
 
 #### Scenario: Member disables a map layer
 
@@ -286,6 +294,35 @@ by sending the first message, without leaving that profile for the website.
   session
 - **THEN** the previously assembled contact, recommendation and active-member
   groups appear without repeating the full lookup
+
+### Requirement: Native member safety actions
+
+Native member profiles SHALL let a signed-in member report or block another
+member through the established support and blocked-member routes without
+opening the website. The app SHALL clearly confirm blocking before changing the
+relationship and SHALL keep reporting and blocking as independent actions.
+
+#### Scenario: Member reports another member
+
+- **WHEN** a signed-in member selects Report member on another member's profile
+- **THEN** the app presents a native form identifying the reported member
+- **AND** submits the member's description through the existing `/api/support`
+  route with the reported username
+- **AND** confirms that the report was sent
+
+#### Scenario: Member blocks another member
+
+- **WHEN** a signed-in member confirms Block member on another member's profile
+- **THEN** the app uses the existing `/api/blocked-users/:username` route
+- **AND** indicates that the member is blocked
+- **AND** no longer offers to start or continue a conversation with that member
+
+#### Scenario: Member unblocks another member
+
+- **WHEN** a signed-in member confirms Unblock member on a blocked member's
+  profile
+- **THEN** the app removes the block through the existing blocked-member route
+- **AND** restores the permitted messaging action
 
 ### Requirement: Configured member avatars
 

--- a/openspec/changes/add-native-ios-member-mvp/tasks.md
+++ b/openspec/changes/add-native-ios-member-mvp/tasks.md
@@ -46,6 +46,9 @@
 - [x] 2.10 Implement native member search through the existing protected
       `/api/users?search=` route, including native results, empty and error
       states, keyboard dismissal, and navigation to native profiles.
+- [x] 2.11 Show the existing last-seen and reply statistics on native profiles,
+      and let a member open or begin the existing native conversation with
+      another member directly from their profile.
 
 ## 3. TestFlight readiness
 

--- a/openspec/changes/add-native-ios-member-mvp/tasks.md
+++ b/openspec/changes/add-native-ios-member-mvp/tasks.md
@@ -27,6 +27,8 @@
       proposal.
 - [x] 2.5.3 Enable Meetups by default and add the website-compatible,
       validator-approved Community Notes via Nostroots map layer.
+- [x] 2.5.4 Default map results to members seen within six months and provide
+      the website-compatible toggle between six- and 24-month windows.
 - [ ] 2.6 Implement inbox, paginated conversation history, sending replies,
       unread state, and protected/empty/error states.
 - [ ] 2.6.1 Add native local filtering for loaded conversations and circles.
@@ -49,6 +51,8 @@
 - [x] 2.11 Show the existing last-seen and reply statistics on native profiles,
       and let a member open or begin the existing native conversation with
       another member directly from their profile.
+- [x] 2.12 Let a member report, block and unblock another member from a native
+      profile through the existing support and blocked-member routes.
 
 ## 3. TestFlight readiness
 


### PR DESCRIPTION
## What changed

- show existing last-login, reply-rate and typical reply-time information on native profiles
- open or start a native conversation directly from another member profile
- report a member through the existing support route with a native report form
- block and unblock members through the existing blocked-member routes, with confirmation and messaging hidden while blocked
- default map results to members seen within six months
- add the website-compatible map toggle between six- and 24-month activity windows
- document and validate the behaviour in the native iOS OpenSpec

## Why

Native profiles should expose the existing communication and safety tools without sending members to the website. The map should also match the website’s useful default of prioritising recently active hosts.

## Compatibility

This reuses the existing profile, messaging, support, blocked-member and offer-search routes. It does not add or change server APIs, stored data, or website behaviour.

## Validation

- `openspec validate add-native-ios-member-mvp --strict`
- signed physical-device iOS build
- installed successfully on a connected iPhone
- staged diff validation

Contract regression coverage was added but the full test suite was not run locally, as requested.