### PR TITLE
Polish the iOS header and embedded home

### DIFF
--- a/apps/ios/TrustrootsApp/TrustrootsBrowserView.swift
+++ b/apps/ios/TrustrootsApp/TrustrootsBrowserView.swift
@@ -30,6 +30,15 @@ enum TrustrootsBrowserRoute: Identifiable {
         }
     }
 
+    var isHome: Bool {
+        guard case .website(let path, _) = self else { return false }
+        if let absoluteURL = URL(string: path), absoluteURL.scheme != nil {
+            return absoluteURL.host == "www.trustroots.org" &&
+                (absoluteURL.path.isEmpty || absoluteURL.path == "/")
+        }
+        return path == "/"
+    }
+
     var url: URL {
         switch self {
         case .join:
@@ -153,6 +162,8 @@ struct TrustrootsWebView: UIViewRepresentable {
             #tr-header { display: none !important; }
             .container-spacer { margin-top: 0 !important; }
             .container-fullscreen.container-spacer { top: 0 !important; }
+            .home-intro .home-join,
+            #manifesto a[href^="/signup"] { display: none !important; }
           `;
           (document.head || document.documentElement).appendChild(style);
         })();

--- a/apps/ios/TrustrootsApp/TrustrootsRootView.swift
+++ b/apps/ios/TrustrootsApp/TrustrootsRootView.swift
@@ -100,7 +100,7 @@ struct TrustrootsRootView: View {
 
             TrustrootsBrandHeader(
                 isOverArtwork: isImmersiveDetail,
-                goBack: browserRoute == nil ? nil : {
+                goBack: browserRoute == nil || browserRoute?.isHome == true ? nil : {
                     browserRoute = nil
                 },
                 openHome: {
@@ -186,6 +186,10 @@ struct TrustrootsRootView: View {
 }
 
 private struct TrustrootsBrandHeader: View {
+    private static let islandHalfWidth: CGFloat = 63
+    private static let islandCentreY: CGFloat = 29
+    private static let islandSpacing: CGFloat = 7
+
     let isOverArtwork: Bool
     let goBack: (() -> Void)?
     let openHome: () -> Void
@@ -194,7 +198,7 @@ private struct TrustrootsBrandHeader: View {
 
     var body: some View {
         GeometryReader { proxy in
-            HStack(spacing: 0) {
+            HStack(spacing: 4) {
                 if let goBack {
                     headerButton("chevron.backward", label: "Back", action: goBack)
                 }
@@ -204,25 +208,32 @@ private struct TrustrootsBrandHeader: View {
                         .renderingMode(.template)
                         .scaledToFit()
                         .foregroundStyle(.white)
-                        .frame(width: 36, height: 36)
-                        .frame(width: 38, height: 38)
-                        .background(buttonBackground)
-                        .clipShape(Circle())
+                        .frame(width: 42, height: 42)
+                        .shadow(color: isOverArtwork ? .black.opacity(0.7) : .clear, radius: 2, y: 1)
                 }
                 .accessibilityLabel("Trustroots home")
             }
             .position(
-                x: proxy.size.width / 2 - (goBack == nil ? 91 : 109),
-                y: 19
+                x: proxy.size.width / 2
+                    - Self.islandHalfWidth
+                    - Self.islandSpacing
+                    - (goBack == nil ? 21 : 42),
+                y: Self.islandCentreY
             )
 
-            HStack(spacing: 0) {
+            HStack(spacing: 4) {
                 headerButton("person.crop.circle.fill", label: "Profile", action: openProfile)
                 headerButton("gearshape.fill", label: "Account", action: openAccount)
             }
-            .position(x: proxy.size.width / 2 + 103, y: 19)
+            .position(
+                x: proxy.size.width / 2
+                    + Self.islandHalfWidth
+                    + Self.islandSpacing
+                    + 38,
+                y: Self.islandCentreY
+            )
         }
-        .frame(height: 44)
+        .frame(height: 52)
         .background(isOverArtwork ? Color.clear : TrustrootsPalette.green)
         .shadow(color: isOverArtwork ? .black.opacity(0.45) : .clear, radius: 3, y: 1)
     }

--- a/apps/ios/TrustrootsTests/TrustrootsTests.swift
+++ b/apps/ios/TrustrootsTests/TrustrootsTests.swift
@@ -74,6 +74,20 @@ final class TrustrootsTests: XCTestCase {
         )
     }
 
+    func testBrowserHomeRouteDoesNotBehaveLikeAChildPage() {
+        XCTAssertTrue(TrustrootsBrowserRoute.website(path: "/", title: "Trustroots").isHome)
+        XCTAssertTrue(
+            TrustrootsBrowserRoute.website(
+                path: "https://www.trustroots.org/",
+                title: "Trustroots"
+            ).isHome
+        )
+        XCTAssertFalse(
+            TrustrootsBrowserRoute.website(path: "/about", title: "About Trustroots").isHome
+        )
+        XCTAssertFalse(TrustrootsBrowserRoute.join.isHome)
+    }
+
     func testBrowserKeepsTrustrootsSubdomainsInApp() throws {
         XCTAssertTrue(
             TrustrootsWebView.Coordinator.isTrustrootsURL(


### PR DESCRIPTION
## What changed

- align the logo, profile, and account controls with the Dynamic Island
- remove the circular plate from the Trustroots logo while retaining contrast over artwork
- treat the embedded website home as a root destination without a back button
- hide both homepage signup calls to action in the signed-in native browser
- add regression coverage for home-route detection

## Why

The header controls sat above the Dynamic Island centre and the logo's circular clipping made it look like another action button. Opening Home also retained a misleading close/back control, while the embedded signed-in experience could still expose website signup calls to action.

## Impact

Native navigation and embedded-home presentation only; website behaviour outside the iOS app is unchanged.

## Validation

- TrustrootsTests: 32 tests passed, 0 failures