### PR TITLE
Replace MailDev with Mailpit

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -23,12 +23,15 @@ apps. Set `TRUSTROOTS_DEV_*_HOST_PORT` before rebuilding to customize.
 | --------------------- | -------------: | ----------------: |
 | Webpack dev server    |         `3000` |           `13000` |
 | Express API/server    |         `3001` |           `13001` |
+| Mailpit web UI        |         `8025` |           `11080` |
 | MongoDB               |        `27017` |           `37017` |
 | LiveReload            |        `35729` |           `45729` |
 | Node server inspector |         `5858` |           `15858` |
 | Node worker inspector |         `5859` |           `15859` |
 
-MongoDB is available inside the app container at `mongodb:27017`.
+MongoDB is available inside the app container at `mongodb:27017`. Mailpit's
+SMTP service is available at `mailpit:1025`; its web UI is bound to the host's
+loopback interface at http://localhost:11080.
 
 ## Testing on a phone
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,6 +16,10 @@
       "label": "Express API/server",
       "onAutoForward": "ignore"
     },
+    "8025": {
+      "label": "Mailpit web UI",
+      "onAutoForward": "ignore"
+    },
     "27017": {
       "label": "MongoDB",
       "onAutoForward": "ignore"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -15,8 +15,14 @@ services:
       # Named volume keeps the image's linux-correct node_modules, shadowing
       # whatever is on the host. Seeded from the image on first creation.
       - node_modules:/home/app/trustroots/node_modules
+      # Use container service names without loading a developer's host config.
+      - ./local.js:/home/app/trustroots/config/env/local.js:ro
     depends_on:
       - mongodb
+      - mailpit
+    networks:
+      - default
+      - mailpit
     ports:
       # Keep the dev server private by default. Set
       # TRUSTROOTS_DEV_WEBPACK_BIND_ADDRESS=0.0.0.0 before rebuilding the
@@ -30,11 +36,30 @@ services:
       - NODE_ENV=development
       - TRUSTROOTS_NODE_INSPECT_HOST=0.0.0.0
       - DB_1_PORT_27017_TCP_ADDR=mongodb
-      - TRUSTROOTS_SKIP_LOCAL_CONFIG=true
       - TRUSTROOTS_AVATAR_PROCESSOR_FALLBACK=true
       - TRUSTROOTS_FILE_MAGIC_FALLBACK=true
       - TRUSTROOTS_E2E_MONGO_URI=mongodb://mongodb:27017/trustroots-test
       - TRUSTROOTS_CODEX_MONGO_URI=mongodb://mongodb:27017/trustroots-test
+
+  mailpit:
+    image: axllent/mailpit:v1.30.6@sha256:7f33095f80e901f6ad08028f06ca284aa58fe84942be5496008d041d3b9f4d4d
+    user: '65534:65534'
+    read_only: true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,nodev,size=64m,mode=1777
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    environment:
+      MP_DATABASE: /tmp/mailpit.db
+      MP_DISABLE_VERSION_CHECK: 'true'
+      MP_BLOCK_REMOTE_CSS_AND_FONTS: 'true'
+      MP_MAX_MESSAGE_SIZE: '10'
+    ports:
+      - '127.0.0.1:${TRUSTROOTS_DEV_MAILPIT_HOST_PORT:-11080}:8025'
+    networks:
+      - mailpit
 
   mongodb:
     image: mongo:4.4
@@ -46,6 +71,10 @@ services:
       - mongodb:/data/db
     ports:
       - '127.0.0.1:${TRUSTROOTS_DEV_MONGODB_HOST_PORT:-37017}:27017'
+
+networks:
+  mailpit:
+    internal: true
 
 volumes:
   mongodb:

--- a/.devcontainer/local.js
+++ b/.devcontainer/local.js
@@ -1,0 +1,16 @@
+'use strict';
+
+// Container-only overrides. This file is mounted over config/env/local.js so a
+// developer's host configuration cannot redirect email outside the dev stack.
+module.exports = {
+  mailer: {
+    options: {
+      jsonTransport: false,
+      host: 'mailpit',
+      port: 1025,
+      ignoreTLS: true,
+      auth: false,
+      pool: true,
+    },
+  },
+};

--- a/README.md
+++ b/README.md
@@ -67,8 +67,13 @@ Choose the setup that fits what you're doing:
 
 The host and Docker setups serve the app at http://localhost:3000.
 
-Docker dev uses hot reload and a shared MongoDB service. Development emails are
-captured locally and are not delivered. See
+Mailpit catches outbound development email when using Docker Compose or the Dev
+Container. Its web UI is available at http://localhost:1080 for Docker Compose
+and http://localhost:11080 for the Dev Container. Bare `npm start` uses an
+in-process JSON transport instead and does not start the mail UI.
+
+Docker dev uses hot reload, Mailpit, and a shared MongoDB service. Development
+emails are captured locally and are not delivered. See
 [`deploy/docker/README.md`](deploy/docker/README.md) for first-time setup,
 troubleshooting, dependency rebuilds, test workflows, and production-like image
 checks. See [`.devcontainer/README.md`](.devcontainer/README.md) for editor and

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -1,7 +1,8 @@
 # Docker
 
 This directory is the **single** local Docker setup for Trustroots (dev,
-mongodb, optional prod-like image test, data import, and production image build).
+Mailpit, MongoDB, optional prod-like image test, data import, and production
+image build).
 
 > Production is **not** deployed from this `docker-compose.yml`. Production runs
 > images built by `dockerBuild.sh` elsewhere.
@@ -9,7 +10,8 @@ mongodb, optional prod-like image test, data import, and production image build)
 ## First-time setup
 
 Create `data/local.js` (the `data/` directory is gitignored). It is mounted into
-the app and must point the database at the `mongodb` compose service:
+the app and must point the database at the `mongodb` Compose service and email
+at the `mailpit` service:
 
 ```js
 'use strict';
@@ -27,7 +29,12 @@ module.exports = {
   },
   mailer: {
     options: {
-      jsonTransport: true,
+      jsonTransport: false,
+      host: 'mailpit',
+      port: 1025,
+      ignoreTLS: true,
+      auth: false,
+      pool: true,
     },
   },
 };
@@ -42,8 +49,10 @@ docker compose up
 
 - App with hot reload at http://localhost:3000 (webpack-dev-server; the API runs
   on :3001 inside the container).
-- Development emails are captured locally and are not delivered.
-- Runs `dev` + `mongodb`; the repo is bind-mounted.
+- Mailpit UI at http://localhost:1080 (SMTP to `mailpit:1025` from the app).
+- Runs `dev` + `mongodb` + `mailpit`; the repo is bind-mounted.
+- Mailpit's UI is bound to localhost and its SMTP port is not published to the
+  host. It runs on an internal-only Docker network with no outbound relay.
 - Uses the `trustroots` database, so data imported via `importMongoData.sh` is
   visible.
 - MongoDB data lives in the `trustroots_mongodb_data` Docker volume. This keeps

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -42,6 +42,9 @@ services:
       - DB_1_PORT_27017_TCP_ADDR=mongodb
     depends_on:
       - mongodb
+    networks:
+      - default
+      - mailpit
     ports:
       - '3000:3000'
     command: ['npm', 'run', 'start:docker']
@@ -114,6 +117,32 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD}
     profiles:
       - stats
+
+  # Local-only email inbox. SMTP stays on the Compose network; only the web UI
+  # is published, and only on the host loopback interface.
+  mailpit:
+    image: axllent/mailpit:v1.30.6@sha256:7f33095f80e901f6ad08028f06ca284aa58fe84942be5496008d041d3b9f4d4d
+    user: '65534:65534'
+    read_only: true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,nodev,size=64m,mode=1777
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    environment:
+      MP_DATABASE: /tmp/mailpit.db
+      MP_DISABLE_VERSION_CHECK: 'true'
+      MP_BLOCK_REMOTE_CSS_AND_FONTS: 'true'
+      MP_MAX_MESSAGE_SIZE: '10'
+    ports:
+      - '127.0.0.1:1080:8025'
+    networks:
+      - mailpit
+
+networks:
+  mailpit:
+    internal: true
 
 volumes:
   # Keep WiredTiger data on Docker's Linux filesystem. Host bind mounts on

--- a/scripts/ci/ensure-compose-local.js
+++ b/scripts/ci/ensure-compose-local.js
@@ -28,7 +28,12 @@ module.exports = {
   },
   mailer: {
     options: {
-      jsonTransport: true,
+      jsonTransport: false,
+      host: 'mailpit',
+      port: 1025,
+      ignoreTLS: true,
+      auth: false,
+      pool: true,
     },
   },
 };


### PR DESCRIPTION
## Summary

- replace the development email preview service with Mailpit in Docker Compose
- add Mailpit to the Dev Container with container-only mail settings
- document the Docker Compose and Dev Container email preview URLs
- keep SMTP internal while binding the Mailpit web UI to localhost

## Motivation

Development email previews should use the actively maintained Mailpit service in both supported container workflows. Keeping SMTP on an internal-only Docker network prevents the preview service from relaying email externally.

## Developer impact

Docker Compose users can open Mailpit at http://localhost:1080. Dev Container users can open it at http://localhost:11080. Bare host development continues to use the in-process JSON transport.

## Verification

- `docker compose config --quiet` for `deploy/docker/docker-compose.yml`
- `docker compose -f .devcontainer/docker-compose.yml config --quiet`
- JavaScript syntax checks for `.devcontainer/local.js` and `scripts/ci/ensure-compose-local.js`
- Git whitespace check
