### PR TITLE
Test circle-only host visibility end to end

### DIFF
--- a/tests/e2e/feature-coverage.js
+++ b/tests/e2e/feature-coverage.js
@@ -1653,12 +1653,17 @@ const features = [
       'Host offer edit page loads.',
       'Member can create/update a host offer.',
       'Host offer visibility appears in profile/search.',
+      'Host can limit search visibility to members sharing a circle.',
       'Member can remove or disable a host offer.',
     ],
     relatedSpecs: [
       spec(
         'member.spec.js',
         'host offer edit page loads for a confirmed member',
+      ),
+      spec(
+        'offers-and-circles.spec.js',
+        'hosts can limit search visibility to members in their circles',
       ),
     ],
   },

--- a/tests/e2e/features/search-offers-circles/offers-and-circles.spec.js
+++ b/tests/e2e/features/search-offers-circles/offers-and-circles.spec.js
@@ -164,6 +164,95 @@ test.describe.serial('search offers and circles feature coverage', () => {
     expect(remove.ok()).toBeTruthy();
   });
 
+  test('hosts can limit search visibility to members in their circles', async ({
+    baseURL,
+    browser,
+    page,
+    request,
+  }, testInfo) => {
+    annotateFeature(testInfo, 'offers.host', [
+      'Host can limit search visibility to members sharing a circle.',
+    ]);
+
+    const aliceId = await fetchUserIdByUsername(request, alice.username);
+    const [aliceOffer] = await findOffersByUser(aliceId, { type: 'host' });
+    expect(aliceOffer).toBeTruthy();
+
+    const circles = await request.get('/api/tribes', {
+      params: { limit: 150 },
+    });
+    expect(circles.ok()).toBeTruthy();
+    const families = (await circles.json()).find(
+      circle => circle.label === 'Families',
+    );
+    expect(families).toBeTruthy();
+
+    const hostContext = await browser.newContext({ baseURL });
+    const hostPage = await hostContext.newPage();
+    let joinedFamilies = false;
+
+    try {
+      await signInViaApi(hostPage, hostContext.request, alice);
+      await hostPage.goto('/offer/host');
+
+      const circleOnly = hostPage.getByLabel(
+        'People that are not in any of my circles should not find me.',
+      );
+      await expect(circleOnly).toBeVisible();
+      await circleOnly.check();
+
+      const saved = hostPage.waitForResponse(
+        response =>
+          response.url().endsWith(`/api/offers/${aliceOffer._id}`) &&
+          response.request().method() === 'PUT',
+      );
+      await hostPage.locator('button[type="submit"].hidden-xs').click();
+      expect((await saved).ok()).toBeTruthy();
+
+      const withoutSharedCircle = await request.get(
+        `/api/offers${EUROPE_OFFERS_QUERY}`,
+      );
+      expect(withoutSharedCircle.ok()).toBeTruthy();
+      expect(
+        (await withoutSharedCircle.json()).features.map(
+          feature => feature.properties.id,
+        ),
+      ).not.toContain(aliceOffer._id.toString());
+
+      const join = await page.request.post(
+        `/api/users/memberships/${families._id}`,
+      );
+      expect(join.ok()).toBeTruthy();
+      joinedFamilies = true;
+
+      const withSharedCircle = await request.get(
+        `/api/offers${EUROPE_OFFERS_QUERY}`,
+      );
+      expect(withSharedCircle.ok()).toBeTruthy();
+      expect(
+        (await withSharedCircle.json()).features.map(
+          feature => feature.properties.id,
+        ),
+      ).toContain(aliceOffer._id.toString());
+    } finally {
+      if (joinedFamilies) {
+        await page.request.delete(`/api/users/memberships/${families._id}`);
+      }
+
+      await hostContext.request.put(`/api/offers/${aliceOffer._id}`, {
+        data: {
+          status: aliceOffer.status,
+          description: aliceOffer.description,
+          noOfferDescription: aliceOffer.noOfferDescription,
+          maxGuests: aliceOffer.maxGuests,
+          location: aliceOffer.location,
+          showOnlyInMyCircles: aliceOffer.showOnlyInMyCircles,
+        },
+      });
+      await hostContext.close();
+    }
+  });
+
   test('meet offers can be listed, created, edited, expired, and deleted', async ({
     page,
     request,


### PR DESCRIPTION
## Summary

- add browser-level coverage for enabling “Available only in my circles?” through the hosting form
- verify the restricted host is hidden from a member without a shared circle
- verify the host becomes discoverable after that member joins a shared circle
- register the behaviour in the end-to-end feature coverage manifest

## Why

The search filtering already had server-level coverage, but there was no end-to-end regression covering the complete form-save-to-search flow. This adds that coverage while reviewing the behaviour discussed in #2798.

## Impact

Test-only change; production behaviour is unchanged.

## Validation

- Prettier check passed
- ESLint passed
- focused `search-offers-circles` Playwright run: 8/8 tests passed
- the project-filtered wrapper subsequently reported partial global feature coverage because it expects all 276 scenarios from a full-suite run
