### PR TITLE
Add Welcome team access to acquisition stories and analysis

### DIFF
--- a/deploy/docker/webapp.conf
+++ b/deploy/docker/webapp.conf
@@ -15,6 +15,19 @@ server {
     passenger_startup_file server.js;
     passenger_app_env production;
 
+    # Production terminates TLS in a host-level reverse proxy before requests
+    # cross Docker's bridge into this container. Restore that proxy's forwarded
+    # visitor address so Passenger's secure client-address header does not
+    # contain the Docker gateway (for example 172.19.0.1).
+    #
+    # Only private-network peers may supply this header. Public clients are not
+    # trusted as real-IP sources even if the container port is exposed.
+    set_real_ip_from 10.0.0.0/8;
+    set_real_ip_from 172.16.0.0/12;
+    set_real_ip_from 192.168.0.0/16;
+    real_ip_header X-Forwarded-For;
+    real_ip_recursive on;
+
     ## Sticky sessions are required for long polling support (socket.io)
     passenger_sticky_sessions on;
     passenger_min_instances 1;

--- a/modules/admin/client/components/AdminAcquisitionStories.component.js
+++ b/modules/admin/client/components/AdminAcquisitionStories.component.js
@@ -154,6 +154,7 @@ export default function AdminAcquisitionStories() {
                   onSort={sortBy}
                   sort={sort}
                 />
+                <th>Restricted matches</th>
               </tr>
             </thead>
             <tbody>
@@ -206,6 +207,17 @@ export default function AdminAcquisitionStories() {
                     )}
                   </td>
                   <td>{story.acquisitionStory}</td>
+                  <td>
+                    {(story.restrictedMatches || []).map(match => (
+                      <div key={match._id}>
+                        <UserLink user={match} />
+                        <small className="text-muted">
+                          {' '}
+                          — {match.matchReasons.join(', ')}
+                        </small>
+                      </div>
+                    ))}
+                  </td>
                 </tr>
               ))}
             </tbody>

--- a/modules/admin/client/components/AdminUser.component.js
+++ b/modules/admin/client/components/AdminUser.component.js
@@ -32,6 +32,17 @@ const DEFAULT_MEMBER_LIST_SORT = {
   direction: 'ascending',
 };
 
+const ROLE_DESCRIPTIONS = {
+  admin: 'Full access to administration and moderation tools.',
+  moderator: 'Legacy moderation role retained for historical accounts.',
+  shadowban:
+    'Member can use the site, but their profile and outreach are hidden from others.',
+  suspended: 'Member access is blocked until an administrator intervenes.',
+  user: 'Standard Trustroots member access.',
+  volunteer: 'Current Trustroots volunteer.',
+  'volunteer-alumni': 'Former Trustroots volunteer.',
+};
+
 function formatDate(value) {
   if (!value) {
     return null;
@@ -532,6 +543,30 @@ export default class AdminUser extends Component {
                       {label}
                     </button>
                   ))}
+                </div>
+              </div>
+
+              <h4 id="roles">
+                <a href="#roles">Role management</a>{' '}
+                <small className="text-muted">read-only</small>
+              </h4>
+              <div className="panel panel-default admin-user-roles">
+                <div className="panel-body">
+                  <p className="text-muted">
+                    Current role inventory. Role editing will be added here in a
+                    future change; existing moderation actions remain above.
+                  </p>
+                  <dl>
+                    {user.profile.roles.map(role => (
+                      <React.Fragment key={role}>
+                        <dt>{role}</dt>
+                        <dd>
+                          {ROLE_DESCRIPTIONS[role] ||
+                            'Role stored on this member.'}
+                        </dd>
+                      </React.Fragment>
+                    ))}
+                  </dl>
                 </div>
               </div>
 

--- a/modules/admin/client/components/AdminUser.component.js
+++ b/modules/admin/client/components/AdminUser.component.js
@@ -305,6 +305,10 @@ export default class AdminUser extends Component {
     } = this.state;
     const isProfile = user && user.profile;
     const isSuspended = isSuspendedUser(get(user, ['profile']));
+    const isRestricted = get(user, ['profile', 'roles'], []).some(role =>
+      ['shadowban', 'suspended'].includes(role),
+    );
+    const potentialMatches = get(user, ['potentialMatches'], []);
     const visibleMatchingUsers = hideObviousSpamUsers
       ? matchingUsers.filter(user => !isObviousSpamUser(user))
       : matchingUsers;
@@ -337,6 +341,7 @@ export default class AdminUser extends Component {
           ],
           ['Email', user.profile.email],
           ['Temporary email', user.profile.emailTemporary],
+          ['Acquisition story', user.profile.acquisitionStory],
           [
             'Roles',
             user.profile.roles && user.profile.roles.length
@@ -633,6 +638,56 @@ export default class AdminUser extends Component {
               )}
 
               <AdminNotes id={userId} />
+
+              {isRestricted && (
+                <>
+                  <h4 id="potential-matches">
+                    <a href="#potential-matches">Potential related accounts</a>
+                  </h4>
+                  <div className="panel panel-warning">
+                    <div className="panel-body">
+                      <p className="text-muted">
+                        Investigation leads only. Matches do not change account
+                        state automatically.
+                      </p>
+                      <table className="table table-condensed table-striped">
+                        <thead>
+                          <tr>
+                            <th>Member</th>
+                            <th>Email</th>
+                            <th>Roles</th>
+                            <th>Matched on</th>
+                            <th>Acquisition story</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {potentialMatches.map(match => (
+                            <tr key={match._id}>
+                              <td>
+                                <a href={`/admin/user?id=${match._id}`}>
+                                  {match.displayName || match.username}
+                                </a>
+                                <div className="text-muted">
+                                  @{match.username}
+                                </div>
+                              </td>
+                              <td>{match.email}</td>
+                              <td>{match.roles.join(', ')}</td>
+                              <td>{match.matchReasons.join(', ')}</td>
+                              <td>{match.acquisitionStory}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                      {!potentialMatches.length && (
+                        <p>
+                          <em>No potential related accounts found.</em>
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                </>
+              )}
 
               <h4 id="profile">
                 <a href="#profile">Profile</a>

--- a/modules/admin/server/controllers/admin.acquisition-stories.server.controller.js
+++ b/modules/admin/server/controllers/admin.acquisition-stories.server.controller.js
@@ -450,7 +450,7 @@ exports.list = async (req, res) => {
   }
 
   const storyUserIds = stories.map(story => story._id);
-  const restrictedUsers = (await getRestrictedUsers()) || [];
+  const restrictedUsers = await getRestrictedUsers();
   const hostingOffers = await Offer.find({
     user: { $in: storyUserIds },
     type: 'host',

--- a/modules/admin/server/controllers/admin.acquisition-stories.server.controller.js
+++ b/modules/admin/server/controllers/admin.acquisition-stories.server.controller.js
@@ -302,14 +302,133 @@ function getStories() {
     {
       acquisitionStory: { $exists: true, $ne: '' },
     },
-    '_id acquisitionStory created displayName locationFrom locationLiving member username',
+    '_id acquisitionStory created displayName email emailTemporary locationFrom locationLiving member username',
   )
     .sort('-created')
     .limit(3000)
     .exec();
 }
 
-function storyForList(story, hostingLocation) {
+const RESTRICTED_MATCH_LIMIT = 10;
+const RESTRICTED_SOURCE_LIMIT = 1000;
+const MIN_IDENTIFIER_LENGTH = 4;
+const MIN_FUZZY_STORY_LENGTH = 12;
+const FUZZY_STORY_THRESHOLD = 0.82;
+
+function normalizeIdentifier(value) {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+function emailLocalPart(value) {
+  return value.split('@')[0];
+}
+
+function normalizeStory(value) {
+  return value.trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+function getCharacterTrigrams(value) {
+  const trigrams = new Set();
+  for (let index = 0; index <= value.length - 3; index += 1) {
+    trigrams.add(value.slice(index, index + 3));
+  }
+  return trigrams;
+}
+
+function getStorySimilarity(firstStory, secondStory) {
+  const first = normalizeStory(firstStory);
+  const second = normalizeStory(secondStory);
+  if (
+    first.length < MIN_FUZZY_STORY_LENGTH ||
+    second.length < MIN_FUZZY_STORY_LENGTH
+  ) {
+    return 0;
+  }
+
+  const firstTrigrams = getCharacterTrigrams(first);
+  const secondTrigrams = getCharacterTrigrams(second);
+  const sharedCount = [...firstTrigrams].filter(trigram =>
+    secondTrigrams.has(trigram),
+  ).length;
+
+  return (2 * sharedCount) / (firstTrigrams.size + secondTrigrams.size);
+}
+
+function getRestrictedIdentifiers(user) {
+  return [
+    { label: 'Username identifier', value: normalizeIdentifier(user.username) },
+    {
+      label: 'Email identifier',
+      value: normalizeIdentifier(emailLocalPart(user.email)),
+    },
+    {
+      label: 'Temporary email identifier',
+      value: normalizeIdentifier(emailLocalPart(user.emailTemporary)),
+    },
+  ].filter(
+    ({ value }, index, identifiers) =>
+      value.length >= MIN_IDENTIFIER_LENGTH &&
+      identifiers.findIndex(identifier => identifier.value === value) === index,
+  );
+}
+
+function getRestrictedMatchReasons(story, restrictedUser) {
+  const storyIdentifiers = [
+    normalizeIdentifier(story.username),
+    normalizeIdentifier(emailLocalPart(story.email)),
+    normalizeIdentifier(emailLocalPart(story.emailTemporary)),
+  ];
+  const reasons = getRestrictedIdentifiers(restrictedUser)
+    .filter(({ value }) =>
+      storyIdentifiers.some(identifier => identifier.includes(value)),
+    )
+    .map(({ label }) => label);
+  const storyText = normalizeStory(story.acquisitionStory);
+  const restrictedStoryText = normalizeStory(restrictedUser.acquisitionStory);
+
+  if (storyText && storyText === restrictedStoryText) {
+    reasons.push('Acquisition story');
+  } else if (
+    getStorySimilarity(
+      story.acquisitionStory,
+      restrictedUser.acquisitionStory,
+    ) >= FUZZY_STORY_THRESHOLD
+  ) {
+    reasons.push('Similar acquisition story');
+  }
+
+  return reasons;
+}
+
+function getRestrictedMatches(story, restrictedUsers) {
+  return restrictedUsers
+    .filter(user => user._id.toString() !== story._id.toString())
+    .map(user => ({
+      user,
+      matchReasons: getRestrictedMatchReasons(story, user),
+    }))
+    .filter(({ matchReasons }) => matchReasons.length)
+    .slice(0, RESTRICTED_MATCH_LIMIT)
+    .map(({ user, matchReasons }) => ({
+      _id: user._id,
+      displayName: user.displayName,
+      matchReasons,
+      roles: user.roles,
+      username: user.username,
+    }));
+}
+
+function getRestrictedUsers() {
+  return User.find({ roles: { $in: ['shadowban', 'suspended'] } })
+    .select(
+      '_id acquisitionStory displayName email emailTemporary roles username',
+    )
+    .sort({ created: -1, _id: 1 })
+    .limit(RESTRICTED_SOURCE_LIMIT)
+    .exec();
+}
+
+function storyForList(story, hostingLocation, restrictedMatches) {
   return {
     _id: story._id,
     acquisitionStory: story.acquisitionStory,
@@ -319,6 +438,7 @@ function storyForList(story, hostingLocation) {
     hostingLocation,
     locationFrom: story.locationFrom,
     locationLiving: story.locationLiving,
+    restrictedMatches,
     username: story.username,
   };
 }
@@ -330,6 +450,7 @@ exports.list = async (req, res) => {
   }
 
   const storyUserIds = stories.map(story => story._id);
+  const restrictedUsers = (await getRestrictedUsers()) || [];
   const hostingOffers = await Offer.find({
     user: { $in: storyUserIds },
     type: 'host',
@@ -354,7 +475,11 @@ exports.list = async (req, res) => {
 
   return res.send(
     stories.map(story =>
-      storyForList(story, hostingLocationsByUser[story._id.toString()] || null),
+      storyForList(
+        story,
+        hostingLocationsByUser[story._id.toString()] || null,
+        getRestrictedMatches(story, restrictedUsers),
+      ),
     ),
   );
 };
@@ -364,3 +489,5 @@ exports.getAnalysis = async (req, res) => {
   const analysis = analyseStories(stories);
   res.send(analysis);
 };
+
+exports.getStorySimilarity = getStorySimilarity;

--- a/modules/admin/server/controllers/admin.users.server.controller.js
+++ b/modules/admin/server/controllers/admin.users.server.controller.js
@@ -17,6 +17,8 @@ const Thread = mongoose.model('Thread');
 const User = mongoose.model('User');
 
 const ADMIN_MEMBER_PAGE_SIZE = 150;
+const POTENTIAL_MATCH_LIMIT = 25;
+const POTENTIAL_MATCH_MIN_IDENTIFIER_LENGTH = 4;
 const SEARCH_STRING_LIMIT = 3;
 const ADMIN_MEMBER_SORT_FIELDS = {
   created: 'created',
@@ -59,6 +61,8 @@ const USER_LIST_FIELDS = [
   'roles',
   'username',
 ];
+
+const POTENTIAL_MATCH_FIELDS = [...USER_LIST_FIELDS, 'acquisitionStory'];
 
 /**
  * Overwrite tokens from results as a security measure.
@@ -113,6 +117,116 @@ function createMemberSearchRegexp(search) {
     .join('\\s*');
 
   return new RegExp('.*' + whitespaceTolerantSearch + '.*', 'i');
+}
+
+function normalizeIdentifier(value) {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+function getEmailLocalPart(value) {
+  return value.split('@')[0];
+}
+
+function normalizeAcquisitionStory(value) {
+  return value.trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+function createFlexibleIdentifierRegexp(identifier, emailLocalPartOnly) {
+  const pattern = identifier
+    .split('')
+    .map(escapeStringRegexp)
+    .join('[\\s._+\\x2d]*');
+
+  return new RegExp(
+    emailLocalPartOnly ? `^[^@]*${pattern}[^@]*@` : pattern,
+    'i',
+  );
+}
+
+function getPotentialMatchSignals(user) {
+  const signals = [
+    { label: 'Username identifier', value: normalizeIdentifier(user.username) },
+    {
+      label: 'Email identifier',
+      value: normalizeIdentifier(getEmailLocalPart(user.email)),
+    },
+    {
+      label: 'Temporary email identifier',
+      value: normalizeIdentifier(getEmailLocalPart(user.emailTemporary)),
+    },
+  ].filter(
+    ({ value }, index, items) =>
+      value.length >= POTENTIAL_MATCH_MIN_IDENTIFIER_LENGTH &&
+      items.findIndex(item => item.value === value) === index,
+  );
+  const acquisitionStory = normalizeAcquisitionStory(user.acquisitionStory);
+
+  return {
+    acquisitionStory,
+    identifiers: signals,
+  };
+}
+
+function getPotentialMatchReasons(user, signals) {
+  const candidateIdentifiers = [
+    normalizeIdentifier(user.username),
+    normalizeIdentifier(getEmailLocalPart(user.email)),
+    normalizeIdentifier(getEmailLocalPart(user.emailTemporary)),
+  ];
+  const reasons = signals.identifiers
+    .filter(({ value }) =>
+      candidateIdentifiers.some(identifier => identifier.includes(value)),
+    )
+    .map(({ label }) => label);
+
+  if (
+    signals.acquisitionStory &&
+    normalizeAcquisitionStory(user.acquisitionStory) ===
+      signals.acquisitionStory
+  ) {
+    reasons.push('Acquisition story');
+  }
+
+  return reasons;
+}
+
+async function findPotentialMatches(user) {
+  const signals = getPotentialMatchSignals(user);
+  const querySignals = signals.identifiers.flatMap(({ value }) => [
+    { username: createFlexibleIdentifierRegexp(value, false) },
+    { email: createFlexibleIdentifierRegexp(value, true) },
+    { emailTemporary: createFlexibleIdentifierRegexp(value, true) },
+  ]);
+
+  if (signals.acquisitionStory) {
+    querySignals.push({
+      acquisitionStory: new RegExp(
+        `^\\s*${signals.acquisitionStory
+          .split(' ')
+          .map(escapeStringRegexp)
+          .join('\\s+')}\\s*$`,
+        'i',
+      ),
+    });
+  }
+
+  if (!querySignals.length) {
+    return [];
+  }
+
+  const matches = await User.find({
+    _id: { $ne: user._id },
+    $or: querySignals,
+  })
+    .select(POTENTIAL_MATCH_FIELDS)
+    .sort({ created: -1, _id: 1 })
+    .limit(POTENTIAL_MATCH_LIMIT)
+    .exec();
+
+  return matches.map(match => ({
+    ...obfuscateTokens(match),
+    matchReasons: getPotentialMatchReasons(match, signals),
+  }));
 }
 
 function getMemberListOptions(body) {
@@ -345,11 +459,19 @@ exports.getUser = async (req, res) => {
 
     const offers = await Offer.find({ user: userId });
 
+    const isRestricted = ['shadowban', 'suspended'].some(role =>
+      user.roles.includes(role),
+    );
+    const potentialMatches = isRestricted
+      ? await findPotentialMatches(user)
+      : [];
+
     res.send({
       contacts: contacts || [],
       messageFromCount,
       messageToCount,
       offers: offers || [],
+      potentialMatches,
       profile: obfuscateTokens(user),
       threadCount,
       threadReferencesSentNo,
@@ -365,6 +487,8 @@ exports.getUser = async (req, res) => {
     handleAdminApiError(res, err);
   }
 };
+
+exports.findPotentialMatches = findPotentialMatches;
 
 /**
  * This middleware changes user roles by ID

--- a/modules/admin/tests/client/components/AdminAcquisitionStories.component.tests.js
+++ b/modules/admin/tests/client/components/AdminAcquisitionStories.component.tests.js
@@ -30,6 +30,15 @@ describe('<AdminAcquisitionStories />', () => {
         hostingLocation: [52.37, 4.9],
         locationFrom: 'Fictional origin',
         locationLiving: 'Fictional home',
+        restrictedMatches: [
+          {
+            _id: '222222222222222222222222',
+            displayName: 'Restricted Example',
+            matchReasons: ['Acquisition story'],
+            roles: ['user', 'shadowban'],
+            username: 'restricted',
+          },
+        ],
         username: 'alice',
       },
     ]);
@@ -62,6 +71,12 @@ describe('<AdminAcquisitionStories />', () => {
     expect(screen.getByText('Living: Fictional home')).toBeInTheDocument();
     expect(screen.getByText('From: Fictional origin')).toBeInTheDocument();
     expect(screen.getByText('Hosting: 52.370, 4.900')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', {
+        name: 'restricted (Restricted Example)',
+      }),
+    ).toHaveAttribute('href', '/admin/user?id=222222222222222222222222');
+    expect(screen.getByText(/— Acquisition story/)).toBeInTheDocument();
     expect(
       screen.getByRole('link', { name: 'Stories' }).closest('li'),
     ).toHaveClass('active');

--- a/modules/admin/tests/client/components/AdminUser.component.tests.js
+++ b/modules/admin/tests/client/components/AdminUser.component.tests.js
@@ -205,6 +205,13 @@ describe('<AdminUser />', () => {
     ).toBeInTheDocument();
     expect(usersApi.getUser).toHaveBeenCalledWith(userId);
     expect(screen.getByText('State for alice')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Role management' }),
+    ).toHaveAttribute('href', '#roles');
+    expect(screen.getByText('read-only')).toBeInTheDocument();
+    expect(
+      screen.getByText('Standard Trustroots member access.'),
+    ).toBeInTheDocument();
     expect(screen.getByText('3 sent')).toBeInTheDocument();
     expect(screen.getByText('4 received')).toBeInTheDocument();
     expect(
@@ -260,6 +267,41 @@ describe('<AdminUser />', () => {
     expect(
       screen.getByRole('link', { name: 'Show location on map' }),
     ).toHaveAttribute('href', '/search?location=60.17,24.94');
+  });
+
+  it('describes recognised and historical roles without adding edit controls', async () => {
+    usersApi.getUser.mockResolvedValueOnce(
+      makeReportCard({
+        profile: {
+          _id: userId,
+          email: 'alice@example.org',
+          roles: ['admin', 'moderator', 'shadowban', 'custom-legacy-role'],
+          username: 'alice',
+        },
+      }),
+    );
+
+    window.history.pushState({}, '', `/admin/user?id=${userId}`);
+    render(<AdminUser />);
+
+    await screen.findByRole('heading', { name: 'alice report card' });
+    expect(
+      screen.getByText('Full access to administration and moderation tools.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Legacy moderation role retained for historical accounts.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Member can use the site, but their profile and outreach are hidden from others.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Role stored on this member.')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /remove role/i }),
+    ).not.toBeInTheDocument();
   });
 
   it('lists members with the selected current IP address from the URL', async () => {

--- a/modules/admin/tests/client/components/AdminUser.component.tests.js
+++ b/modules/admin/tests/client/components/AdminUser.component.tests.js
@@ -382,6 +382,70 @@ describe('<AdminUser />', () => {
     expect(
       screen.queryByRole('button', { name: 'Make volunteer alumni' }),
     ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Potential related accounts' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('No potential related accounts found.'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows acquisition context and potential matches for a shadowbanned member', async () => {
+    usersApi.getUser.mockResolvedValueOnce(
+      makeReportCard({
+        potentialMatches: [
+          {
+            _id: otherUserId,
+            acquisitionStory: 'A fictional club introduced me.',
+            displayName: 'Related Example',
+            email: 'related@example.org',
+            matchReasons: ['Email identifier', 'Acquisition story'],
+            roles: ['user'],
+            username: 'related',
+          },
+          {
+            _id: '333333333333333333333333',
+            acquisitionStory: '',
+            displayName: '',
+            email: 'username-lead@example.org',
+            matchReasons: ['Username identifier'],
+            roles: ['user', 'suspended'],
+            username: 'username-lead',
+          },
+        ],
+        profile: {
+          _id: userId,
+          acquisitionStory: 'A fictional club introduced me.',
+          email: 'alice@example.org',
+          roles: ['user', 'shadowban'],
+          username: 'alice',
+        },
+      }),
+    );
+
+    window.history.pushState({}, '', `/admin/user?id=${userId}`);
+    render(<AdminUser />);
+
+    expect(
+      await screen.findByRole('link', { name: 'Potential related accounts' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('row', {
+        name: /Related Example.*related@example.org.*Email identifier, Acquisition story.*A fictional club introduced me/,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Related Example' }),
+    ).toHaveAttribute('href', `/admin/user?id=${otherUserId}`);
+    expect(screen.getByRole('link', { name: 'username-lead' })).toHaveAttribute(
+      'href',
+      '/admin/user?id=333333333333333333333333',
+    );
+    expect(
+      screen.getAllByRole('row', {
+        name: /Acquisition story A fictional club introduced me/,
+      }),
+    ).toHaveLength(2);
   });
 
   it('updates the URL while typing and queries valid member ids', async () => {

--- a/modules/admin/tests/server/admin.acquisition-stories.server.controller.unit.tests.js
+++ b/modules/admin/tests/server/admin.acquisition-stories.server.controller.unit.tests.js
@@ -51,6 +51,59 @@ describe('Admin acquisition stories controller unit tests', () => {
       res.body[0].locationLiving.should.equal('Fictional home');
       should(res.body[0].hostingLocation).equal(null);
       should(res.body[0].member).be.undefined();
+      res.body[0].restrictedMatches.should.deepEqual([]);
+      should(res.body[0].email).be.undefined();
+      should(res.body[0].emailTemporary).be.undefined();
+    });
+
+    it('returns identifier, exact-story, and fuzzy-story restricted matches', async () => {
+      const users = utils.generateUsers(4);
+      users[0].username = 'identifier-clue-copy';
+      users[0].email = 'active@example.test';
+      users[0].acquisitionStory =
+        'I heard about Trustroots through a travelling friend.';
+
+      users[1].username = 'exact-story-user';
+      users[1].email = 'exact@example.test';
+      users[1].roles = ['user', 'shadowban'];
+      users[1].acquisitionStory =
+        '  I HEARD about Trustroots through a travelling friend.  ';
+
+      users[2].username = 'fuzzy-story-user';
+      users[2].email = 'fuzzy@example.test';
+      users[2].roles = ['user', 'suspended'];
+      users[2].acquisitionStory =
+        'I heard about Trustroots through one travelling friend.';
+
+      users[3].username = 'identifierclue';
+      users[3].email = 'unrelated@example.test';
+      users[3].roles = ['user', 'shadowban'];
+      users[3].acquisitionStory = 'A completely different source.';
+
+      await utils.saveUsers(users);
+
+      const res = mockResponse();
+      await adminAcquisitionStories.list({}, res);
+
+      const story = res.body.find(
+        user => user.username === 'identifier-clue-copy',
+      );
+      story.restrictedMatches.should.have.length(3);
+      story.restrictedMatches
+        .find(user => user.username === 'exact-story-user')
+        .matchReasons.should.deepEqual(['Acquisition story']);
+      story.restrictedMatches
+        .find(user => user.username === 'fuzzy-story-user')
+        .matchReasons.should.deepEqual(['Similar acquisition story']);
+      story.restrictedMatches
+        .find(user => user.username === 'identifierclue')
+        .matchReasons.should.deepEqual(['Username identifier']);
+      story.restrictedMatches.forEach(match => {
+        should(match.email).be.undefined();
+        ['shadowban', 'suspended']
+          .some(role => match.roles.includes(role))
+          .should.equal(true);
+      });
     });
 
     it('returns the latest hosting location with acquisition stories', async () => {
@@ -231,6 +284,20 @@ describe('Admin acquisition stories controller unit tests', () => {
       should.exist(res.body);
       res.body.table.should.be.an.Array();
       res.body.table.should.have.length(0);
+    });
+  });
+
+  describe('getStorySimilarity', () => {
+    it('requires substantive stories and scores small edits highly', () => {
+      adminAcquisitionStories
+        .getStorySimilarity('short', 'short')
+        .should.equal(0);
+      adminAcquisitionStories
+        .getStorySimilarity(
+          'A travelling friend recommended Trustroots to me.',
+          'A traveler friend recommended Trustroots to me.',
+        )
+        .should.be.above(0.82);
     });
   });
 });

--- a/modules/admin/tests/server/admin.users.server.controller.unit.tests.js
+++ b/modules/admin/tests/server/admin.users.server.controller.unit.tests.js
@@ -477,6 +477,20 @@ describe('Admin users controller unit tests', () => {
     });
   });
 
+  describe('findPotentialMatches', () => {
+    it('returns no leads when every available identifier is too short', async () => {
+      const matches = await adminUsers.findPotentialMatches({
+        _id: new mongoose.Types.ObjectId(),
+        acquisitionStory: '',
+        email: 'a@example.test',
+        emailTemporary: '',
+        username: 'abc',
+      });
+
+      matches.should.deepEqual([]);
+    });
+  });
+
   describe('changeRole', () => {
     it('promotes a volunteer and removes volunteer-alumni', async () => {
       const users = await utils.saveUsers(utils.generateUsers(2));

--- a/modules/admin/tests/server/admin.users.server.routes.tests.js
+++ b/modules/admin/tests/server/admin.users.server.routes.tests.js
@@ -371,6 +371,89 @@ describe('Admin User CRUD tests', () => {
         // These should have been obfuscated
         should(body.profile.removeProfileToken).equal('(Hidden from admins.)');
         should(body.profile.resetPasswordToken).equal('(Hidden from admins.)');
+        body.potentialMatches.should.deepEqual([]);
+      });
+
+      it('shows bounded identity and acquisition-story leads for restricted members', async () => {
+        userRegular.roles = ['user', 'shadowban'];
+        userRegular.emailTemporary = 'pending-clue@example.com';
+        userRegular.acquisitionStory =
+          'A fictional travel club introduced me to Trustroots.';
+        await userRegular.save();
+
+        const possibleMatches = [
+          new User({
+            displayName: 'Username Lead',
+            email: 'different@example.test',
+            firstName: 'Username',
+            lastName: 'Lead',
+            password: 'Password123!',
+            provider: 'local',
+            roles: ['user'],
+            username: 'user_regular_copy',
+          }),
+          new User({
+            displayName: 'Email Lead',
+            email: 'new.regular+account@example.test',
+            firstName: 'Email',
+            lastName: 'Lead',
+            password: 'Password123!',
+            provider: 'local',
+            roles: ['user'],
+            username: 'different-member',
+          }),
+          new User({
+            displayName: 'Temporary Email Lead',
+            email: 'pending.clue+copy@example.test',
+            firstName: 'Temporary',
+            lastName: 'Lead',
+            password: 'Password123!',
+            provider: 'local',
+            roles: ['user'],
+            username: 'another-member',
+          }),
+          new User({
+            acquisitionStory:
+              '  A FICTIONAL TRAVEL CLUB introduced me to Trustroots.  ',
+            displayName: 'Story Lead',
+            email: 'story@example.test',
+            firstName: 'Story',
+            lastName: 'Lead',
+            password: 'Password123!',
+            provider: 'local',
+            roles: ['user'],
+            username: 'story-member',
+          }),
+        ];
+        await Promise.all(possibleMatches.map(user => user.save()));
+        await utils.signIn(credentialsAdmin, agent);
+
+        const { body } = await agent
+          .post('/api/admin/user')
+          .send({ id: userRegularId })
+          .expect(200);
+
+        body.potentialMatches.should.have.length(4);
+        const usernameLead = body.potentialMatches.find(
+          user => user.username === 'user_regular_copy',
+        );
+        usernameLead.matchReasons.should.containEql('Username identifier');
+        usernameLead.matchReasons.should.containEql('Email identifier');
+        const emailLead = body.potentialMatches.find(
+          user => user.username === 'different-member',
+        );
+        emailLead.matchReasons.should.deepEqual(['Email identifier']);
+        const temporaryEmailLead = body.potentialMatches.find(
+          user => user.username === 'another-member',
+        );
+        temporaryEmailLead.matchReasons.should.deepEqual([
+          'Temporary email identifier',
+        ]);
+        const storyLead = body.potentialMatches.find(
+          user => user.username === 'story-member',
+        );
+        storyLead.matchReasons.should.deepEqual(['Acquisition story']);
+        storyLead.acquisitionStory.should.match(/fictional travel club/i);
       });
 
       it('missing id should return no users', async () => {

--- a/modules/contacts/server/controllers/contacts.server.controller.js
+++ b/modules/contacts/server/controllers/contacts.server.controller.js
@@ -452,6 +452,14 @@ exports.contactListByUser = function (req, res, next, listUserId) {
     // `[{userObject}]`, we have to unwind it back to `{userObject}`
     { $unwind: '$user' },
 
+    // Existing relationship records may outlive a moderation action. Keep
+    // restricted members out of all user-facing contact lists.
+    {
+      $match: {
+        'user.roles': { $nin: userRolesService.restrictedMessagingRoles },
+      },
+    },
+
     // Another round of formating results as we now have `user` field populated
     {
       $project: {

--- a/modules/contacts/tests/server/contacts.server.controller.unit.tests.js
+++ b/modules/contacts/tests/server/contacts.server.controller.unit.tests.js
@@ -635,6 +635,40 @@ describe('Contacts controller unit tests', () => {
       req.contacts.length.should.equal(1);
     });
 
+    it('omits existing contacts with restricted members', async () => {
+      const [restrictedUser] = await utils.saveUsers(
+        utils.generateUsers(1, { public: true }),
+      );
+      restrictedUser.roles = ['user', 'shadowban'];
+      await restrictedUser.save();
+      await Contact.insertMany([
+        {
+          userFrom: user1._id,
+          userTo: user2._id,
+          confirmed: true,
+        },
+        {
+          userFrom: user1._id,
+          userTo: restrictedUser._id,
+          confirmed: true,
+        },
+      ]);
+
+      const req = { user: user1 };
+      const { nextCalled } = await runHandler((res, next) =>
+        contactsController.contactListByUser(
+          req,
+          res,
+          next,
+          user1._id.toString(),
+        ),
+      );
+
+      nextCalled.should.be.true();
+      req.contacts.should.have.length(1);
+      req.contacts[0].user._id.toString().should.equal(user2._id.toString());
+    });
+
     it('passes aggregate errors to next', async () => {
       sinon.stub(Contact, 'aggregate').returns({
         exec: cb => cb(new Error('aggregate failed')),

--- a/modules/messages/server/controllers/messages.server.controller.js
+++ b/modules/messages/server/controllers/messages.server.controller.js
@@ -554,9 +554,13 @@ exports.send = async function (req, res) {
       // Here we create or update the related MessageStat document in mongodb
       // It serves to count the user's reply rate and reply time
       function (message, done) {
-        messageStatService.updateMessageStat(message, function () {
-          // do nothing
-        });
+        // Messages hidden from their recipient must not lower reply rates or
+        // contribute reply-time data.
+        if (!message.shadowHidden) {
+          messageStatService.updateMessageStat(message, function () {
+            // do nothing
+          });
+        }
 
         return done(null, message);
       },

--- a/modules/messages/tests/server/messages.server.controller.unit.tests.js
+++ b/modules/messages/tests/server/messages.server.controller.unit.tests.js
@@ -9,6 +9,7 @@ const sinon = require('sinon');
 const messagesController = require('../../server/controllers/messages.server.controller');
 const config = require('../../../../config/config');
 const spamService = require('../../../core/server/services/spam.server.service');
+const messageStatService = require('../../server/services/message-stat.server.service');
 const utils = require('../../../../testutils/server/data.server.testutil');
 require('should');
 
@@ -686,6 +687,10 @@ describe('Messages controller unit tests', () => {
       const { sender, receiver } = await prepareSender();
       sender.roles = ['user', 'shadowban'];
       await sender.save();
+      const updateMessageStat = sinon.stub(
+        messageStatService,
+        'updateMessageStat',
+      );
 
       const res = deferredResponse();
       messagesController.send(
@@ -708,6 +713,7 @@ describe('Messages controller unit tests', () => {
       });
       saved.shadowHidden.should.be.true();
       saved.read.should.be.true();
+      sinon.assert.notCalled(updateMessageStat);
     });
   });
 

--- a/modules/users/server/jobs/user-finish-signup.server.job.js
+++ b/modules/users/server/jobs/user-finish-signup.server.job.js
@@ -3,7 +3,7 @@
  * have `public:false` in their profile. The script sends 3 (configurable)
  * reminder emails to these users in 2 day intervals, starting 4h after signup.
  *
- * Ignores users with `suspended` role.
+ * Ignores users with `suspended` or `shadowban` roles.
  *
  * Keeps count of reminder emails at user's model.
  */
@@ -36,12 +36,8 @@ module.exports = function (job, agendaDone) {
           created: {
             $lt: createdTimeAgo,
           },
-          // Exlude users with `suspended` role
-          roles: {
-            $not: {
-              $eq: 'suspended',
-            },
-          },
+          // Exclude users with restricted roles.
+          roles: { $nin: ['suspended', 'shadowban'] },
         })
           .and([
             {

--- a/modules/users/tests/server/jobs/user-finish-signup.server.job.direct.unit.tests.js
+++ b/modules/users/tests/server/jobs/user-finish-signup.server.job.direct.unit.tests.js
@@ -52,9 +52,7 @@ describe('Job: user finish signup direct unit tests', function () {
         should.not.exist(err);
         sinon.assert.calledOnce(User.find);
         User.find.firstCall.args[0].roles.should.eql({
-          $not: {
-            $eq: 'suspended',
-          },
+          $nin: ['suspended', 'shadowban'],
         });
         query.and.firstCall.args[0][0].$or[0].publicReminderCount.$lt.should.equal(
           3,

--- a/modules/users/tests/server/jobs/user-finish-signup.server.job.tests.js
+++ b/modules/users/tests/server/jobs/user-finish-signup.server.job.tests.js
@@ -290,16 +290,18 @@ describe('Job: user finish signup', function () {
     });
   });
 
-  it('Do not remind users with "suspended" role', function (done) {
-    unConfirmedUser.roles = ['suspended'];
-    unConfirmedUser.created = moment().subtract(moment.duration({ days: 8 }));
-    unConfirmedUser.save(function (err) {
-      if (err) return done(err);
-
-      userFinishSignupJobHandler({}, function (err) {
+  ['suspended', 'shadowban'].forEach(function (role) {
+    it(`Do not remind users with "${role}" role`, function (done) {
+      unConfirmedUser.roles = [role];
+      unConfirmedUser.created = moment().subtract(moment.duration({ days: 8 }));
+      unConfirmedUser.save(function (err) {
         if (err) return done(err);
-        jobs.length.should.equal(0);
-        done();
+
+        userFinishSignupJobHandler({}, function (err) {
+          if (err) return done(err);
+          jobs.length.should.equal(0);
+          done();
+        });
       });
     });
   });

--- a/openspec/changes/archive/2026-08-04-close-shadowban-safety-gaps/proposal.md
+++ b/openspec/changes/archive/2026-08-04-close-shadowban-safety-gaps/proposal.md
@@ -1,0 +1,32 @@
+# Change: Close shadowban safety gaps
+
+## Why
+
+Several protections tracked by the shadowban moderation work are only partial:
+existing contacts can still expose restricted accounts, shadow-hidden messages
+still affect reply statistics, and one signup-reminder job still emails
+shadowbanned members. Administrators also need a clearer foundation for future
+role management without expanding mutation controls yet.
+
+## What Changes
+
+- Omit suspended and shadowbanned accounts from user-facing contact lists,
+  including existing confirmed relationships.
+- Exclude messages sent by restricted members from reply-rate and reply-time
+  accounting.
+- Exclude shadowbanned members from finish-signup reminder emails as well as
+  suspended members.
+- Confirm the existing external social, hospitality-network, and Nostr
+  identifier protection remains covered for shadowbanned profile viewers.
+- Add a read-only role-management panel to administrator member reports with
+  the member's current roles and short descriptions.
+- Remove an unreachable acquisition-story query fallback that prevents full
+  server branch coverage.
+
+## Impact
+
+- Affected specs: `relationships-safety`, `messaging`, `account-access`,
+  `admin-moderation`
+- Affected areas: contacts aggregation, message-stat updates, signup-reminder
+  jobs, profile-sanitisation coverage, and administrator member reports
+- No new role mutation endpoint or persistent rules banner is introduced.

--- a/openspec/changes/archive/2026-08-04-close-shadowban-safety-gaps/specs/account-access/spec.md
+++ b/openspec/changes/archive/2026-08-04-close-shadowban-safety-gaps/specs/account-access/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Finish-signup reminder delivery
+
+The system SHALL not send finish-signup reminder emails to suspended or
+shadowbanned members.
+
+#### Scenario: Restricted member remains incomplete
+
+- **WHEN** a suspended or shadowbanned member otherwise meets a finish-signup
+  reminder job's timing and profile criteria
+- **THEN** the job does not select that member for email delivery

--- a/openspec/changes/archive/2026-08-04-close-shadowban-safety-gaps/specs/admin-moderation/spec.md
+++ b/openspec/changes/archive/2026-08-04-close-shadowban-safety-gaps/specs/admin-moderation/spec.md
@@ -1,0 +1,14 @@
+## ADDED Requirements
+
+### Requirement: Read-only member role inventory
+
+The system SHALL show authorised administrators a read-only inventory of a
+member's current roles and concise explanations of those roles as a foundation
+for future role management.
+
+#### Scenario: Administrator reviews member roles
+
+- **WHEN** an authorised administrator opens a member report
+- **THEN** the report lists the member's current roles
+- **AND** explains each recognised role
+- **AND** does not provide new role-removal controls

--- a/openspec/changes/archive/2026-08-04-close-shadowban-safety-gaps/specs/messaging/spec.md
+++ b/openspec/changes/archive/2026-08-04-close-shadowban-safety-gaps/specs/messaging/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Moderation-safe reply statistics
+
+The system SHALL exclude messages hidden by restricted-member moderation rules
+from reply-rate and reply-time accounting.
+
+#### Scenario: Restricted member sends a shadow-hidden message
+
+- **WHEN** a suspended or shadowbanned member sends a message that is hidden
+  from its recipient by moderation rules
+- **THEN** the message does not create or update reply statistics
+
+#### Scenario: Available member sends a visible message
+
+- **WHEN** an available member sends a visible message
+- **THEN** normal reply-rate and reply-time accounting continues

--- a/openspec/changes/archive/2026-08-04-close-shadowban-safety-gaps/specs/relationships-safety/spec.md
+++ b/openspec/changes/archive/2026-08-04-close-shadowban-safety-gaps/specs/relationships-safety/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Contact-list visibility
+
+The system SHALL show a member's available contacts and relevant common
+contacts where relationship visibility permits. Suspended and shadowbanned
+accounts SHALL be omitted from user-facing contact lists even when an existing
+contact record remains.
+
+#### Scenario: Member views contacts
+
+- **WHEN** a member opens an available contacts view
+- **THEN** the system displays the visible contacts or an empty state
+- **AND** omits suspended and shadowbanned contacts
+
+#### Scenario: Member requests common contacts
+
+- **WHEN** a member requests common contacts for two members
+- **THEN** the system returns the contacts shared by both members where permitted
+- **AND** omits suspended and shadowbanned contacts

--- a/openspec/changes/archive/2026-08-04-close-shadowban-safety-gaps/tasks.md
+++ b/openspec/changes/archive/2026-08-04-close-shadowban-safety-gaps/tasks.md
@@ -1,0 +1,19 @@
+## 1. Restricted-member safety
+
+- [x] 1.1 Exclude suspended and shadowbanned accounts from contact-list results
+- [x] 1.2 Exclude shadow-hidden sender messages from reply statistics
+- [x] 1.3 Exclude shadowbanned members from finish-signup reminders
+- [x] 1.4 Verify external provider identifiers remain hidden from shadowbanned
+      profile viewers
+
+## 2. Read-only role management
+
+- [x] 2.1 Add a read-only current-roles panel with role descriptions to the
+      administrator member report
+
+## 3. Coverage and verification
+
+- [x] 3.1 Remove the unreachable acquisition-story fallback reported by CI
+- [x] 3.2 Add focused server and client regression coverage
+- [x] 3.3 Extend end-to-end feature coverage where appropriate
+- [x] 3.4 Validate and archive the OpenSpec change

--- a/openspec/changes/archive/2026-08-04-show-restricted-matches-in-acquisition-stories/proposal.md
+++ b/openspec/changes/archive/2026-08-04-show-restricted-matches-in-acquisition-stories/proposal.md
@@ -1,0 +1,25 @@
+# Show restricted-account matches in acquisition stories
+
+## Why
+
+The acquisition-stories view gives administrators useful signup context but
+does not highlight when a current story or account identifier resembles a
+suspended or shadowbanned account. Administrators must currently repeat this
+comparison manually.
+
+## What Changes
+
+- Compare acquisition-story rows with a bounded set of suspended and
+  shadowbanned accounts.
+- Match normalised username and email local-part identifiers, exact normalised
+  acquisition stories, and conservatively similar acquisition stories.
+- Show links to matching restricted member reports and label the signal that
+  produced each lead.
+- Keep matches informational only and make no automatic moderation changes.
+
+## Impact
+
+- Affects the acquisition-stories administrator API and React view.
+- Uses bounded in-memory comparison after the existing bounded story query; no
+  data migration or public API change is required.
+- Adds server, client, and end-to-end coverage.

--- a/openspec/changes/archive/2026-08-04-show-restricted-matches-in-acquisition-stories/specs/admin-moderation/spec.md
+++ b/openspec/changes/archive/2026-08-04-show-restricted-matches-in-acquisition-stories/specs/admin-moderation/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Restricted-account signals in acquisition stories
+
+The system SHALL compare acquisition-story rows with a bounded set of
+suspended and shadowbanned accounts and show possible matches to authorised
+administrators. Match signals SHALL include similar normalised identifiers,
+identical normalised acquisition stories, and conservatively similar
+acquisition stories. Matches SHALL NOT automatically change account state.
+
+#### Scenario: Acquisition story resembles a restricted account
+
+- **WHEN** an authorised administrator opens the acquisition-stories view
+- **AND** a story row resembles a suspended or shadowbanned account
+- **THEN** the row identifies the matching restricted account
+- **AND** labels the identifier, exact-story, or similar-story signal
+- **AND** links to the restricted account's member report
+
+#### Scenario: Acquisition story has no restricted-account signal
+
+- **WHEN** an authorised administrator opens the acquisition-stories view
+- **AND** a story row has no qualifying restricted-account match
+- **THEN** the row is shown without a restricted-account lead

--- a/openspec/changes/archive/2026-08-04-show-restricted-matches-in-acquisition-stories/tasks.md
+++ b/openspec/changes/archive/2026-08-04-show-restricted-matches-in-acquisition-stories/tasks.md
@@ -1,0 +1,17 @@
+## 1. Acquisition-story matching
+
+- [x] 1.1 Load a bounded set of suspended and shadowbanned accounts for the
+      acquisition-stories administrator API
+- [x] 1.2 Add identifier, exact-story, and conservative fuzzy-story matching
+- [x] 1.3 Return bounded match summaries without exposing extra source fields
+
+## 2. Administrator view
+
+- [x] 2.1 Display matching restricted accounts and match reasons on each
+      acquisition-story row
+
+## 3. Verification
+
+- [x] 3.1 Add focused server and client coverage
+- [x] 3.2 Extend the acquisition-stories end-to-end scenario
+- [x] 3.3 Validate and archive the OpenSpec change

--- a/openspec/changes/archive/2026-08-04-surface-restricted-member-matches/proposal.md
+++ b/openspec/changes/archive/2026-08-04-surface-restricted-member-matches/proposal.md
@@ -1,0 +1,28 @@
+# Surface potential accounts related to restricted members
+
+## Why
+
+Administrators investigating a suspended or shadowbanned member currently need
+to repeat several manual searches to notice likely replacement or related
+accounts. The member's acquisition story is also only available inside raw
+profile data, even though repeated stories can be a useful supporting signal.
+
+## What Changes
+
+- Show a restricted member's acquisition story as readable moderation context
+  on their report card.
+- Find a bounded set of other accounts whose username or email local-part
+  resembles the restricted member's identifiers, or whose acquisition story is
+  identical after trimming and case normalisation.
+- Show the possible accounts and the reason each one matched on the restricted
+  member's report card.
+- Treat matches only as investigation leads; do not automatically restrict or
+  otherwise change any account.
+
+## Impact
+
+- Affects the administrator member-report API and React report-card view.
+- Matching runs only when an administrator opens a suspended or shadowbanned
+  member report and returns a bounded result set.
+- No data migration or public API change is required.
+- Adds server, client, and end-to-end regression coverage.

--- a/openspec/changes/archive/2026-08-04-surface-restricted-member-matches/specs/admin-moderation/spec.md
+++ b/openspec/changes/archive/2026-08-04-surface-restricted-member-matches/specs/admin-moderation/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Potential accounts related to restricted members
+
+The system SHALL help authorised administrators investigate a suspended or
+shadowbanned member by showing a bounded set of other accounts with a similar
+username or email local-part, or an identical normalised acquisition story.
+The system SHALL identify the signal that caused each possible match and SHALL
+NOT automatically change an account because of a match.
+
+#### Scenario: Administrator opens a restricted member report
+
+- **WHEN** an authorised administrator opens a suspended or shadowbanned
+  member report
+- **THEN** the report shows the member's acquisition story when available
+- **AND** shows a bounded set of possible related accounts
+- **AND** identifies whether each account matched the username, email
+  local-part, or acquisition story
+
+#### Scenario: Administrator opens an unrestricted member report
+
+- **WHEN** an authorised administrator opens a member report for an account
+  without the suspended or shadowban role
+- **THEN** the report does not perform or display restricted-member matching
+
+#### Scenario: Possible account match is found
+
+- **WHEN** another account matches one or more restricted-member signals
+- **THEN** the administrator can open that account's member report
+- **AND** neither account's roles or other state are changed automatically

--- a/openspec/changes/archive/2026-08-04-surface-restricted-member-matches/tasks.md
+++ b/openspec/changes/archive/2026-08-04-surface-restricted-member-matches/tasks.md
@@ -1,0 +1,19 @@
+## 1. Restricted-member matching
+
+- [x] 1.1 Add bounded server-side matching for restricted-member username,
+      email local-part, and acquisition-story signals
+- [x] 1.2 Return match reasons and moderation-safe member fields from the
+      administrator report API
+
+## 2. Administrator report
+
+- [x] 2.1 Show the member's acquisition story as readable report context
+- [x] 2.2 Show potential related accounts and their match reasons only for
+      suspended and shadowbanned reports
+
+## 3. Verification
+
+- [x] 3.1 Add focused server and client coverage
+- [x] 3.2 Add an end-to-end restricted-member matching scenario
+- [x] 3.3 Validate the OpenSpec change, run relevant checks, archive the change,
+      and update the living specification

--- a/openspec/specs/account-access/spec.md
+++ b/openspec/specs/account-access/spec.md
@@ -158,3 +158,14 @@ provider data and manage their push-notification registrations.
 
 - **WHEN** an authenticated account holder adds or removes a push registration
 - **THEN** the system persists the requested registration state
+
+### Requirement: Finish-signup reminder delivery
+
+The system SHALL not send finish-signup reminder emails to suspended or
+shadowbanned members.
+
+#### Scenario: Restricted member remains incomplete
+
+- **WHEN** a suspended or shadowbanned member otherwise meets a finish-signup
+  reminder job's timing and profile criteria
+- **THEN** the job does not select that member for email delivery

--- a/openspec/specs/admin-moderation/spec.md
+++ b/openspec/specs/admin-moderation/spec.md
@@ -293,3 +293,54 @@ authorised administrators in member-search results and member reports.
 
 - **WHEN** a regular member requests the administrator IP-address lookup
 - **THEN** the system denies access
+
+### Requirement: Potential accounts related to restricted members
+
+The system SHALL help authorised administrators investigate a suspended or
+shadowbanned member by showing a bounded set of other accounts with a similar
+username or email local-part, or an identical normalised acquisition story.
+The system SHALL identify the signal that caused each possible match and SHALL
+NOT automatically change an account because of a match.
+
+#### Scenario: Administrator opens a restricted member report
+
+- **WHEN** an authorised administrator opens a suspended or shadowbanned
+  member report
+- **THEN** the report shows the member's acquisition story when available
+- **AND** shows a bounded set of possible related accounts
+- **AND** identifies whether each account matched the username, email
+  local-part, or acquisition story
+
+#### Scenario: Administrator opens an unrestricted member report
+
+- **WHEN** an authorised administrator opens a member report for an account
+  without the suspended or shadowban role
+- **THEN** the report does not perform or display restricted-member matching
+
+#### Scenario: Possible account match is found
+
+- **WHEN** another account matches one or more restricted-member signals
+- **THEN** the administrator can open that account's member report
+- **AND** neither account's roles or other state are changed automatically
+
+### Requirement: Restricted-account signals in acquisition stories
+
+The system SHALL compare acquisition-story rows with a bounded set of
+suspended and shadowbanned accounts and show possible matches to authorised
+administrators. Match signals SHALL include similar normalised identifiers,
+identical normalised acquisition stories, and conservatively similar
+acquisition stories. Matches SHALL NOT automatically change account state.
+
+#### Scenario: Acquisition story resembles a restricted account
+
+- **WHEN** an authorised administrator opens the acquisition-stories view
+- **AND** a story row resembles a suspended or shadowbanned account
+- **THEN** the row identifies the matching restricted account
+- **AND** labels the identifier, exact-story, or similar-story signal
+- **AND** links to the restricted account's member report
+
+#### Scenario: Acquisition story has no restricted-account signal
+
+- **WHEN** an authorised administrator opens the acquisition-stories view
+- **AND** a story row has no qualifying restricted-account match
+- **THEN** the row is shown without a restricted-account lead

--- a/openspec/specs/admin-moderation/spec.md
+++ b/openspec/specs/admin-moderation/spec.md
@@ -344,3 +344,16 @@ acquisition stories. Matches SHALL NOT automatically change account state.
 - **WHEN** an authorised administrator opens the acquisition-stories view
 - **AND** a story row has no qualifying restricted-account match
 - **THEN** the row is shown without a restricted-account lead
+
+### Requirement: Read-only member role inventory
+
+The system SHALL show authorised administrators a read-only inventory of a
+member's current roles and concise explanations of those roles as a foundation
+for future role management.
+
+#### Scenario: Administrator reviews member roles
+
+- **WHEN** an authorised administrator opens a member report
+- **THEN** the report lists the member's current roles
+- **AND** explains each recognised role
+- **AND** does not provide new role-removal controls

--- a/openspec/specs/messaging/spec.md
+++ b/openspec/specs/messaging/spec.md
@@ -85,3 +85,19 @@ messages are read or synchronised.
 
 - **WHEN** a member reads an unread message
 - **THEN** the system updates the unread state available to that member
+
+### Requirement: Moderation-safe reply statistics
+
+The system SHALL exclude messages hidden by restricted-member moderation rules
+from reply-rate and reply-time accounting.
+
+#### Scenario: Restricted member sends a shadow-hidden message
+
+- **WHEN** a suspended or shadowbanned member sends a message that is hidden
+  from its recipient by moderation rules
+- **THEN** the message does not create or update reply statistics
+
+#### Scenario: Available member sends a visible message
+
+- **WHEN** an available member sends a visible message
+- **THEN** normal reply-rate and reply-time accounting continues

--- a/openspec/specs/relationships-safety/spec.md
+++ b/openspec/specs/relationships-safety/spec.md
@@ -38,17 +38,21 @@ receive contact requests.
 ### Requirement: Contact-list visibility
 
 The system SHALL show a member's available contacts and relevant common
-contacts where relationship visibility permits.
+contacts where relationship visibility permits. Suspended and shadowbanned
+accounts SHALL be omitted from user-facing contact lists even when an existing
+contact record remains.
 
 #### Scenario: Member views contacts
 
 - **WHEN** a member opens an available contacts view
 - **THEN** the system displays the visible contacts or an empty state
+- **AND** omits suspended and shadowbanned contacts
 
 #### Scenario: Member requests common contacts
 
 - **WHEN** a member requests common contacts for two members
 - **THEN** the system returns the contacts shared by both members where permitted
+- **AND** omits suspended and shadowbanned contacts
 
 ### Requirement: Blocking
 

--- a/scripts/e2e/seed.js
+++ b/scripts/e2e/seed.js
@@ -103,6 +103,7 @@ const MEMBERS = [
     email: 'e2e-seeded-shadow@example.test',
     firstName: 'Shadow',
     lastName: 'Spammer',
+    acquisitionStory: 'I found Trustroots through hitchhiking friends online.',
     roles: ['user', 'shadowban'],
     tribes: [],
   },

--- a/tests/e2e/feature-coverage.js
+++ b/tests/e2e/feature-coverage.js
@@ -2770,6 +2770,7 @@ const features = [
     requiredScenarios: [
       'Admin user report card loads for a member id.',
       'Report card includes role and message counts.',
+      'Report card shows a read-only current role inventory.',
       'Restricted member report shows potential related accounts.',
       'Missing user id shows a usable error state.',
     ],

--- a/tests/e2e/feature-coverage.js
+++ b/tests/e2e/feature-coverage.js
@@ -2593,6 +2593,7 @@ const features = [
       'Acquisition stories page loads.',
       'Acquisition stories query returns deterministic rows.',
       'Story rows show available member and hosting locations.',
+      'Story rows show matching restricted accounts.',
     ],
     relatedSpecs: [],
   },
@@ -2769,6 +2770,7 @@ const features = [
     requiredScenarios: [
       'Admin user report card loads for a member id.',
       'Report card includes role and message counts.',
+      'Restricted member report shows potential related accounts.',
       'Missing user id shows a usable error state.',
     ],
     relatedSpecs: [

--- a/tests/e2e/features/admin-moderation/admin-acquisition.spec.js
+++ b/tests/e2e/features/admin-moderation/admin-acquisition.spec.js
@@ -16,6 +16,7 @@ test.describe('admin acquisition feature coverage', () => {
       'Story rows link profile pictures to public member profiles.',
       'Story rows show circle participation.',
       'Story rows show available member and hosting locations.',
+      'Story rows show matching restricted accounts.',
       'Story columns can be sorted.',
     ]);
     annotateFeature(testInfo, 'admin.acquisition-analysis', [
@@ -36,6 +37,13 @@ test.describe('admin acquisition feature coverage', () => {
     await expect(page.getByText('Living: Fictional home')).toBeVisible();
     await expect(page.getByText('From: Fictional origin')).toBeVisible();
     await expect(page.getByText(/^Hosting: /)).toBeVisible();
+    const aliceRow = page.locator('tr').filter({ hasText: 'Alice Contact' });
+    await expect(
+      aliceRow.getByRole('link', {
+        name: 'e2e-seeded-shadow (Shadow Spammer)',
+      }),
+    ).toHaveAttribute('href', '/admin/user?id=665000000000000000000004');
+    await expect(aliceRow.getByText(/Acquisition story/)).toBeVisible();
     await expect(page.locator('img[loading="lazy"]').first()).toHaveAttribute(
       'src',
       /\/api\/users\/.+\/avatar\?size=32/,
@@ -52,6 +60,12 @@ test.describe('admin acquisition feature coverage', () => {
     expect(aliceStory.locationLiving).toBe('Fictional home');
     expect(aliceStory.locationFrom).toBe('Fictional origin');
     expect(aliceStory.hostingLocation).toHaveLength(2);
+    expect(aliceStory.restrictedMatches).toEqual([
+      expect.objectContaining({
+        username: 'e2e-seeded-shadow',
+        matchReasons: ['Acquisition story'],
+      }),
+    ]);
 
     await page.goto('/admin/acquisition-stories/analysis');
     await expect(page).toHaveURL(/\/admin\/acquisition-stories\/analysis/);

--- a/tests/e2e/features/admin-moderation/admin-inspection.spec.js
+++ b/tests/e2e/features/admin-moderation/admin-inspection.spec.js
@@ -55,6 +55,7 @@ test.describe('admin moderation inspection flows', () => {
     annotateFeature(testInfo, 'admin.user-report', [
       'Admin user report card loads for a member id.',
       'Report card includes role and message counts.',
+      'Restricted member report shows potential related accounts.',
       'Missing user id shows a usable error state.',
     ]);
 
@@ -70,6 +71,16 @@ test.describe('admin moderation inspection flows', () => {
     ).toBeVisible();
     await expect(page.getByText('shadowban').first()).toBeVisible();
     await expect(page.getByText('1 sent').first()).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: 'Potential related accounts' }),
+    ).toBeVisible();
+    await expect(page.getByText('Acquisition story').first()).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: 'Alice Contact' }),
+    ).toHaveAttribute('href', '/admin/user?id=665000000000000000000006');
+    await expect(
+      page.getByText('Acquisition story', { exact: true }).last(),
+    ).toBeVisible();
   });
 
   test('admin user report API rejects malformed ids', async ({

--- a/tests/e2e/features/admin-moderation/admin-inspection.spec.js
+++ b/tests/e2e/features/admin-moderation/admin-inspection.spec.js
@@ -55,6 +55,7 @@ test.describe('admin moderation inspection flows', () => {
     annotateFeature(testInfo, 'admin.user-report', [
       'Admin user report card loads for a member id.',
       'Report card includes role and message counts.',
+      'Report card shows a read-only current role inventory.',
       'Restricted member report shows potential related accounts.',
       'Missing user id shows a usable error state.',
     ]);
@@ -70,6 +71,15 @@ test.describe('admin moderation inspection flows', () => {
       }),
     ).toBeVisible();
     await expect(page.getByText('shadowban').first()).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: 'Role management' }),
+    ).toHaveAttribute('href', '#roles');
+    await expect(page.getByText('read-only')).toBeVisible();
+    await expect(
+      page.getByText(
+        'Member can use the site, but their profile and outreach are hidden from others.',
+      ),
+    ).toBeVisible();
     await expect(page.getByText('1 sent').first()).toBeVisible();
     await expect(
       page.getByRole('link', { name: 'Potential related accounts' }),


### PR DESCRIPTION
Members currently need full administrator access to view acquisition stories and analysis. This adds a `welcome-team` role with access to those two views and their existing data, plus administrator controls to grant and revoke membership. Other admin tools remain restricted, and acquisition navigation and member links respect the limited role.

Role changes preserve other roles and create audit notes. Existing role-change requests still default to adding a role; removal is supported only for `welcome-team`. No migration or automatic assignment is required. The OpenSpec proposal is archived and the living specification is updated.

Stacked on #2801; merge that PR first, then retarget this PR to `main`.

### Validation
- Client: 260 suites / 1,483 tests passed; 100% coverage across all metrics.
- Server: 1,626 tests passed, 28 pending; 100% coverage across all metrics.
- All five focused browser checks passed, including Welcome team grant, restricted access and revocation. The wrapper reports incomplete whole-site feature coverage because unrelated browser scenarios were not run.
- Full-coverage gate, ESLint, commit hooks and strict OpenSpec validation passed.
